### PR TITLE
Fixes #103 - Environment Failure without Public Library

### DIFF
--- a/src/fabric_cicd/_items/_environment.py
+++ b/src/fabric_cicd/_items/_environment.py
@@ -176,7 +176,11 @@ def _remove_libraries(fabric_workspace_obj, item_guid, repo_library_files):
     )
 
     if response_environment["body"].get("errorCode", "") != "EnvironmentLibrariesNotFound":
-        if "environmentYml" in response_environment["body"] and "environment.yml" not in repo_library_files:
+        if (
+            "environmentYml" in response_environment["body"]
+            and response_environment["body"]["environmentYml"]  # not none or ''
+            and "environment.yml" not in repo_library_files
+        ):
             _remove_library(fabric_workspace_obj, item_guid, "environment.yml")
 
         custom_libraries = response_environment["body"].get("customLibraries", None)


### PR DESCRIPTION
This pull request includes a change to the `_remove_libraries` function in the `src/fabric_cicd/_items/_environment.py` file to improve the handling of the `environmentYml` key in the response body.

Improvements to `_remove_libraries` function:

* [`src/fabric_cicd/_items/_environment.py`](diffhunk://#diff-d21d8d1ab1b91c6581949c76a61d12d3f838509ef127b4ae5144feb5bc23bd8aL179-R183): Modified the condition to check if `response_environment["body"]["environmentYml"]` is not None or an empty string before calling `_remove_library` for `environment.yml`.