### PR TITLE
Remove Private Preview References

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,11 +22,6 @@ To install fabric-cicd, run:
 ```bash
 pip install fabric-cicd
 ```
-While in private preview, to install fabric-cicd, run:
-
-```bash
-pip install --upgrade --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ fabric-cicd
-```
 
 ## Basic Example
 


### PR DESCRIPTION
This pull request includes a change to the `docs/index.md` file to simplify the installation instructions for `fabric-cicd`.

Documentation update:

* Removed the instructions for installing `fabric-cicd` during the private preview phase, leaving only the standard installation command.