### PR TITLE
Test Fabric Endpoint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -53,5 +53,10 @@
         "tabWidth": 4,
         "useTabs": false
     },
-    "python.terminal.activateEnvironment": false
+    "python.terminal.activateEnvironment": false,
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dev = [
     "pytest>=8.3.4",
     "pytest-mock>=3.14.0",
     "ruff>=0.9.3",
+    "coverage>=7.6.10",
 ]
 
 
@@ -45,6 +46,6 @@ python-preference = "only-managed"
 
 
 [tool.pytest.ini_options]
-addopts = "-v --tb=short --disable-warnings"
+addopts = "-v --tb=short"
 testpaths = ["tests"]
 pythonpath = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "coverage>=7.6.10",
     "gitpython>=3.1.44",
     "mike>=2.1.3",
     "mkdocs-include-markdown-plugin>=7.1.2",
@@ -27,8 +28,7 @@ dev = [
     "mkdocstrings-python>=1.13.0",
     "pytest>=8.3.4",
     "pytest-mock>=3.14.0",
-    "ruff>=0.9.3",
-    "coverage>=7.6.10",
+    "ruff>=0.9.5",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ dev = [
     "mkdocs-include-markdown-plugin>=7.1.2",
     "mkdocs-minify-plugin>=0.8.0",
     "mkdocstrings-python>=1.13.0",
+    "pytest>=8.3.4",
+    "pytest-mock>=3.14.0",
+    "ruff>=0.9.3",
 ]
 
 
@@ -39,3 +42,9 @@ packages.find.where = ["src"]
 [tool.uv]
 package = true
 python-preference = "only-managed"
+
+
+[tool.pytest.ini_options]
+addopts = "-v --tb=short --disable-warnings"
+testpaths = ["tests"]
+pythonpath = ["src"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,4 @@
 ruff
 gitpython
+pytest
+pytest-mock

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ ruff
 gitpython
 pytest
 pytest-mock
+coverage

--- a/ruff.toml
+++ b/ruff.toml
@@ -30,7 +30,7 @@ ignore = [
 ]
 
 [lint.per-file-ignores]
-"{devtools}/*" = [
+"{devtools,tests}/*" = [
     "D",   # pydocstyle
     "INP", # flake8-no-pep420
 ]

--- a/src/fabric_cicd/_common/_fabric_endpoint.py
+++ b/src/fabric_cicd/_common/_fabric_endpoint.py
@@ -43,134 +43,29 @@ class FabricEndpoint:
 
         while not exit_loop:
             try:
+                headers = {"Authorization": f"Bearer {self.aad_token}"}
                 if files is None:
-                    headers = {
-                        "Authorization": f"Bearer {self.aad_token}",
-                        "Content-Type": "application/json; charset=utf-8",
-                    }
-                    response = requests.request(method=method, url=url, headers=headers, json=body)
-                else:
-                    headers = {"Authorization": f"Bearer {self.aad_token}"}
-                    response = requests.request(method=method, url=url, headers=headers, files=files)
+                    headers["Content-Type"] = "application/json; charset=utf-8"
+                response = requests.request(method=method, url=url, headers=headers, json=body, files=files)
 
                 iteration_count += 1
 
-                retry_after = response.headers.get("Retry-After", 60)
                 invoke_log_message = _format_invoke_log(response, method, url, body)
 
-                # Handle long-running operations
-                # https://learn.microsoft.com/en-us/rest/api/fabric/core/long-running-operations/get-operation-result
-                if (response.status_code == 200 and long_running) or response.status_code == 202:
-                    url = response.headers.get("Location")
-                    method = "GET"
-                    body = "{}"
-                    response_json = response.json()
-
-                    if long_running:
-                        status = response_json.get("status")
-                        if status == "Succeeded":
-                            long_running = False
-                            # If location not included in operation success call, no body is expected to be returned
-                            exit_loop = url is None
-
-                        elif status == "Failed":
-                            response_error = response_json["error"]
-                            msg = (
-                                f"Operation failed. Error Code: {response_error['errorCode']}. "
-                                f"Error Message: {response_error['message']}"
-                            )
-                            raise Exception(msg)
-                        elif status == "Undefined":
-                            msg = f"Operation is in an undefined state. Full Body: {response_json}"
-                            raise Exception(msg)
-                        else:
-                            handle_retry(
-                                attempt=iteration_count - 1,
-                                base_delay=0.5,
-                                response_retry_after=retry_after,
-                                max_retries=kwargs.get("max_retries", 5),
-                                prepend_message="Operation in progress.",
-                            )
-                    else:
-                        time.sleep(1)
-                        long_running = True
-
-                # Handle successful responses
-                elif response.status_code in {200, 201} or (
-                    # Valid response for environmentlibrariesnotfound
-                    response.status_code == 404
-                    and response.headers.get("x-ms-public-api-error-code") == "EnvironmentLibrariesNotFound"
-                ):
-                    exit_loop = True
-
-                # Handle API throttling
-                elif response.status_code == 429:
-                    handle_retry(
-                        attempt=iteration_count,
-                        base_delay=10,
-                        max_retries=5,
-                        response_retry_after=retry_after,
-                        prepend_message="API is throttled.",
-                    )
-
                 # Handle expired authentication token
-                elif (
-                    response.status_code == 401 and response.headers.get("x-ms-public-api-error-code") == "TokenExpired"
-                ):
+                if response.status_code == 401 and response.headers.get("x-ms-public-api-error-code") == "TokenExpired":
                     logger.info("AAD token expired. Refreshing token.")
                     self._refresh_token()
-
-                # Handle unauthorized access
-                elif (
-                    response.status_code == 401 and response.headers.get("x-ms-public-api-error-code") == "Unauthorized"
-                ):
-                    msg = f"The executing identity is not authorized to call {method} on '{url}'."
-                    raise Exception(msg)
-
-                # Handle item name conflicts
-                elif (
-                    response.status_code == 400
-                    and response.headers.get("x-ms-public-api-error-code") == "ItemDisplayNameAlreadyInUse"
-                ):
-                    handle_retry(
-                        attempt=iteration_count,
-                        base_delay=2.5,
-                        max_retries=5,
-                        prepend_message="Item name is reserved. ",
-                    )
-
-                # Handle scenario where library removed from environment before being removed from repo
-                elif response.status_code == 400 and "is not present in the environment." in response.json().get(
-                    "message", "No message provided"
-                ):
-                    msg = (
-                        f"Deployment attempted to remove a library that is not present in the environment. "
-                        f"Description: {response.json().get('message')}"
-                    )
-                    raise Exception(msg)
-
-                # Handle unsupported principal type
-                elif (
-                    response.status_code == 400
-                    and response.headers.get("x-ms-public-api-error-code") == "PrincipalTypeNotSupported"
-                ):
-                    msg = f"The executing principal type is not supported to call {method} on '{url}'."
-                    raise Exception(msg)
-
-                # Handle unsupported item types
-                elif response.status_code == 403 and response.reason == "FeatureNotAvailable":
-                    msg = f"Item type not supported. Description: {response.reason}"
-                    raise Exception(msg)
-
-                # Handle unexpected errors
                 else:
-                    err_msg = (
-                        f" Message: {response.json()['message']}"
-                        if "application/json" in (response.headers.get("Content-Type") or "")
-                        else ""
+                    exit_loop, method, url, body, long_running = _handle_response(
+                        response,
+                        method,
+                        url,
+                        body,
+                        long_running,
+                        iteration_count,
+                        **kwargs,
                     )
-                    msg = f"Unhandled error occurred calling {method} on '{url}'.{err_msg}"
-                    raise Exception(msg)
 
                 # Log if reached to end of loop iteration
                 if logger.isEnabledFor(logging.DEBUG):
@@ -230,6 +125,132 @@ class FabricEndpoint:
             except Exception as e:
                 msg = f"An unexpected error occurred while decoding the credential token. {e}"
                 raise TokenError(msg, logger) from e
+
+
+def _handle_response(response, method, url, body, long_running, iteration_count, **kwargs):
+    """
+    Handles the response from an HTTP request, including retries, throttling, and token expiration.
+    Technical debt: this method needs to be refactored to be more testable and requires less paramters.
+    Initial approach is only temporary to support testing, but only temporary.
+
+    ::param response: The response object from the HTTP request.
+    ::param method: The HTTP method used in the request.
+    ::param url: The URL used in the request.
+    ::param body: The JSON body used in the request.
+    ::param long_running: A boolean indicating if the operation is long-running.
+    ::param invoke_log_message: The formatted log message for the request.
+    ::param iteration_count: The current iteration count of the loop.
+    ::param kwargs: Additional keyword arguments to pass to the method.
+    """
+    exit_loop = False
+    retry_after = response.headers.get("Retry-After", 60)
+
+    # Handle long-running operations
+    # https://learn.microsoft.com/en-us/rest/api/fabric/core/long-running-operations/get-operation-result
+    if (response.status_code == 200 and long_running) or response.status_code == 202:
+        url = response.headers.get("Location")
+        method = "GET"
+        body = "{}"
+        response_json = response.json()
+
+        if long_running:
+            status = response_json.get("status")
+            if status == "Succeeded":
+                long_running = False
+                # If location not included in operation success call, no body is expected to be returned
+                exit_loop = url is None
+
+            elif status == "Failed":
+                response_error = response_json["error"]
+                msg = (
+                    f"Operation failed. Error Code: {response_error['errorCode']}. "
+                    f"Error Message: {response_error['message']}"
+                )
+                raise Exception(msg)
+            elif status == "Undefined":
+                msg = f"Operation is in an undefined state. Full Body: {response_json}"
+                raise Exception(msg)
+            else:
+                handle_retry(
+                    attempt=iteration_count - 1,
+                    base_delay=0.5,
+                    response_retry_after=retry_after,
+                    max_retries=kwargs.get("max_retries", 5),
+                    prepend_message="Operation in progress.",
+                )
+        else:
+            time.sleep(1)
+            long_running = True
+
+    # Handle successful responses
+    elif response.status_code in {200, 201} or (
+        # Valid response for environmentlibrariesnotfound
+        response.status_code == 404
+        and response.headers.get("x-ms-public-api-error-code") == "EnvironmentLibrariesNotFound"
+    ):
+        exit_loop = True
+
+    # Handle API throttling
+    elif response.status_code == 429:
+        handle_retry(
+            attempt=iteration_count,
+            base_delay=10,
+            max_retries=5,
+            response_retry_after=retry_after,
+            prepend_message="API is throttled.",
+        )
+
+    # Handle unauthorized access
+    elif response.status_code == 401 and response.headers.get("x-ms-public-api-error-code") == "Unauthorized":
+        msg = f"The executing identity is not authorized to call {method} on '{url}'."
+        raise Exception(msg)
+
+    # Handle item name conflicts
+    elif (
+        response.status_code == 400
+        and response.headers.get("x-ms-public-api-error-code") == "ItemDisplayNameAlreadyInUse"
+    ):
+        handle_retry(
+            attempt=iteration_count,
+            base_delay=2.5,
+            max_retries=5,
+            prepend_message="Item name is reserved. ",
+        )
+
+    # Handle scenario where library removed from environment before being removed from repo
+    elif response.status_code == 400 and "is not present in the environment." in response.json().get(
+        "message", "No message provided"
+    ):
+        msg = (
+            f"Deployment attempted to remove a library that is not present in the environment. "
+            f"Description: {response.json().get('message')}"
+        )
+        raise Exception(msg)
+
+    # Handle unsupported principal type
+    elif (
+        response.status_code == 400
+        and response.headers.get("x-ms-public-api-error-code") == "PrincipalTypeNotSupported"
+    ):
+        msg = f"The executing principal type is not supported to call {method} on '{url}'."
+        raise Exception(msg)
+
+    # Handle unsupported item types
+    elif response.status_code == 403 and response.reason == "FeatureNotAvailable":
+        msg = f"Item type not supported. Description: {response.reason}"
+        raise Exception(msg)
+
+    # Handle unexpected errors
+    else:
+        err_msg = (
+            f" Message: {response.json()['message']}"
+            if "application/json" in (response.headers.get("Content-Type") or "")
+            else ""
+        )
+        msg = f"Unhandled error occurred calling {method} on '{url}'.{err_msg}"
+        raise Exception(msg)
+
+    return exit_loop, method, url, body, long_running
 
 
 def handle_retry(attempt, base_delay, max_retries, response_retry_after=60, prepend_message=""):

--- a/src/fabric_cicd/_common/_fabric_endpoint.py
+++ b/src/fabric_cicd/_common/_fabric_endpoint.py
@@ -42,6 +42,7 @@ class FabricEndpoint:
         iteration_count = 0
         long_running = False
         start_time = time.time()
+        invoke_log_message = ""
 
         while not exit_loop:
             try:
@@ -219,7 +220,7 @@ def _handle_response(response, method, url, body, long_running, iteration_count,
             attempt=iteration_count,
             base_delay=2.5,
             max_retries=5,
-            prepend_message="Item name is reserved. ",
+            prepend_message="Item name is reserved.",
         )
 
     # Handle scenario where library removed from environment before being removed from repo

--- a/tests/test_fabric_endpoint.py
+++ b/tests/test_fabric_endpoint.py
@@ -1,0 +1,95 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from unittest.mock import Mock
+
+import pytest
+
+from fabric_cicd._common._fabric_endpoint import _handle_response
+
+
+@pytest.fixture
+def mock_requests(mocker):
+    return mocker.patch("requests.request")
+
+
+@pytest.mark.parametrize( 
+    ("status_code", "request_method", "expected_long_running", "expected_exit_loop", "response_header"),  
+    [
+        (200, "POST", False, True, {}),
+        (202, "POST", True, False, {"Retry-After": 20, "Location": "new"})
+    ],
+    ids=[
+        "success",
+        "long_running_redirect",
+    ])  # fmt: skip
+def test_handle_response(status_code, request_method, expected_long_running, expected_exit_loop, response_header):
+    """Long running scenarios expected to pass"""
+    response = Mock(status_code=status_code, headers=response_header, json=Mock(return_value={}))
+
+    exit_loop, _method, url, _body, long_running = _handle_response(
+        response=response,
+        method=request_method,
+        url="old",
+        body="{}",
+        long_running=False,
+        iteration_count=1,
+    )
+    assert exit_loop == expected_exit_loop
+    assert long_running == expected_long_running
+
+
+@pytest.mark.parametrize( 
+    ("expected_long_running", "expected_exit_loop", "response_json", "response_header"),  
+    [
+        (True, False,    {"status": "Running"}, {"Retry-After": 20, "Location": "old"}),
+        (False, True,  {"status": "Succeeded"}, {}),
+        (False, False, {"status": "Succeeded"}, {"Retry-After": 20, "Location": "old"}),
+    ],
+    ids=[
+        "long_running_running",
+        "long_running__success",
+        "long_running__success_with_result",
+    ])  # fmt: skip
+def test_handle_response_longrunning(expected_long_running, expected_exit_loop, response_json, response_header):
+    """Long running scenarios expected to pass"""
+    response = Mock(status_code=200, headers=response_header, json=Mock(return_value=response_json))
+
+    exit_loop, _method, _url, _body, long_running = _handle_response(
+        response=response,
+        method="GET",
+        url="old",
+        body="{}",
+        long_running=True,
+        iteration_count=2,
+    )
+    assert exit_loop == expected_exit_loop
+    assert long_running == expected_long_running
+
+
+@pytest.mark.parametrize( 
+    ("exception_match", "response_json"),  
+    [
+        ("[Operation failed].*", {"status": "Failed","error": {"errorCode": "SampleErrorCode", "message": "Sample failure message"}}),
+        ("[Operation is in an undefined state].*", {"status": "Undefined"}),
+    ],
+    ids=[
+        "failed",
+        "undefined",
+    ])  # fmt: skip
+def test_handle_response_longrunning_exception(
+    exception_match,
+    response_json,
+):
+    """Long running scenarios expected to pass"""
+    response = Mock(status_code=200, headers={}, json=Mock(return_value=response_json))
+
+    with pytest.raises(Exception, match=exception_match):
+        _handle_response(
+            response=response,
+            method="GET",
+            url="old",
+            body="{}",
+            long_running=True,
+            iteration_count=2,
+        )

--- a/tests/test_fabric_endpoint.py
+++ b/tests/test_fabric_endpoint.py
@@ -3,11 +3,28 @@
 
 import base64
 import json
+import time
 from unittest.mock import Mock
 
 import pytest
 
-from fabric_cicd._common._fabric_endpoint import FabricEndpoint, _handle_response
+from fabric_cicd._common._exceptions import InvokeError, TokenError
+from fabric_cicd._common._fabric_endpoint import FabricEndpoint, _decode_jwt, _format_invoke_log, _handle_response
+
+
+class DummyLogger:
+    def __init__(self):
+        self.messages = []
+
+    def info(self, message):
+        self.messages.append(message)
+
+
+@pytest.fixture
+def dummy_logger(monkeypatch):
+    dl = DummyLogger()
+    monkeypatch.setattr("fabric_cicd._common._fabric_endpoint.logger", dl)
+    return dl
 
 
 @pytest.fixture
@@ -22,6 +39,34 @@ def generate_mock_jwt():
     return f"{header}.{payload}.{signature}"
 
 
+def test_integration(mock_requests):
+    """Integration test for FabricEndpoint"""
+    mock_requests.return_value = Mock(
+        status_code=200, headers={"Content-Type": "application/json"}, json=Mock(return_value={})
+    )
+    mock_token_credential = Mock()
+    mock_token_credential.get_token.return_value.token = generate_mock_jwt()
+    endpoint = FabricEndpoint(token_credential=mock_token_credential)
+    response = endpoint.invoke("GET", "http://example.com")
+    assert response["status_code"] == 200
+
+
+def test_performance(mock_requests):
+    """Performance test for _handle_response"""
+    response = Mock(status_code=200, headers={}, json=Mock(return_value={"status": "Succeeded"}))
+    start_time = time.time()
+    _handle_response(
+        response=response,
+        method="GET",
+        url="old",
+        body="{}",
+        long_running=True,
+        iteration_count=2,
+    )
+    end_time = time.time()
+    assert (end_time - start_time) < 1  # Ensure the function completes within 1 second
+
+
 def test_invoke(mock_requests):
     """Test the invoke method of FabricEndpoint"""
     mock_requests.return_value = Mock(
@@ -34,6 +79,28 @@ def test_invoke(mock_requests):
     assert response["status_code"] == 200
 
 
+def test_invoke_with_files(mock_requests):
+    """Test the invoke method of FabricEndpoint with files"""
+    mock_requests.return_value = Mock(
+        status_code=200, headers={"Content-Type": "application/json"}, json=Mock(return_value={})
+    )
+    mock_token_credential = Mock()
+    mock_token_credential.get_token.return_value.token = generate_mock_jwt()
+    endpoint = FabricEndpoint(token_credential=mock_token_credential)
+    response = endpoint.invoke("POST", "http://example.com", files={"file": "test.txt"})
+    assert response["status_code"] == 200
+
+
+def test_invoke_exception(mock_requests):
+    """Test the invoke method of FabricEndpoint with exception"""
+    mock_requests.side_effect = Exception("Test exception")
+    mock_token_credential = Mock()
+    mock_token_credential.get_token.return_value.token = generate_mock_jwt()
+    endpoint = FabricEndpoint(token_credential=mock_token_credential)
+    with pytest.raises(InvokeError):
+        endpoint.invoke("GET", "http://example.com")
+
+
 def test_refresh_token(mock_requests):
     """Test the _refresh_token method of FabricEndpoint"""
     mock_requests.return_value = Mock(
@@ -44,6 +111,19 @@ def test_refresh_token(mock_requests):
     endpoint = FabricEndpoint(token_credential=mock_token_credential)
     endpoint._refresh_token()
     assert endpoint.aad_token == generate_mock_jwt()
+
+
+# def test_invoke_token_expired(mock_requests):
+#     """Test the invoke method of FabricEndpoint with expired token"""
+#     mock_requests.side_effect = [
+#         Mock(status_code=401, headers={"x-ms-public-api-error-code": "TokenExpired"}),
+#         Mock(status_code=200, headers={"Content-Type": "application/json"}, json=Mock(return_value={})),
+#     ]
+#     mock_token_credential = Mock()
+#     mock_token_credential.get_token.return_value.token = generate_mock_jwt()
+#     endpoint = FabricEndpoint(token_credential=mock_token_credential)
+#     response = endpoint.invoke("GET", "http://example.com")
+#     assert response["status_code"] == 200
 
 
 @pytest.mark.parametrize(
@@ -128,31 +208,135 @@ def test_handle_response_longrunning_exception(
         )
 
 
-def test_integration(mock_requests):
-    """Integration test for FabricEndpoint"""
-    mock_requests.return_value = Mock(
-        status_code=200, headers={"Content-Type": "application/json"}, json=Mock(return_value={})
-    )
-    mock_token_credential = Mock()
-    mock_token_credential.get_token.return_value.token = generate_mock_jwt()
-    endpoint = FabricEndpoint(token_credential=mock_token_credential)
-    response = endpoint.invoke("GET", "http://example.com")
-    assert response["status_code"] == 200
-
-
-def test_performance(mock_requests):
-    """Performance test for _handle_response"""
-    import time
-
-    response = Mock(status_code=200, headers={}, json=Mock(return_value={"status": "Succeeded"}))
-    start_time = time.time()
-    _handle_response(
+def test_handle_response_environment_libraries_not_found(mock_requests):
+    """Test _handle_response for environment libraries not found"""
+    response = Mock(status_code=404, headers={"x-ms-public-api-error-code": "EnvironmentLibrariesNotFound"})
+    exit_loop, method, url, body, long_running = _handle_response(
         response=response,
         method="GET",
-        url="old",
+        url="http://example.com",
         body="{}",
-        long_running=True,
-        iteration_count=2,
+        long_running=False,
+        iteration_count=1,
     )
-    end_time = time.time()
-    assert (end_time - start_time) < 1  # Ensure the function completes within 1 second
+    assert exit_loop is True
+    assert long_running is False
+
+
+def test_handle_response_throttled(dummy_logger):
+    """Test _handle_response for API throttling"""
+    response = Mock(status_code=429, headers={"Retry-After": "10"})
+    _handle_response(response, "GET", "http://example.com", "{}", False, 1)
+    expected = "API is throttled. Checking again in 10 seconds (Attempt 1/5)..."
+    assert dummy_logger.messages == [expected]
+
+
+def test_handle_response_unauthorized(mock_requests):
+    """Test _handle_response for unauthorized access"""
+    response = Mock(status_code=401, headers={"x-ms-public-api-error-code": "Unauthorized"})
+    with pytest.raises(
+        Exception, match="The executing identity is not authorized to call GET on 'http://example.com'."
+    ):
+        _handle_response(
+            response=response,
+            method="GET",
+            url="http://example.com",
+            body="{}",
+            long_running=False,
+            iteration_count=1,
+        )
+
+
+def test_handle_response_item_display_name_already_in_use(dummy_logger):
+    """Test _handle_response for item display name already in use"""
+    response = Mock(status_code=400, headers={"x-ms-public-api-error-code": "ItemDisplayNameAlreadyInUse"})
+    _handle_response(response, "GET", "http://example.com", "{}", False, 1)
+    expected = "Item name is reserved. Checking again in 5 seconds (Attempt 1/5)..."
+    assert dummy_logger.messages == [expected]
+
+
+def test_handle_response_failed_library_removal(mock_requests):
+    """Test _handle_response for principal type not supported"""
+    response = Mock(
+        status_code=400,
+        headers={"x-ms-public-api-error-code": "PrincipalTypeNotSupported"},
+        json=Mock(return_value={"message": "Test Libabry is not present in the environment."}),
+    )
+    with pytest.raises(
+        Exception, match="Deployment attempted to remove a library that is not present in the environment. "
+    ):
+        _handle_response(
+            response=response,
+            method="GET",
+            url="http://example.com",
+            body="{}",
+            long_running=False,
+            iteration_count=1,
+        )
+
+
+def test_handle_response_principal_type_not_supported(mock_requests):
+    """Test _handle_response for principal type not supported"""
+    response = Mock(
+        status_code=400, headers={"x-ms-public-api-error-code": "PrincipalTypeNotSupported"}, json=Mock(return_value={})
+    )
+    with pytest.raises(
+        Exception, match="The executing principal type is not supported to call GET on 'http://example.com'."
+    ):
+        _handle_response(
+            response=response,
+            method="GET",
+            url="http://example.com",
+            body="{}",
+            long_running=False,
+            iteration_count=1,
+        )
+
+
+def test_handle_response_feature_not_available(mock_requests):
+    """Test _handle_response for feature not available"""
+    response = Mock(status_code=403, reason="FeatureNotAvailable")
+    with pytest.raises(Exception, match="Item type not supported. Description: FeatureNotAvailable"):
+        _handle_response(
+            response=response,
+            method="GET",
+            url="http://example.com",
+            body="{}",
+            long_running=False,
+            iteration_count=1,
+        )
+
+
+def test_handle_response_max_retry(mock_requests):
+    """Test _handle_response for retry"""
+    response = Mock(status_code=429, headers={"Retry-After": "10"})
+    with pytest.raises(Exception, match=r"Maximum retry attempts \(5\) exceeded."):
+        _handle_response(
+            response=response,
+            method="GET",
+            url="http://example.com",
+            body="{}",
+            long_running=True,
+            iteration_count=5,
+        )
+
+
+def test_decode_jwt():
+    """Test _decode_jwt function"""
+    token = generate_mock_jwt()
+    decoded = _decode_jwt(token)
+    assert decoded["exp"] == 9999999999
+
+
+def test_decode_jwt_invalid():
+    """Test _decode_jwt function with invalid token"""
+    with pytest.raises(TokenError):
+        _decode_jwt("invalid.token")
+
+
+def test_format_invoke_log():
+    """Test _format_invoke_log function"""
+    response = Mock(status_code=200, headers={"Content-Type": "application/json"}, json=Mock(return_value={}))
+    log_message = _format_invoke_log(response, "GET", "http://example.com", "{}")
+    assert "Method: GET" in log_message
+    assert "URL: http://example.com" in log_message

--- a/tests/test_fabric_endpoint.py
+++ b/tests/test_fabric_endpoint.py
@@ -1,11 +1,13 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+import base64
+import json
 from unittest.mock import Mock
 
 import pytest
 
-from fabric_cicd._common._fabric_endpoint import _handle_response
+from fabric_cicd._common._fabric_endpoint import FabricEndpoint, _handle_response
 
 
 @pytest.fixture
@@ -13,8 +15,39 @@ def mock_requests(mocker):
     return mocker.patch("requests.request")
 
 
-@pytest.mark.parametrize( 
-    ("status_code", "request_method", "expected_long_running", "expected_exit_loop", "response_header"),  
+def generate_mock_jwt():
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "HS256", "typ": "JWT"}).encode()).decode().strip("=")
+    payload = base64.urlsafe_b64encode(json.dumps({"exp": 9999999999}).encode()).decode().strip("=")
+    signature = "signature"
+    return f"{header}.{payload}.{signature}"
+
+
+def test_invoke(mock_requests):
+    """Test the invoke method of FabricEndpoint"""
+    mock_requests.return_value = Mock(
+        status_code=200, headers={"Content-Type": "application/json"}, json=Mock(return_value={})
+    )
+    mock_token_credential = Mock()
+    mock_token_credential.get_token.return_value.token = generate_mock_jwt()
+    endpoint = FabricEndpoint(token_credential=mock_token_credential)
+    response = endpoint.invoke("GET", "http://example.com")
+    assert response["status_code"] == 200
+
+
+def test_refresh_token(mock_requests):
+    """Test the _refresh_token method of FabricEndpoint"""
+    mock_requests.return_value = Mock(
+        status_code=200, json=Mock(return_value={"access_token": generate_mock_jwt(), "expires_in": 3600})
+    )
+    mock_token_credential = Mock()
+    mock_token_credential.get_token.return_value.token = generate_mock_jwt()
+    endpoint = FabricEndpoint(token_credential=mock_token_credential)
+    endpoint._refresh_token()
+    assert endpoint.aad_token == generate_mock_jwt()
+
+
+@pytest.mark.parametrize(
+    ("status_code", "request_method", "expected_long_running", "expected_exit_loop", "response_header"),
     [
         (200, "POST", False, True, {}),
         (202, "POST", True, False, {"Retry-After": 20, "Location": "new"})
@@ -39,11 +72,11 @@ def test_handle_response(status_code, request_method, expected_long_running, exp
     assert long_running == expected_long_running
 
 
-@pytest.mark.parametrize( 
-    ("expected_long_running", "expected_exit_loop", "response_json", "response_header"),  
+@pytest.mark.parametrize(
+    ("expected_long_running", "expected_exit_loop", "response_json", "response_header"),
     [
-        (True, False,    {"status": "Running"}, {"Retry-After": 20, "Location": "old"}),
-        (False, True,  {"status": "Succeeded"}, {}),
+        (True, False, {"status": "Running"}, {"Retry-After": 20, "Location": "old"}),
+        (False, True, {"status": "Succeeded"}, {}),
         (False, False, {"status": "Succeeded"}, {"Retry-After": 20, "Location": "old"}),
     ],
     ids=[
@@ -67,8 +100,8 @@ def test_handle_response_longrunning(expected_long_running, expected_exit_loop, 
     assert long_running == expected_long_running
 
 
-@pytest.mark.parametrize( 
-    ("exception_match", "response_json"),  
+@pytest.mark.parametrize(
+    ("exception_match", "response_json"),
     [
         ("[Operation failed].*", {"status": "Failed","error": {"errorCode": "SampleErrorCode", "message": "Sample failure message"}}),
         ("[Operation is in an undefined state].*", {"status": "Undefined"}),
@@ -93,3 +126,33 @@ def test_handle_response_longrunning_exception(
             long_running=True,
             iteration_count=2,
         )
+
+
+def test_integration(mock_requests):
+    """Integration test for FabricEndpoint"""
+    mock_requests.return_value = Mock(
+        status_code=200, headers={"Content-Type": "application/json"}, json=Mock(return_value={})
+    )
+    mock_token_credential = Mock()
+    mock_token_credential.get_token.return_value.token = generate_mock_jwt()
+    endpoint = FabricEndpoint(token_credential=mock_token_credential)
+    response = endpoint.invoke("GET", "http://example.com")
+    assert response["status_code"] == 200
+
+
+def test_performance(mock_requests):
+    """Performance test for _handle_response"""
+    import time
+
+    response = Mock(status_code=200, headers={}, json=Mock(return_value={"status": "Succeeded"}))
+    start_time = time.time()
+    _handle_response(
+        response=response,
+        method="GET",
+        url="old",
+        body="{}",
+        long_running=True,
+        iteration_count=2,
+    )
+    end_time = time.time()
+    assert (end_time - start_time) < 1  # Ensure the function completes within 1 second

--- a/uv.lock
+++ b/uv.lock
@@ -254,6 +254,15 @@ wheels = [
 ]
 
 [[package]]
+name = "exceptiongroup"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/35/2495c4ac46b980e4ca1f6ad6db102322ef3ad2410b79fdde159a4b0f3b92/exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc", size = 28883 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/cc/b7e31358aac6ed1ef2bb790a9746ac2c69bcb3c8588b41616914eb106eaf/exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b", size = 16453 },
+]
+
+[[package]]
 name = "fabric-cicd"
 source = { editable = "." }
 dependencies = [
@@ -272,6 +281,9 @@ dev = [
     { name = "mkdocs-include-markdown-plugin" },
     { name = "mkdocs-minify-plugin" },
     { name = "mkdocstrings-python" },
+    { name = "pytest" },
+    { name = "pytest-mock" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -291,6 +303,9 @@ dev = [
     { name = "mkdocs-include-markdown-plugin", specifier = ">=7.1.2" },
     { name = "mkdocs-minify-plugin", specifier = ">=0.8.0" },
     { name = "mkdocstrings-python", specifier = ">=1.13.0" },
+    { name = "pytest", specifier = ">=8.3.4" },
+    { name = "pytest-mock", specifier = ">=3.14.0" },
+    { name = "ruff", specifier = ">=0.9.3" },
 ]
 
 [[package]]
@@ -380,6 +395,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cf/8c/f834fbf984f691b4f7ff60f50b514cc3de5cc08abfc3295564dd89c5e2e7/importlib_resources-6.5.2.tar.gz", hash = "sha256:185f87adef5bcc288449d98fb4fba07cea78bc036455dd44c5fc4a2fe78fed2c", size = 44693 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/ed/1f1afb2e9e7f38a545d628f864d562a5ae64fe6f7a10e28ffb9b185b4e89/importlib_resources-6.5.2-py3-none-any.whl", hash = "sha256:789cfdc3ed28c78b67a06acb8126751ced69a3d5f79c095a98298cd8a760ccec", size = 37461 },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
 ]
 
 [[package]]
@@ -660,6 +684,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
+]
+
+[[package]]
 name = "portalocker"
 version = "2.10.1"
 source = { registry = "https://pypi.org/simple" }
@@ -714,6 +747,35 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8b/1a/3544f4f299a47911c2ab3710f534e52fea62a633c96806995da5d25be4b2/pyparsing-3.2.1.tar.gz", hash = "sha256:61980854fd66de3a90028d679a954d5f2623e83144b5afe5ee86f43d762e5f0a", size = 1067694 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/a7/c8a2d361bf89c0d9577c934ebb7421b25dc84bf3a8e3ac0a40aed9acc547/pyparsing-3.2.1-py3-none-any.whl", hash = "sha256:506ff4f4386c4cec0590ec19e6302d3aedb992fdc02c761e90416f158dacf8e1", size = 107716 },
+]
+
+[[package]]
+name = "pytest"
+version = "8.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083 },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/90/a955c3ab35ccd41ad4de556596fa86685bf4fc5ffcc62d22d856cfd4e29a/pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0", size = 32814 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/3b/b26f90f74e2986a82df6e7ac7e319b8ea7ccece1caec9f8ab6104dc70603/pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f", size = 9863 },
 ]
 
 [[package]]
@@ -818,6 +880,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.9.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/17/529e78f49fc6f8076f50d985edd9a2cf011d1dbadb1cdeacc1d12afc1d26/ruff-0.9.4.tar.gz", hash = "sha256:6907ee3529244bb0ed066683e075f09285b38dd5b4039370df6ff06041ca19e7", size = 3599458 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/f8/3fafb7804d82e0699a122101b5bee5f0d6e17c3a806dcbc527bb7d3f5b7a/ruff-0.9.4-py3-none-linux_armv6l.whl", hash = "sha256:64e73d25b954f71ff100bb70f39f1ee09e880728efb4250c632ceed4e4cdf706", size = 11668400 },
+    { url = "https://files.pythonhosted.org/packages/2e/a6/2efa772d335da48a70ab2c6bb41a096c8517ca43c086ea672d51079e3d1f/ruff-0.9.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6ce6743ed64d9afab4fafeaea70d3631b4d4b28b592db21a5c2d1f0ef52934bf", size = 11628395 },
+    { url = "https://files.pythonhosted.org/packages/dc/d7/cd822437561082f1c9d7225cc0d0fbb4bad117ad7ac3c41cd5d7f0fa948c/ruff-0.9.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:54499fb08408e32b57360f6f9de7157a5fec24ad79cb3f42ef2c3f3f728dfe2b", size = 11090052 },
+    { url = "https://files.pythonhosted.org/packages/9e/67/3660d58e893d470abb9a13f679223368ff1684a4ef40f254a0157f51b448/ruff-0.9.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37c892540108314a6f01f105040b5106aeb829fa5fb0561d2dcaf71485021137", size = 11882221 },
+    { url = "https://files.pythonhosted.org/packages/79/d1/757559995c8ba5f14dfec4459ef2dd3fcea82ac43bc4e7c7bf47484180c0/ruff-0.9.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:de9edf2ce4b9ddf43fd93e20ef635a900e25f622f87ed6e3047a664d0e8f810e", size = 11424862 },
+    { url = "https://files.pythonhosted.org/packages/c0/96/7915a7c6877bb734caa6a2af424045baf6419f685632469643dbd8eb2958/ruff-0.9.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:87c90c32357c74f11deb7fbb065126d91771b207bf9bfaaee01277ca59b574ec", size = 12626735 },
+    { url = "https://files.pythonhosted.org/packages/0e/cc/dadb9b35473d7cb17c7ffe4737b4377aeec519a446ee8514123ff4a26091/ruff-0.9.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:56acd6c694da3695a7461cc55775f3a409c3815ac467279dfa126061d84b314b", size = 13255976 },
+    { url = "https://files.pythonhosted.org/packages/5f/c3/ad2dd59d3cabbc12df308cced780f9c14367f0321e7800ca0fe52849da4c/ruff-0.9.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e0c93e7d47ed951b9394cf352d6695b31498e68fd5782d6cbc282425655f687a", size = 12752262 },
+    { url = "https://files.pythonhosted.org/packages/c7/17/5f1971e54bd71604da6788efd84d66d789362b1105e17e5ccc53bba0289b/ruff-0.9.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1d4c8772670aecf037d1bf7a07c39106574d143b26cfe5ed1787d2f31e800214", size = 14401648 },
+    { url = "https://files.pythonhosted.org/packages/30/24/6200b13ea611b83260501b6955b764bb320e23b2b75884c60ee7d3f0b68e/ruff-0.9.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bfc5f1d7afeda8d5d37660eeca6d389b142d7f2b5a1ab659d9214ebd0e025231", size = 12414702 },
+    { url = "https://files.pythonhosted.org/packages/34/cb/f5d50d0c4ecdcc7670e348bd0b11878154bc4617f3fdd1e8ad5297c0d0ba/ruff-0.9.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:faa935fc00ae854d8b638c16a5f1ce881bc3f67446957dd6f2af440a5fc8526b", size = 11859608 },
+    { url = "https://files.pythonhosted.org/packages/d6/f4/9c8499ae8426da48363bbb78d081b817b0f64a9305f9b7f87eab2a8fb2c1/ruff-0.9.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a6c634fc6f5a0ceae1ab3e13c58183978185d131a29c425e4eaa9f40afe1e6d6", size = 11485702 },
+    { url = "https://files.pythonhosted.org/packages/18/59/30490e483e804ccaa8147dd78c52e44ff96e1c30b5a95d69a63163cdb15b/ruff-0.9.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:433dedf6ddfdec7f1ac7575ec1eb9844fa60c4c8c2f8887a070672b8d353d34c", size = 12067782 },
+    { url = "https://files.pythonhosted.org/packages/3d/8c/893fa9551760b2f8eb2a351b603e96f15af167ceaf27e27ad873570bc04c/ruff-0.9.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:d612dbd0f3a919a8cc1d12037168bfa536862066808960e0cc901404b77968f0", size = 12483087 },
+    { url = "https://files.pythonhosted.org/packages/23/15/f6751c07c21ca10e3f4a51ea495ca975ad936d780c347d9808bcedbd7182/ruff-0.9.4-py3-none-win32.whl", hash = "sha256:db1192ddda2200671f9ef61d9597fcef89d934f5d1705e571a93a67fb13a4402", size = 9852302 },
+    { url = "https://files.pythonhosted.org/packages/12/41/2d2d2c6a72e62566f730e49254f602dfed23019c33b5b21ea8f8917315a1/ruff-0.9.4-py3-none-win_amd64.whl", hash = "sha256:05bebf4cdbe3ef75430d26c375773978950bbf4ee3c95ccb5448940dc092408e", size = 10850051 },
+    { url = "https://files.pythonhosted.org/packages/c6/e6/3d6ec3bc3d254e7f005c543a661a41c3e788976d0e52a1ada195bd664344/ruff-0.9.4-py3-none-win_arm64.whl", hash = "sha256:585792f1e81509e38ac5123492f8875fbc36f3ede8185af0a26df348e5154f41", size = 10078251 },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -833,6 +920,35 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/44/cd/a040c4b3119bbe532e5b0732286f805445375489fceaec1f48306068ee3b/smmap-5.0.2.tar.gz", hash = "sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5", size = 22329 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/be/d09147ad1ec7934636ad912901c5fd7667e1c858e19d355237db0d0cd5e4/smmap-5.0.2-py3-none-any.whl", hash = "sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e", size = 24303 },
+]
+
+[[package]]
+name = "tomli"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/87/302344fed471e44a87289cf4967697d07e532f2421fdaf868a303cbae4ff/tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff", size = 17175 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/ca/75707e6efa2b37c77dadb324ae7d9571cb424e61ea73fad7c56c2d14527f/tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249", size = 131077 },
+    { url = "https://files.pythonhosted.org/packages/c7/16/51ae563a8615d472fdbffc43a3f3d46588c264ac4f024f63f01283becfbb/tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6", size = 123429 },
+    { url = "https://files.pythonhosted.org/packages/f1/dd/4f6cd1e7b160041db83c694abc78e100473c15d54620083dbd5aae7b990e/tomli-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a", size = 226067 },
+    { url = "https://files.pythonhosted.org/packages/a9/6b/c54ede5dc70d648cc6361eaf429304b02f2871a345bbdd51e993d6cdf550/tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee", size = 236030 },
+    { url = "https://files.pythonhosted.org/packages/1f/47/999514fa49cfaf7a92c805a86c3c43f4215621855d151b61c602abb38091/tomli-2.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c954d2250168d28797dd4e3ac5cf812a406cd5a92674ee4c8f123c889786aa8e", size = 240898 },
+    { url = "https://files.pythonhosted.org/packages/73/41/0a01279a7ae09ee1573b423318e7934674ce06eb33f50936655071d81a24/tomli-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8dd28b3e155b80f4d54beb40a441d366adcfe740969820caf156c019fb5c7ec4", size = 229894 },
+    { url = "https://files.pythonhosted.org/packages/55/18/5d8bc5b0a0362311ce4d18830a5d28943667599a60d20118074ea1b01bb7/tomli-2.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e59e304978767a54663af13c07b3d1af22ddee3bb2fb0618ca1593e4f593a106", size = 245319 },
+    { url = "https://files.pythonhosted.org/packages/92/a3/7ade0576d17f3cdf5ff44d61390d4b3febb8a9fc2b480c75c47ea048c646/tomli-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8", size = 238273 },
+    { url = "https://files.pythonhosted.org/packages/72/6f/fa64ef058ac1446a1e51110c375339b3ec6be245af9d14c87c4a6412dd32/tomli-2.2.1-cp311-cp311-win32.whl", hash = "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff", size = 98310 },
+    { url = "https://files.pythonhosted.org/packages/6a/1c/4a2dcde4a51b81be3530565e92eda625d94dafb46dbeb15069df4caffc34/tomli-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b", size = 108309 },
+    { url = "https://files.pythonhosted.org/packages/52/e1/f8af4c2fcde17500422858155aeb0d7e93477a0d59a98e56cbfe75070fd0/tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea", size = 132762 },
+    { url = "https://files.pythonhosted.org/packages/03/b8/152c68bb84fc00396b83e7bbddd5ec0bd3dd409db4195e2a9b3e398ad2e3/tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8", size = 123453 },
+    { url = "https://files.pythonhosted.org/packages/c8/d6/fc9267af9166f79ac528ff7e8c55c8181ded34eb4b0e93daa767b8841573/tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192", size = 233486 },
+    { url = "https://files.pythonhosted.org/packages/5c/51/51c3f2884d7bab89af25f678447ea7d297b53b5a3b5730a7cb2ef6069f07/tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222", size = 242349 },
+    { url = "https://files.pythonhosted.org/packages/ab/df/bfa89627d13a5cc22402e441e8a931ef2108403db390ff3345c05253935e/tomli-2.2.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77", size = 252159 },
+    { url = "https://files.pythonhosted.org/packages/9e/6e/fa2b916dced65763a5168c6ccb91066f7639bdc88b48adda990db10c8c0b/tomli-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6", size = 237243 },
+    { url = "https://files.pythonhosted.org/packages/b4/04/885d3b1f650e1153cbb93a6a9782c58a972b94ea4483ae4ac5cedd5e4a09/tomli-2.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd", size = 259645 },
+    { url = "https://files.pythonhosted.org/packages/9c/de/6b432d66e986e501586da298e28ebeefd3edc2c780f3ad73d22566034239/tomli-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e", size = 244584 },
+    { url = "https://files.pythonhosted.org/packages/1c/9a/47c0449b98e6e7d1be6cbac02f93dd79003234ddc4aaab6ba07a9a7482e2/tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98", size = 98875 },
+    { url = "https://files.pythonhosted.org/packages/ef/60/9b9638f081c6f1261e2688bd487625cd1e660d0a85bd469e91d8db969734/tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4", size = 109418 },
+    { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -356,7 +356,7 @@ dev = [
     { name = "mkdocstrings-python", specifier = ">=1.13.0" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
-    { name = "ruff", specifier = ">=0.9.3" },
+    { name = "ruff", specifier = ">=0.9.5" },
 ]
 
 [[package]]
@@ -932,27 +932,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.9.4"
+version = "0.9.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c0/17/529e78f49fc6f8076f50d985edd9a2cf011d1dbadb1cdeacc1d12afc1d26/ruff-0.9.4.tar.gz", hash = "sha256:6907ee3529244bb0ed066683e075f09285b38dd5b4039370df6ff06041ca19e7", size = 3599458 }
+sdist = { url = "https://files.pythonhosted.org/packages/02/74/6c359f6b9ed85b88df6ef31febce18faeb852f6c9855651dfb1184a46845/ruff-0.9.5.tar.gz", hash = "sha256:11aecd7a633932875ab3cb05a484c99970b9d52606ce9ea912b690b02653d56c", size = 3634177 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/f8/3fafb7804d82e0699a122101b5bee5f0d6e17c3a806dcbc527bb7d3f5b7a/ruff-0.9.4-py3-none-linux_armv6l.whl", hash = "sha256:64e73d25b954f71ff100bb70f39f1ee09e880728efb4250c632ceed4e4cdf706", size = 11668400 },
-    { url = "https://files.pythonhosted.org/packages/2e/a6/2efa772d335da48a70ab2c6bb41a096c8517ca43c086ea672d51079e3d1f/ruff-0.9.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6ce6743ed64d9afab4fafeaea70d3631b4d4b28b592db21a5c2d1f0ef52934bf", size = 11628395 },
-    { url = "https://files.pythonhosted.org/packages/dc/d7/cd822437561082f1c9d7225cc0d0fbb4bad117ad7ac3c41cd5d7f0fa948c/ruff-0.9.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:54499fb08408e32b57360f6f9de7157a5fec24ad79cb3f42ef2c3f3f728dfe2b", size = 11090052 },
-    { url = "https://files.pythonhosted.org/packages/9e/67/3660d58e893d470abb9a13f679223368ff1684a4ef40f254a0157f51b448/ruff-0.9.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37c892540108314a6f01f105040b5106aeb829fa5fb0561d2dcaf71485021137", size = 11882221 },
-    { url = "https://files.pythonhosted.org/packages/79/d1/757559995c8ba5f14dfec4459ef2dd3fcea82ac43bc4e7c7bf47484180c0/ruff-0.9.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:de9edf2ce4b9ddf43fd93e20ef635a900e25f622f87ed6e3047a664d0e8f810e", size = 11424862 },
-    { url = "https://files.pythonhosted.org/packages/c0/96/7915a7c6877bb734caa6a2af424045baf6419f685632469643dbd8eb2958/ruff-0.9.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:87c90c32357c74f11deb7fbb065126d91771b207bf9bfaaee01277ca59b574ec", size = 12626735 },
-    { url = "https://files.pythonhosted.org/packages/0e/cc/dadb9b35473d7cb17c7ffe4737b4377aeec519a446ee8514123ff4a26091/ruff-0.9.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:56acd6c694da3695a7461cc55775f3a409c3815ac467279dfa126061d84b314b", size = 13255976 },
-    { url = "https://files.pythonhosted.org/packages/5f/c3/ad2dd59d3cabbc12df308cced780f9c14367f0321e7800ca0fe52849da4c/ruff-0.9.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e0c93e7d47ed951b9394cf352d6695b31498e68fd5782d6cbc282425655f687a", size = 12752262 },
-    { url = "https://files.pythonhosted.org/packages/c7/17/5f1971e54bd71604da6788efd84d66d789362b1105e17e5ccc53bba0289b/ruff-0.9.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1d4c8772670aecf037d1bf7a07c39106574d143b26cfe5ed1787d2f31e800214", size = 14401648 },
-    { url = "https://files.pythonhosted.org/packages/30/24/6200b13ea611b83260501b6955b764bb320e23b2b75884c60ee7d3f0b68e/ruff-0.9.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bfc5f1d7afeda8d5d37660eeca6d389b142d7f2b5a1ab659d9214ebd0e025231", size = 12414702 },
-    { url = "https://files.pythonhosted.org/packages/34/cb/f5d50d0c4ecdcc7670e348bd0b11878154bc4617f3fdd1e8ad5297c0d0ba/ruff-0.9.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:faa935fc00ae854d8b638c16a5f1ce881bc3f67446957dd6f2af440a5fc8526b", size = 11859608 },
-    { url = "https://files.pythonhosted.org/packages/d6/f4/9c8499ae8426da48363bbb78d081b817b0f64a9305f9b7f87eab2a8fb2c1/ruff-0.9.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a6c634fc6f5a0ceae1ab3e13c58183978185d131a29c425e4eaa9f40afe1e6d6", size = 11485702 },
-    { url = "https://files.pythonhosted.org/packages/18/59/30490e483e804ccaa8147dd78c52e44ff96e1c30b5a95d69a63163cdb15b/ruff-0.9.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:433dedf6ddfdec7f1ac7575ec1eb9844fa60c4c8c2f8887a070672b8d353d34c", size = 12067782 },
-    { url = "https://files.pythonhosted.org/packages/3d/8c/893fa9551760b2f8eb2a351b603e96f15af167ceaf27e27ad873570bc04c/ruff-0.9.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:d612dbd0f3a919a8cc1d12037168bfa536862066808960e0cc901404b77968f0", size = 12483087 },
-    { url = "https://files.pythonhosted.org/packages/23/15/f6751c07c21ca10e3f4a51ea495ca975ad936d780c347d9808bcedbd7182/ruff-0.9.4-py3-none-win32.whl", hash = "sha256:db1192ddda2200671f9ef61d9597fcef89d934f5d1705e571a93a67fb13a4402", size = 9852302 },
-    { url = "https://files.pythonhosted.org/packages/12/41/2d2d2c6a72e62566f730e49254f602dfed23019c33b5b21ea8f8917315a1/ruff-0.9.4-py3-none-win_amd64.whl", hash = "sha256:05bebf4cdbe3ef75430d26c375773978950bbf4ee3c95ccb5448940dc092408e", size = 10850051 },
-    { url = "https://files.pythonhosted.org/packages/c6/e6/3d6ec3bc3d254e7f005c543a661a41c3e788976d0e52a1ada195bd664344/ruff-0.9.4-py3-none-win_arm64.whl", hash = "sha256:585792f1e81509e38ac5123492f8875fbc36f3ede8185af0a26df348e5154f41", size = 10078251 },
+    { url = "https://files.pythonhosted.org/packages/17/4b/82b7c9ac874e72b82b19fd7eab57d122e2df44d2478d90825854f9232d02/ruff-0.9.5-py3-none-linux_armv6l.whl", hash = "sha256:d466d2abc05f39018d53f681fa1c0ffe9570e6d73cde1b65d23bb557c846f442", size = 11681264 },
+    { url = "https://files.pythonhosted.org/packages/27/5c/f5ae0a9564e04108c132e1139d60491c0abc621397fe79a50b3dc0bd704b/ruff-0.9.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:38840dbcef63948657fa7605ca363194d2fe8c26ce8f9ae12eee7f098c85ac8a", size = 11657554 },
+    { url = "https://files.pythonhosted.org/packages/2a/83/c6926fa3ccb97cdb3c438bb56a490b395770c750bf59f9bc1fe57ae88264/ruff-0.9.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d56ba06da53536b575fbd2b56517f6f95774ff7be0f62c80b9e67430391eeb36", size = 11088959 },
+    { url = "https://files.pythonhosted.org/packages/af/a7/42d1832b752fe969ffdbfcb1b4cb477cb271bed5835110fb0a16ef31ab81/ruff-0.9.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f7cb2a01da08244c50b20ccfaeb5972e4228c3c3a1989d3ece2bc4b1f996001", size = 11902041 },
+    { url = "https://files.pythonhosted.org/packages/53/cf/1fffa09fb518d646f560ccfba59f91b23c731e461d6a4dedd21a393a1ff1/ruff-0.9.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:96d5c76358419bc63a671caac70c18732d4fd0341646ecd01641ddda5c39ca0b", size = 11421069 },
+    { url = "https://files.pythonhosted.org/packages/09/27/bb8f1b7304e2a9431f631ae7eadc35550fe0cf620a2a6a0fc4aa3d736f94/ruff-0.9.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:deb8304636ed394211f3a6d46c0e7d9535b016f53adaa8340139859b2359a070", size = 12625095 },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/ab00bc9d3df35a5f1b64f5117458160a009f93ae5caf65894ebb63a1842d/ruff-0.9.5-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:df455000bf59e62b3e8c7ba5ed88a4a2bc64896f900f311dc23ff2dc38156440", size = 13257797 },
+    { url = "https://files.pythonhosted.org/packages/88/81/c639a082ae6d8392bc52256058ec60f493c6a4d06d5505bccface3767e61/ruff-0.9.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de92170dfa50c32a2b8206a647949590e752aca8100a0f6b8cefa02ae29dce80", size = 12763793 },
+    { url = "https://files.pythonhosted.org/packages/b3/d0/0a3d8f56d1e49af466dc770eeec5c125977ba9479af92e484b5b0251ce9c/ruff-0.9.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3d28532d73b1f3f627ba88e1456f50748b37f3a345d2be76e4c653bec6c3e393", size = 14386234 },
+    { url = "https://files.pythonhosted.org/packages/04/70/e59c192a3ad476355e7f45fb3a87326f5219cc7c472e6b040c6c6595c8f0/ruff-0.9.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c746d7d1df64f31d90503ece5cc34d7007c06751a7a3bbeee10e5f2463d52d2", size = 12437505 },
+    { url = "https://files.pythonhosted.org/packages/55/4e/3abba60a259d79c391713e7a6ccabf7e2c96e5e0a19100bc4204f1a43a51/ruff-0.9.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:11417521d6f2d121fda376f0d2169fb529976c544d653d1d6044f4c5562516ee", size = 11884799 },
+    { url = "https://files.pythonhosted.org/packages/a3/db/b0183a01a9f25b4efcae919c18fb41d32f985676c917008620ad692b9d5f/ruff-0.9.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:5b9d71c3879eb32de700f2f6fac3d46566f644a91d3130119a6378f9312a38e1", size = 11527411 },
+    { url = "https://files.pythonhosted.org/packages/0a/e4/3ebfcebca3dff1559a74c6becff76e0b64689cea02b7aab15b8b32ea245d/ruff-0.9.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2e36c61145e70febcb78483903c43444c6b9d40f6d2f800b5552fec6e4a7bb9a", size = 12078868 },
+    { url = "https://files.pythonhosted.org/packages/ec/b2/5ab808833e06c0a1b0d046a51c06ec5687b73c78b116e8d77687dc0cd515/ruff-0.9.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2f71d09aeba026c922aa7aa19a08d7bd27c867aedb2f74285a2639644c1c12f5", size = 12524374 },
+    { url = "https://files.pythonhosted.org/packages/e0/51/1432afcc3b7aa6586c480142caae5323d59750925c3559688f2a9867343f/ruff-0.9.5-py3-none-win32.whl", hash = "sha256:134f958d52aa6fdec3b294b8ebe2320a950d10c041473c4316d2e7d7c2544723", size = 9853682 },
+    { url = "https://files.pythonhosted.org/packages/b7/ad/c7a900591bd152bb47fc4882a27654ea55c7973e6d5d6396298ad3fd6638/ruff-0.9.5-py3-none-win_amd64.whl", hash = "sha256:78cc6067f6d80b6745b67498fb84e87d32c6fc34992b52bffefbdae3442967d6", size = 10865744 },
+    { url = "https://files.pythonhosted.org/packages/75/d9/fde7610abd53c0c76b6af72fc679cb377b27c617ba704e25da834e0a0608/ruff-0.9.5-py3-none-win_arm64.whl", hash = "sha256:18a29f1a005bddb229e580795627d297dfa99f16b30c7039e73278cf6b5f9fa9", size = 10064595 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -202,6 +202,55 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.6.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/ba/ac14d281f80aab516275012e8875991bb06203957aa1e19950139238d658/coverage-7.6.10.tar.gz", hash = "sha256:7fb105327c8f8f0682e29843e2ff96af9dcbe5bab8eeb4b398c6a33a16d80a23", size = 803868 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/12/2a2a923edf4ddabdffed7ad6da50d96a5c126dae7b80a33df7310e329a1e/coverage-7.6.10-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5c912978f7fbf47ef99cec50c4401340436d200d41d714c7a4766f377c5b7b78", size = 207982 },
+    { url = "https://files.pythonhosted.org/packages/ca/49/6985dbca9c7be3f3cb62a2e6e492a0c88b65bf40579e16c71ae9c33c6b23/coverage-7.6.10-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a01ec4af7dfeb96ff0078ad9a48810bb0cc8abcb0115180c6013a6b26237626c", size = 208414 },
+    { url = "https://files.pythonhosted.org/packages/35/93/287e8f1d1ed2646f4e0b2605d14616c9a8a2697d0d1b453815eb5c6cebdb/coverage-7.6.10-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3b204c11e2b2d883946fe1d97f89403aa1811df28ce0447439178cc7463448a", size = 236860 },
+    { url = "https://files.pythonhosted.org/packages/de/e1/cfdb5627a03567a10031acc629b75d45a4ca1616e54f7133ca1fa366050a/coverage-7.6.10-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:32ee6d8491fcfc82652a37109f69dee9a830e9379166cb73c16d8dc5c2915165", size = 234758 },
+    { url = "https://files.pythonhosted.org/packages/6d/85/fc0de2bcda3f97c2ee9fe8568f7d48f7279e91068958e5b2cc19e0e5f600/coverage-7.6.10-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:675cefc4c06e3b4c876b85bfb7c59c5e2218167bbd4da5075cbe3b5790a28988", size = 235920 },
+    { url = "https://files.pythonhosted.org/packages/79/73/ef4ea0105531506a6f4cf4ba571a214b14a884630b567ed65b3d9c1975e1/coverage-7.6.10-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f4f620668dbc6f5e909a0946a877310fb3d57aea8198bde792aae369ee1c23b5", size = 234986 },
+    { url = "https://files.pythonhosted.org/packages/c6/4d/75afcfe4432e2ad0405c6f27adeb109ff8976c5e636af8604f94f29fa3fc/coverage-7.6.10-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:4eea95ef275de7abaef630c9b2c002ffbc01918b726a39f5a4353916ec72d2f3", size = 233446 },
+    { url = "https://files.pythonhosted.org/packages/86/5b/efee56a89c16171288cafff022e8af44f8f94075c2d8da563c3935212871/coverage-7.6.10-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e2f0280519e42b0a17550072861e0bc8a80a0870de260f9796157d3fca2733c5", size = 234566 },
+    { url = "https://files.pythonhosted.org/packages/f2/db/67770cceb4a64d3198bf2aa49946f411b85ec6b0a9b489e61c8467a4253b/coverage-7.6.10-cp310-cp310-win32.whl", hash = "sha256:bc67deb76bc3717f22e765ab3e07ee9c7a5e26b9019ca19a3b063d9f4b874244", size = 210675 },
+    { url = "https://files.pythonhosted.org/packages/8d/27/e8bfc43f5345ec2c27bc8a1fa77cdc5ce9dcf954445e11f14bb70b889d14/coverage-7.6.10-cp310-cp310-win_amd64.whl", hash = "sha256:0f460286cb94036455e703c66988851d970fdfd8acc2a1122ab7f4f904e4029e", size = 211518 },
+    { url = "https://files.pythonhosted.org/packages/85/d2/5e175fcf6766cf7501a8541d81778fd2f52f4870100e791f5327fd23270b/coverage-7.6.10-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ea3c8f04b3e4af80e17bab607c386a830ffc2fb88a5484e1df756478cf70d1d3", size = 208088 },
+    { url = "https://files.pythonhosted.org/packages/4b/6f/06db4dc8fca33c13b673986e20e466fd936235a6ec1f0045c3853ac1b593/coverage-7.6.10-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:507a20fc863cae1d5720797761b42d2d87a04b3e5aeb682ef3b7332e90598f43", size = 208536 },
+    { url = "https://files.pythonhosted.org/packages/0d/62/c6a0cf80318c1c1af376d52df444da3608eafc913b82c84a4600d8349472/coverage-7.6.10-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d37a84878285b903c0fe21ac8794c6dab58150e9359f1aaebbeddd6412d53132", size = 240474 },
+    { url = "https://files.pythonhosted.org/packages/a3/59/750adafc2e57786d2e8739a46b680d4fb0fbc2d57fbcb161290a9f1ecf23/coverage-7.6.10-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a534738b47b0de1995f85f582d983d94031dffb48ab86c95bdf88dc62212142f", size = 237880 },
+    { url = "https://files.pythonhosted.org/packages/2c/f8/ef009b3b98e9f7033c19deb40d629354aab1d8b2d7f9cfec284dbedf5096/coverage-7.6.10-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0d7a2bf79378d8fb8afaa994f91bfd8215134f8631d27eba3e0e2c13546ce994", size = 239750 },
+    { url = "https://files.pythonhosted.org/packages/a6/e2/6622f3b70f5f5b59f705e680dae6db64421af05a5d1e389afd24dae62e5b/coverage-7.6.10-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6713ba4b4ebc330f3def51df1d5d38fad60b66720948112f114968feb52d3f99", size = 238642 },
+    { url = "https://files.pythonhosted.org/packages/2d/10/57ac3f191a3c95c67844099514ff44e6e19b2915cd1c22269fb27f9b17b6/coverage-7.6.10-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:ab32947f481f7e8c763fa2c92fd9f44eeb143e7610c4ca9ecd6a36adab4081bd", size = 237266 },
+    { url = "https://files.pythonhosted.org/packages/ee/2d/7016f4ad9d553cabcb7333ed78ff9d27248ec4eba8dd21fa488254dff894/coverage-7.6.10-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:7bbd8c8f1b115b892e34ba66a097b915d3871db7ce0e6b9901f462ff3a975377", size = 238045 },
+    { url = "https://files.pythonhosted.org/packages/a7/fe/45af5c82389a71e0cae4546413266d2195c3744849669b0bab4b5f2c75da/coverage-7.6.10-cp311-cp311-win32.whl", hash = "sha256:299e91b274c5c9cdb64cbdf1b3e4a8fe538a7a86acdd08fae52301b28ba297f8", size = 210647 },
+    { url = "https://files.pythonhosted.org/packages/db/11/3f8e803a43b79bc534c6a506674da9d614e990e37118b4506faf70d46ed6/coverage-7.6.10-cp311-cp311-win_amd64.whl", hash = "sha256:489a01f94aa581dbd961f306e37d75d4ba16104bbfa2b0edb21d29b73be83609", size = 211508 },
+    { url = "https://files.pythonhosted.org/packages/86/77/19d09ea06f92fdf0487499283b1b7af06bc422ea94534c8fe3a4cd023641/coverage-7.6.10-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:27c6e64726b307782fa5cbe531e7647aee385a29b2107cd87ba7c0105a5d3853", size = 208281 },
+    { url = "https://files.pythonhosted.org/packages/b6/67/5479b9f2f99fcfb49c0d5cf61912a5255ef80b6e80a3cddba39c38146cf4/coverage-7.6.10-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c56e097019e72c373bae32d946ecf9858fda841e48d82df7e81c63ac25554078", size = 208514 },
+    { url = "https://files.pythonhosted.org/packages/15/d1/febf59030ce1c83b7331c3546d7317e5120c5966471727aa7ac157729c4b/coverage-7.6.10-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c7827a5bc7bdb197b9e066cdf650b2887597ad124dd99777332776f7b7c7d0d0", size = 241537 },
+    { url = "https://files.pythonhosted.org/packages/4b/7e/5ac4c90192130e7cf8b63153fe620c8bfd9068f89a6d9b5f26f1550f7a26/coverage-7.6.10-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:204a8238afe787323a8b47d8be4df89772d5c1e4651b9ffa808552bdf20e1d50", size = 238572 },
+    { url = "https://files.pythonhosted.org/packages/dc/03/0334a79b26ecf59958f2fe9dd1f5ab3e2f88db876f5071933de39af09647/coverage-7.6.10-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e67926f51821b8e9deb6426ff3164870976fe414d033ad90ea75e7ed0c2e5022", size = 240639 },
+    { url = "https://files.pythonhosted.org/packages/d7/45/8a707f23c202208d7b286d78ad6233f50dcf929319b664b6cc18a03c1aae/coverage-7.6.10-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e78b270eadb5702938c3dbe9367f878249b5ef9a2fcc5360ac7bff694310d17b", size = 240072 },
+    { url = "https://files.pythonhosted.org/packages/66/02/603ce0ac2d02bc7b393279ef618940b4a0535b0868ee791140bda9ecfa40/coverage-7.6.10-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:714f942b9c15c3a7a5fe6876ce30af831c2ad4ce902410b7466b662358c852c0", size = 238386 },
+    { url = "https://files.pythonhosted.org/packages/04/62/4e6887e9be060f5d18f1dd58c2838b2d9646faf353232dec4e2d4b1c8644/coverage-7.6.10-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:abb02e2f5a3187b2ac4cd46b8ced85a0858230b577ccb2c62c81482ca7d18852", size = 240054 },
+    { url = "https://files.pythonhosted.org/packages/5c/74/83ae4151c170d8bd071924f212add22a0e62a7fe2b149edf016aeecad17c/coverage-7.6.10-cp312-cp312-win32.whl", hash = "sha256:55b201b97286cf61f5e76063f9e2a1d8d2972fc2fcfd2c1272530172fd28c359", size = 210904 },
+    { url = "https://files.pythonhosted.org/packages/c3/54/de0893186a221478f5880283119fc40483bc460b27c4c71d1b8bba3474b9/coverage-7.6.10-cp312-cp312-win_amd64.whl", hash = "sha256:e4ae5ac5e0d1e4edfc9b4b57b4cbecd5bc266a6915c500f358817a8496739247", size = 211692 },
+    { url = "https://files.pythonhosted.org/packages/40/41/473617aadf9a1c15bc2d56be65d90d7c29bfa50a957a67ef96462f7ebf8e/coverage-7.6.10-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:656c82b8a0ead8bba147de9a89bda95064874c91a3ed43a00e687f23cc19d53a", size = 207978 },
+    { url = "https://files.pythonhosted.org/packages/10/f6/480586607768b39a30e6910a3c4522139094ac0f1677028e1f4823688957/coverage-7.6.10-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ccc2b70a7ed475c68ceb548bf69cec1e27305c1c2606a5eb7c3afff56a1b3b27", size = 208415 },
+    { url = "https://files.pythonhosted.org/packages/f1/af/439bb760f817deff6f4d38fe7da08d9dd7874a560241f1945bc3b4446550/coverage-7.6.10-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5e37dc41d57ceba70956fa2fc5b63c26dba863c946ace9705f8eca99daecdc4", size = 236452 },
+    { url = "https://files.pythonhosted.org/packages/d0/13/481f4ceffcabe29ee2332e60efb52e4694f54a402f3ada2bcec10bb32e43/coverage-7.6.10-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0aa9692b4fdd83a4647eeb7db46410ea1322b5ed94cd1715ef09d1d5922ba87f", size = 234374 },
+    { url = "https://files.pythonhosted.org/packages/c5/59/4607ea9d6b1b73e905c7656da08d0b00cdf6e59f2293ec259e8914160025/coverage-7.6.10-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aa744da1820678b475e4ba3dfd994c321c5b13381d1041fe9c608620e6676e25", size = 235505 },
+    { url = "https://files.pythonhosted.org/packages/85/60/d66365723b9b7f29464b11d024248ed3523ce5aab958e4ad8c43f3f4148b/coverage-7.6.10-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:c0b1818063dc9e9d838c09e3a473c1422f517889436dd980f5d721899e66f315", size = 234616 },
+    { url = "https://files.pythonhosted.org/packages/74/f8/2cf7a38e7d81b266f47dfcf137fecd8fa66c7bdbd4228d611628d8ca3437/coverage-7.6.10-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:59af35558ba08b758aec4d56182b222976330ef8d2feacbb93964f576a7e7a90", size = 233099 },
+    { url = "https://files.pythonhosted.org/packages/50/2b/bff6c1c6b63c4396ea7ecdbf8db1788b46046c681b8fcc6ec77db9f4ea49/coverage-7.6.10-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:7ed2f37cfce1ce101e6dffdfd1c99e729dd2ffc291d02d3e2d0af8b53d13840d", size = 234089 },
+    { url = "https://files.pythonhosted.org/packages/bf/b5/baace1c754d546a67779358341aa8d2f7118baf58cac235db457e1001d1b/coverage-7.6.10-cp39-cp39-win32.whl", hash = "sha256:4bcc276261505d82f0ad426870c3b12cb177752834a633e737ec5ee79bbdff18", size = 210701 },
+    { url = "https://files.pythonhosted.org/packages/b1/bf/9e1e95b8b20817398ecc5a1e8d3e05ff404e1b9fb2185cd71561698fe2a2/coverage-7.6.10-cp39-cp39-win_amd64.whl", hash = "sha256:457574f4599d2b00f7f637a0700a6422243b3565509457b2dbd3f50703e11f59", size = 211482 },
+    { url = "https://files.pythonhosted.org/packages/a1/70/de81bfec9ed38a64fc44a77c7665e20ca507fc3265597c28b0d989e4082e/coverage-7.6.10-pp39.pp310-none-any.whl", hash = "sha256:fd34e7b3405f0cc7ab03d54a334c17a9e802897580d964bd8c2001f4b9fd488f", size = 200223 },
+]
+
+[[package]]
 name = "cryptography"
 version = "44.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -276,6 +325,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "coverage" },
     { name = "gitpython" },
     { name = "mike" },
     { name = "mkdocs-include-markdown-plugin" },
@@ -298,6 +348,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "coverage", specifier = ">=7.6.10" },
     { name = "gitpython", specifier = ">=3.1.44" },
     { name = "mike", specifier = ">=2.1.3" },
     { name = "mkdocs-include-markdown-plugin", specifier = ">=7.1.2" },


### PR DESCRIPTION
This pull request introduces several changes to improve the testing setup, dependency management, and robustness of the `FabricEndpoint` class. The most important changes include enabling and configuring `pytest`, adding new dependencies, and refactoring the `FabricEndpoint` class to handle token refresh and logging more effectively.

Testing and dependencies:

* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L56-R61): Enabled `pytest` for testing and configured it to look for tests in the `tests` directory.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R28-R31): Added `pytest`, `pytest-mock`, `ruff`, and `coverage` to the development dependencies and configured `pytest` options. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R28-R31) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R46-R51)
* [`requirements-dev.txt`](diffhunk://#diff-2b4945591edfeaa4cf4d3f155e66d4b43d1bda7a55d881d5cf3107f1b05abbbcR3-R5): Added `pytest`, `pytest-mock`, and `coverage` to the development requirements.
* [`ruff.toml`](diffhunk://#diff-26f436cb29eecc7bb4f9066747b43df8da81ac808955ce95c109f5d7aa778989L33-R33): Updated the ignore list to include the `tests` directory.

Refactoring and enhancements:

* [`src/fabric_cicd/_common/_fabric_endpoint.py`](diffhunk://#diff-df48b77e163b4a13c97f80408ad6640fca48ffdc60c19e085b4c73589933178cL23-R28): Refactored the `FabricEndpoint` class to inject the `requests` module, handle token refresh more robustly, and improve logging and error handling in the `invoke` method. [[1]](diffhunk://#diff-df48b77e163b4a13c97f80408ad6640fca48ffdc60c19e085b4c73589933178cL23-R28) [[2]](diffhunk://#diff-df48b77e163b4a13c97f80408ad6640fca48ffdc60c19e085b4c73589933178cR44-L59) [[3]](diffhunk://#diff-df48b77e163b4a13c97f80408ad6640fca48ffdc60c19e085b4c73589933178cL116-R210) [[4]](diffhunk://#diff-df48b77e163b4a13c97f80408ad6640fca48ffdc60c19e085b4c73589933178cL175-R259)