### PR TITLE
Fixes #92 - Broken README Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Section Overview:
 
 -   [Home](https://microsoft.github.io/fabric-cicd/latest/)
 -   How To:
-    -   Example(https://microsoft.github.io/fabric-cicd/latest/how_to/example/)
-    -   Getting Started(https://microsoft.github.io/fabric-cicd/latest/how_to/getting_started/)
-    -   Parameterization(https://microsoft.github.io/fabric-cicd/latest/how_to/parameterization/)
+    -   [Example](https://microsoft.github.io/fabric-cicd/latest/how_to/example/)
+    -   [Getting Started](https://microsoft.github.io/fabric-cicd/latest/how_to/getting_started/)
+    -   [Parameterization](https://microsoft.github.io/fabric-cicd/latest/how_to/parameterization/)
 -   [Contribution](https://microsoft.github.io/fabric-cicd/latest/contribution/)
 -   [Changelog](https://microsoft.github.io/fabric-cicd/latest/changelog/)
 -   [About](https://microsoft.github.io/fabric-cicd/latest/help/) - Inclusive of Support & Security Policies

--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@ All documentation is hosted on our [fabric-cicd](https://microsoft.github.io/fab
 Section Overview:
 
 -   [Home](https://microsoft.github.io/fabric-cicd/latest/)
--   [How To](https://microsoft.github.io/fabric-cicd/latest/how_to/)
+-   How To:
+    -   Example(https://microsoft.github.io/fabric-cicd/latest/how_to/example/)
+    -   Getting Started(https://microsoft.github.io/fabric-cicd/latest/how_to/getting_started/)
+    -   Parameterization(https://microsoft.github.io/fabric-cicd/latest/how_to/parameterization/)
 -   [Contribution](https://microsoft.github.io/fabric-cicd/latest/contribution/)
 -   [Changelog](https://microsoft.github.io/fabric-cicd/latest/changelog/)
 -   [About](https://microsoft.github.io/fabric-cicd/latest/help/) - Inclusive of Support & Security Policies


### PR DESCRIPTION
The existing How To link gave a 404 - fixed it to linke to the three sub-pages. If that's not how you want the links to be, well at least now you know the link is broken :)