### PR TITLE
Update Readme Fixes #43

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,15 @@ fabric-cicd is a Python library designed for use with [Microsoft Fabric](https:/
 
 All documentation is hosted on our [fabric-cicd](https://microsoft.github.io/fabric-cicd/) GitHub Pages
 
--   [Getting Started](https://microsoft.github.io/fabric-cicd/)
--   [Examples](https://microsoft.github.io/fabric-cicd/example/)
--   [Code Reference](https://microsoft.github.io/fabric-cicd/code_reference/)
--   [Contribution](https://microsoft.github.io/fabric-cicd/contribution/)
--   [Changelog](https://microsoft.github.io/fabric-cicd/changelog/)
--   [Support](https://microsoft.github.io/fabric-cicd/help/#support)
--   [Security](https://microsoft.github.io/fabric-cicd/help/#security)
--   [License](https://microsoft.github.io/fabric-cicd/help/#license)
+Useful Sections:
+-   [Getting Started](https://microsoft.github.io/fabric-cicd/latest/how_to/getting_started/)
+-   [Examples](https://microsoft.github.io/fabric-cicd/latest/how_to/example/)
+-   [Code Reference](https://microsoft.github.io/fabric-cicd/latest/code_reference/)
+-   [Contribution](https://microsoft.github.io/fabric-cicd/latest/contribution/)
+-   [Changelog](https://microsoft.github.io/fabric-cicd/latest/changelog/)
+-   [Support](https://microsoft.github.io/fabric-cicd/latest/help/#support)
+-   [Security](https://microsoft.github.io/fabric-cicd/latest/help/#security)
+-   [License](https://microsoft.github.io/fabric-cicd/latest/help/#license)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ fabric-cicd is a Python library designed for use with [Microsoft Fabric](https:/
 
 All documentation is hosted on our [fabric-cicd](https://microsoft.github.io/fabric-cicd/) GitHub Pages
 
-Useful Sections:
+Section Overview:
 -   [Home](https://microsoft.github.io/fabric-cicd/latest/)
 -   [How To](https://microsoft.github.io/fabric-cicd/latest/how_to/)
 -   [Contribution](https://microsoft.github.io/fabric-cicd/latest/contribution/)
 -   [Changelog](https://microsoft.github.io/fabric-cicd/latest/changelog/)
--   [Support & Security](https://microsoft.github.io/fabric-cicd/latest/help/)
+-   [About](https://microsoft.github.io/fabric-cicd/latest/help/) - Inclusive of Support & Security Policies
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -18,14 +18,11 @@ fabric-cicd is a Python library designed for use with [Microsoft Fabric](https:/
 All documentation is hosted on our [fabric-cicd](https://microsoft.github.io/fabric-cicd/) GitHub Pages
 
 Useful Sections:
--   [Getting Started](https://microsoft.github.io/fabric-cicd/latest/how_to/getting_started/)
--   [Examples](https://microsoft.github.io/fabric-cicd/latest/how_to/example/)
--   [Code Reference](https://microsoft.github.io/fabric-cicd/latest/code_reference/)
+-   [Home](https://microsoft.github.io/fabric-cicd/latest/)
+-   [How To](https://microsoft.github.io/fabric-cicd/latest/how_to/)
 -   [Contribution](https://microsoft.github.io/fabric-cicd/latest/contribution/)
 -   [Changelog](https://microsoft.github.io/fabric-cicd/latest/changelog/)
--   [Support](https://microsoft.github.io/fabric-cicd/latest/help/#support)
--   [Security](https://microsoft.github.io/fabric-cicd/latest/help/#security)
--   [License](https://microsoft.github.io/fabric-cicd/latest/help/#license)
+-   [Support & Security](https://microsoft.github.io/fabric-cicd/latest/help/)
 
 ## Installation
 

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,4 +1,4 @@
-# Help
+# About
 
 ## Support
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,9 +29,10 @@ pip install --upgrade --index-url https://test.pypi.org/simple/ --extra-index-ur
 ```
 
 ## Basic Example
-from fabric_cicd import FabricWorkspace, publish_all_items, unpublish_all_orphan_items
 
 ```python
+from fabric_cicd import FabricWorkspace, publish_all_items, unpublish_all_orphan_items
+
 # Initialize the FabricWorkspace object with the required parameters
 target_workspace = FabricWorkspace(
     workspace_id = "your-workspace-id",

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,3 +27,6 @@ While in private preview, to install fabric-cicd, run:
 ```bash
 pip install --upgrade --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ fabric-cicd
 ```
+
+## Basic Example
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,3 +22,8 @@ To install fabric-cicd, run:
 ```bash
 pip install fabric-cicd
 ```
+While in private preview, to install fabric-cicd, run:
+
+```bash
+pip install --upgrade --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ fabric-cicd
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,4 +29,19 @@ pip install --upgrade --index-url https://test.pypi.org/simple/ --extra-index-ur
 ```
 
 ## Basic Example
+from fabric_cicd import FabricWorkspace, publish_all_items, unpublish_all_orphan_items
 
+```python
+# Initialize the FabricWorkspace object with the required parameters
+target_workspace = FabricWorkspace(
+    workspace_id = "your-workspace-id",
+    repository_directory = "your-repository-directory",
+    item_type_in_scope = ["Notebook", "DataPipeline", "Environment"],
+)
+
+# Publish all items defined in item_type_in_scope
+publish_all_items(target_workspace)
+
+# Unpublish all items defined in item_type_in_scope not found in repository
+unpublish_all_orphan_items(target_workspace)
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,7 @@ nav:
     - Code Reference: code_reference.md
     - Contribution: contribution.md
     - Changelog: changelog.md
-    - Help: help.md
+    - About: about.md
 
 theme:
     name: material


### PR DESCRIPTION
This pull request includes several documentation updates and improvements to the `fabric-cicd` project. The most important changes include updating the section overview in the `README.md`, renaming the `help.md` file to `about.md`, adding installation instructions for the private preview, and updating the navigation in the `mkdocs.yml` file.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R25): Updated the section overview links to reflect the new structure and consolidated support and security policies under the "About" section.
* `docs/help.md` renamed to `docs/about.md`: Renamed the file to better reflect its content, which includes support and security information.
* [`docs/index.md`](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R25-R48): Added installation instructions for the private preview and included a basic example of how to use the `fabric-cicd` library.

Configuration updates:

* [`mkdocs.yml`](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2L18-R18): Updated the navigation to reflect the renaming of the `help.md` file to `about.md`.