### PR TITLE
Update Find Referenced Pipelines Function

### DIFF
--- a/src/fabric_cicd/_items/_datapipeline.py
+++ b/src/fabric_cicd/_items/_datapipeline.py
@@ -127,7 +127,7 @@ def _find_referenced_datapipelines(fabric_workspace_obj, item_content_dict, look
         """
         # Check if the current object is a dict
         if isinstance(input_object, dict):
-            for key, value in input_object.items():
+            for _key, value in input_object.items():
                 if isinstance(value, str):
                     match = guid_pattern.search(value)
                     if match:

--- a/src/fabric_cicd/_items/_datapipeline.py
+++ b/src/fabric_cicd/_items/_datapipeline.py
@@ -179,13 +179,15 @@ def _find_referenced_datapipelines(fabric_workspace_obj, item_content_dict, look
         # Check if the current object is a dict
         if isinstance(input_object, dict):
             for key, value in input_object.items():
-                if isinstance(value, str) and guid_pattern.match(value):
-                    referenced_id = match.group(0) # ensure valid guid
-                    referenced_name = fabric_workspace_obj._convert_id_to_name(
-                        item_type=item_type, generic_id=referenced_id, lookup_type=lookup_type
-                    )
-                    if referenced_name:
-                        reference_list.append(referenced_name)
+                if isinstance(value, str):
+                    match = guid_pattern.search(value)
+                    if match:
+                        referenced_id = match.group(0) # ensure valid guid
+                        referenced_name = fabric_workspace_obj._convert_id_to_name(
+                            item_type=item_type, generic_id=referenced_id, lookup_type=lookup_type
+                        )
+                        if referenced_name:
+                            reference_list.append(referenced_name)
                 
                 # Recursively search in the value
                 else:

--- a/src/fabric_cicd/_items/_datapipeline.py
+++ b/src/fabric_cicd/_items/_datapipeline.py
@@ -109,7 +109,7 @@ def sort_datapipelines(fabric_workspace_obj, unsorted_pipeline_dict, lookup_type
 
 def _find_referenced_datapipelines(fabric_workspace_obj, item_content_dict, lookup_type):
     """
-    Scan through item path and find pipeline references (including nested pipeline activities).
+    Scan through item path and find pipeline references (including nested pipelines).
 
     :param item_content_dict: Dict representation of the pipeline-content file.
     :param lookup_type: Finding references in deployed file or repo file (Deployed or Repository).
@@ -119,7 +119,7 @@ def _find_referenced_datapipelines(fabric_workspace_obj, item_content_dict, look
     reference_list = []
     guid_pattern = re.compile(r"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$")
 
-    def find_pipeline(input_object):
+    def find_datapipeline(input_object):
         """
         Recursively scans through JSON to find all pipeline references.
 
@@ -131,7 +131,7 @@ def _find_referenced_datapipelines(fabric_workspace_obj, item_content_dict, look
                 if isinstance(value, str):
                     match = guid_pattern.search(value)
                     if match:
-                        # If a valid GUID is found, convert it to its name. If it's not None, it's a pipeline and will be added to the reference list
+                        # If a valid GUID is found, convert it to name. If name is not None, it's a pipeline and will be added to the reference list
                         referenced_id = match.group(0)
                         referenced_name = fabric_workspace_obj._convert_id_to_name(
                             item_type=item_type, generic_id=referenced_id, lookup_type=lookup_type
@@ -141,15 +141,15 @@ def _find_referenced_datapipelines(fabric_workspace_obj, item_content_dict, look
 
                 # Recursively search in the value
                 else:
-                    find_pipeline(value)
+                    find_datapipeline(value)
 
         # Check if the current object is a list
         elif isinstance(input_object, list):
             # Recursively search in each item
             for item in input_object:
-                find_pipeline(item)
+                find_datapipeline(item)
 
     # Start the recursive search from the root of the JSON data
-    find_pipeline(item_content_dict)
+    find_datapipeline(item_content_dict)
 
     return reference_list

--- a/src/fabric_cicd/_items/_datapipeline.py
+++ b/src/fabric_cicd/_items/_datapipeline.py
@@ -153,4 +153,3 @@ def _find_referenced_datapipelines(fabric_workspace_obj, item_content_dict, look
     find_pipeline(item_content_dict)
     
     return reference_list
-    

--- a/src/fabric_cicd/_items/_datapipeline.py
+++ b/src/fabric_cicd/_items/_datapipeline.py
@@ -127,7 +127,7 @@ def _find_referenced_datapipelines(fabric_workspace_obj, item_content_dict, look
         """
         # Check if the current object is a dict
         if isinstance(input_object, dict):
-            for _key, value in input_object.items():
+            for value in input_object.values():
                 if isinstance(value, str):
                     match = guid_pattern.search(value)
                     if match:

--- a/src/fabric_cicd/_items/_datapipeline.py
+++ b/src/fabric_cicd/_items/_datapipeline.py
@@ -187,6 +187,7 @@ def _find_referenced_datapipelines(fabric_workspace_obj, item_content_dict, look
                         referenced_name = fabric_workspace_obj._convert_id_to_name(
                             item_type=item_type, generic_id=referenced_id, lookup_type=lookup_type
                         )
+                        print("REFERENCED NAME:", referenced_name)
                         if referenced_name:
                             reference_list.append(referenced_name)
                 

--- a/src/fabric_cicd/_items/_datapipeline.py
+++ b/src/fabric_cicd/_items/_datapipeline.py
@@ -183,6 +183,7 @@ def _find_referenced_datapipelines(fabric_workspace_obj, item_content_dict, look
                     match = guid_pattern.search(value)
                     if match:
                         referenced_id = match.group(0) # ensure valid guid
+                        print("VALID GUID:", referenced_id)
                         referenced_name = fabric_workspace_obj._convert_id_to_name(
                             item_type=item_type, generic_id=referenced_id, lookup_type=lookup_type
                         )

--- a/src/fabric_cicd/_items/_datapipeline.py
+++ b/src/fabric_cicd/_items/_datapipeline.py
@@ -132,17 +132,17 @@ def _find_referenced_datapipelines(fabric_workspace_obj, item_content_dict, look
                     match = guid_pattern.search(value)
                     if match:
                         # If a valid GUID is found, convert it to its name. If it's not None, it's a pipeline and will be added to the reference list
-                        referenced_id = match.group(0) 
+                        referenced_id = match.group(0)
                         referenced_name = fabric_workspace_obj._convert_id_to_name(
                             item_type=item_type, generic_id=referenced_id, lookup_type=lookup_type
                         )
                         if referenced_name:
                             reference_list.append(referenced_name)
-                
+
                 # Recursively search in the value
                 else:
                     find_pipeline(value)
-                
+
         # Check if the current object is a list
         elif isinstance(input_object, list):
             # Recursively search in each item
@@ -151,5 +151,5 @@ def _find_referenced_datapipelines(fabric_workspace_obj, item_content_dict, look
 
     # Start the recursive search from the root of the JSON data
     find_pipeline(item_content_dict)
-    
+
     return reference_list


### PR DESCRIPTION
This pull request includes changes to the `src/fabric_cicd/_items/_datapipeline.py` file to improve the method for finding referenced data pipelines. The most important changes include importing the `re` module, renaming a method, and updating the logic for identifying pipeline references.

Improvements to data pipeline reference identification:

* [`src/fabric_cicd/_items/_datapipeline.py`](diffhunk://#diff-f5d57c243b415de3d1c44d5e1084f6301e90adaef563daecf4439dbc217dc254R3): Imported the `re` module to use regular expressions for pattern matching.
* [`src/fabric_cicd/_items/_datapipeline.py`](diffhunk://#diff-f5d57c243b415de3d1c44d5e1084f6301e90adaef563daecf4439dbc217dc254R117-R132): Added a regular expression pattern `guid_pattern` to identify GUIDs in the JSON data.
* [`src/fabric_cicd/_items/_datapipeline.py`](diffhunk://#diff-f5d57c243b415de3d1c44d5e1084f6301e90adaef563daecf4439dbc217dc254R117-R132): Renamed the method `find_execute_pipeline_activities` to `find_pipeline` for better clarity.
* [`src/fabric_cicd/_items/_datapipeline.py`](diffhunk://#diff-f5d57c243b415de3d1c44d5e1084f6301e90adaef563daecf4439dbc217dc254R117-R132): Updated the logic inside the renamed method to use the `guid_pattern` for identifying pipeline references and converting them to names.
* [`src/fabric_cicd/_items/_datapipeline.py`](diffhunk://#diff-f5d57c243b415de3d1c44d5e1084f6301e90adaef563daecf4439dbc217dc254L144-R150): Replaced all calls to `find_execute_pipeline_activities` with `find_pipeline` to reflect the method renaming.