### PR TITLE
Fixed integer check

### DIFF
--- a/src/fabric_cicd/_common/_fabric_endpoint.py
+++ b/src/fabric_cicd/_common/_fabric_endpoint.py
@@ -242,6 +242,7 @@ def handle_retry(attempt, base_delay, max_retries, response_retry_after=60, prep
     """
     if attempt < max_retries:
         retry_after = float(response_retry_after)
+        base_delay = float(base_delay)
         delay = min(retry_after, base_delay * (2**attempt))
 
         # modify output for proper plurality and formatting


### PR DESCRIPTION
Solves an issue with `int.is_integer()` not being available in Python versions < 3.12.

closes #63 