### PR TITLE
Fixes #64, Fixes #65 - Documentation Updates

### DIFF
--- a/sample/auth_spn_secret.py
+++ b/sample/auth_spn_secret.py
@@ -19,7 +19,7 @@ token_credential = ClientSecretCredential(client_id=client_id, client_secret=cli
 workspace_id = "your-workspace-id"
 environment = "your-environment"
 repository_directory = "your-repository-directory"
-item_type_in_scope = ["Notebook", "DataPipeline", "Environment"]
+item_type_in_scope = ["Notebook", "Environment"]
 
 # Initialize the FabricWorkspace object with the required parameters
 target_workspace = FabricWorkspace(

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -42,7 +42,7 @@ class FabricWorkspace:
         workspace_id : str
             The ID of the workspace to interact with.
         repository_directory : str
-            Directory path where repository items are located.
+            Local directory path of the repository where items are to be deployed from.
         item_type_in_scope : list
             Item types that should be deployed for given workspace.
         base_api_url : str, optional


### PR DESCRIPTION
This pull request includes a minor change to the `src/fabric_cicd/fabric_workspace.py` file. The change updates the description of the `repository_directory` parameter in the `__init__` method to clarify that it refers to the local directory path of the repository where items are to be deployed from.

* [`src/fabric_cicd/fabric_workspace.py`](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L45-R45): Updated the description of the `repository_directory` parameter in the `__init__` method to clarify its purpose.