### PR TITLE
Onboard Tech Debt Form & Fixes #26

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -1,13 +1,13 @@
 name: Bug Report
 description: Report a bug
-title: "[Bug]: "
+title: ""
 labels: ["bug"]
 body:
     - type: markdown
       attributes:
           value: Thanks for reporting a bug!
 
-    - type: input
+    - type: textarea
       id: steps-to-reproduce
       attributes:
           label: Steps to Reproduce

--- a/.github/ISSUE_TEMPLATE/3-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/3-documentation.yml
@@ -1,6 +1,6 @@
 name: Documentation Feedback
 description: Provide documentation feedback
-title: "[Documentation]: "
+title: ""
 labels: ["documentation"]
 body:
     - type: markdown

--- a/.github/ISSUE_TEMPLATE/4-question.yml
+++ b/.github/ISSUE_TEMPLATE/4-question.yml
@@ -1,6 +1,6 @@
 name: Question
 description: Ask a question
-title: "[Question]: "
+title: ""
 labels: ["question"]
 body:
     - type: markdown

--- a/.github/ISSUE_TEMPLATE/5-tech-debt.yml
+++ b/.github/ISSUE_TEMPLATE/5-tech-debt.yml
@@ -1,11 +1,11 @@
-name: Feature Request
-description: Request a feature
+name: Technical Debt
+description: Raises technical debt
 title: ""
-labels: ["enhancement"]
+labels: ["tech debt"]
 body:
     - type: markdown
       attributes:
-          value: Thanks for suggesting a feature!
+          value: Used internally to raise improvements in code quality, maintainability, and technical debt.
 
     - type: textarea
       id: problem-description
@@ -22,14 +22,6 @@ body:
           description: Describe the solution you'd like
       validations:
           required: true
-
-    - type: textarea
-      id: alternatives-considered
-      attributes:
-          label: What alternatives have you considered?
-          description: Describe alternatives you've considered
-      validations:
-          required: false
 
     - type: textarea
       id: additional-context


### PR DESCRIPTION
This pull request includes several changes to the GitHub issue templates to improve their clarity and usability. The most important changes involve removing default titles, changing input types, and adding a new template for technical debt.

Improvements to existing templates:

* [`.github/ISSUE_TEMPLATE/1-bug.yml`](diffhunk://#diff-6776d62e4a2433668f6f50806c424a3f35f7c39b885e14ce2dc35ca8510b861aL3-R10): Removed the default title and changed the input type for steps to reproduce from `input` to `textarea`.
* [`.github/ISSUE_TEMPLATE/2-feature.yml`](diffhunk://#diff-1ec81c5c8c2cd65f57c32fb1f61ed32d7c1afb286ef327bed07d3b5acd0d4a8bL3-R3): Removed the default title and the placeholder text in the problem description section. [[1]](diffhunk://#diff-1ec81c5c8c2cd65f57c32fb1f61ed32d7c1afb286ef327bed07d3b5acd0d4a8bL3-R3) [[2]](diffhunk://#diff-1ec81c5c8c2cd65f57c32fb1f61ed32d7c1afb286ef327bed07d3b5acd0d4a8bL15)
* [`.github/ISSUE_TEMPLATE/3-documentation.yml`](diffhunk://#diff-9295a7d51c16b5010e765b4bba9d04aafd3a14c236853278c883035e5342f77dL3-R3): Removed the default title.
* [`.github/ISSUE_TEMPLATE/4-question.yml`](diffhunk://#diff-b5af8cfbd3b986c209adfa75a774029c2ad8ce5f6c98fc0e3ba513d378fce42aL3-R3): Removed the default title.

Addition of a new template:

* [`.github/ISSUE_TEMPLATE/5-tech-debt.yml`](diffhunk://#diff-25439778fe4e73e94cc7fd5ada17fb561be891f23fb2193db29a926ee2016820R1-R32): Added a new issue template for raising technical debt, including sections for problem description, solution description, and additional context.