### PR TITLE
Add Form Titles

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Report a bug
-title: ""
+title: "Bug Report"
 labels: ["bug"]
 body:
     - type: markdown

--- a/.github/ISSUE_TEMPLATE/2-feature.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature.yml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: Request a feature
-title: ""
+title: "Feature Request"
 labels: ["enhancement"]
 body:
     - type: markdown

--- a/.github/ISSUE_TEMPLATE/3-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/3-documentation.yml
@@ -1,6 +1,6 @@
 name: Documentation Feedback
 description: Provide documentation feedback
-title: ""
+title: "Documentation Feedback"
 labels: ["documentation"]
 body:
     - type: markdown

--- a/.github/ISSUE_TEMPLATE/4-question.yml
+++ b/.github/ISSUE_TEMPLATE/4-question.yml
@@ -1,6 +1,6 @@
 name: Question
 description: Ask a question
-title: ""
+title: "Question"
 labels: ["question"]
 body:
     - type: markdown

--- a/.github/ISSUE_TEMPLATE/5-tech-debt.yml
+++ b/.github/ISSUE_TEMPLATE/5-tech-debt.yml
@@ -1,6 +1,6 @@
 name: Technical Debt
 description: Raises technical debt
-title: ""
+title: "Technical Debt"
 labels: ["tech debt"]
 body:
     - type: markdown


### PR DESCRIPTION
This pull request includes changes to the issue templates to provide more descriptive titles. The changes ensure that each issue template has a predefined title to improve clarity and consistency.

Changes to issue templates:

* [`.github/ISSUE_TEMPLATE/1-bug.yml`](diffhunk://#diff-6776d62e4a2433668f6f50806c424a3f35f7c39b885e14ce2dc35ca8510b861aL3-R3): Changed the title from an empty string to "Bug Report".
* [`.github/ISSUE_TEMPLATE/2-feature.yml`](diffhunk://#diff-1ec81c5c8c2cd65f57c32fb1f61ed32d7c1afb286ef327bed07d3b5acd0d4a8bL3-R3): Changed the title from an empty string to "Feature Request".
* [`.github/ISSUE_TEMPLATE/3-documentation.yml`](diffhunk://#diff-9295a7d51c16b5010e765b4bba9d04aafd3a14c236853278c883035e5342f77dL3-R3): Changed the title from an empty string to "Documentation Feedback".
* [`.github/ISSUE_TEMPLATE/4-question.yml`](diffhunk://#diff-b5af8cfbd3b986c209adfa75a774029c2ad8ce5f6c98fc0e3ba513d378fce42aL3-R3): Changed the title from an empty string to "Question".
* [`.github/ISSUE_TEMPLATE/5-tech-debt.yml`](diffhunk://#diff-25439778fe4e73e94cc7fd5ada17fb561be891f23fb2193db29a926ee2016820L3-R3): Changed the title from an empty string to "Technical Debt".