### PR TITLE
Resolves #28 - Leverage UpdateDefinition Flag

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+sample/workspace/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+    "printWidth": 100,
+    "tabWidth": 4,
+    "useTabs": false,
+    "semi": true,
+    "trailingComma": "all"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,8 @@
 {
     "editor": {
-        "tabSize": 4,
-        "trimAutoWhitespace": false
+        "trimAutoWhitespace": false,
+        "defaultFormatter": "esbenp.prettier-vscode",
+        "formatOnSave": true
     },
     "diffEditor": {
         "ignoreTrimWhitespace": false
@@ -27,18 +28,6 @@
         "editor.defaultFormatter": "tamasfe.even-better-toml",
         "editor.formatOnSave": true
     },
-    "[json]": {
-        "editor.defaultFormatter": "esbenp.prettier-vscode",
-        "editor.formatOnSave": true
-    },
-    "[markdown]": {
-        "editor.defaultFormatter": "esbenp.prettier-vscode",
-        "editor.formatOnSave": true
-    },
-    "[yaml]": {
-        "editor.defaultFormatter": "esbenp.prettier-vscode",
-        "editor.formatOnSave": true
-    },
     "git": {
         "branchPrefix": "users/",
         "enableSmartCommit": true,
@@ -49,14 +38,8 @@
         "organizeImports": true,
         "fixAll": true
     },
-    "prettier": {
-        "tabWidth": 4,
-        "useTabs": false
-    },
     "python.terminal.activateEnvironment": false,
-    "python.testing.pytestArgs": [
-        "tests"
-    ],
+    "python.testing.pytestArgs": ["tests"],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true
 }

--- a/src/fabric_cicd/_items/_report.py
+++ b/src/fabric_cicd/_items/_report.py
@@ -15,5 +15,5 @@ def publish_reports(fabric_workspace_obj):
     item_type = "Report"
 
     for item_name in fabric_workspace_obj.repository_items.get(item_type, {}):
-        exclude_path = r".*[/\\]\.pbi[/\\]?.*"
+        exclude_path = r".*\.pbi[/\\].*"
         fabric_workspace_obj._publish_item(item_name=item_name, item_type=item_type, exclude_path=exclude_path)

--- a/src/fabric_cicd/_items/_report.py
+++ b/src/fabric_cicd/_items/_report.py
@@ -15,4 +15,5 @@ def publish_reports(fabric_workspace_obj):
     item_type = "Report"
 
     for item_name in fabric_workspace_obj.repository_items.get(item_type, {}):
-        fabric_workspace_obj._publish_item(item_name=item_name, item_type=item_type, excluded_directories={".pbi"})
+        exclude_path = r".*[/\\]\.pbi[/\\]?.*"
+        fabric_workspace_obj._publish_item(item_name=item_name, item_type=item_type, exclude_path=exclude_path)

--- a/src/fabric_cicd/_items/_semanticmodel.py
+++ b/src/fabric_cicd/_items/_semanticmodel.py
@@ -15,5 +15,5 @@ def publish_semanticmodels(fabric_workspace_obj):
     item_type = "SemanticModel"
 
     for item_name in fabric_workspace_obj.repository_items.get(item_type, {}):
-        exclude_path = r".*[/\\]\.pbi[/\\]?.*"
+        exclude_path = r".*\.pbi[/\\].*"
         fabric_workspace_obj._publish_item(item_name=item_name, item_type=item_type, exclude_path=exclude_path)

--- a/src/fabric_cicd/_items/_semanticmodel.py
+++ b/src/fabric_cicd/_items/_semanticmodel.py
@@ -15,4 +15,5 @@ def publish_semanticmodels(fabric_workspace_obj):
     item_type = "SemanticModel"
 
     for item_name in fabric_workspace_obj.repository_items.get(item_type, {}):
-        fabric_workspace_obj._publish_item(item_name=item_name, item_type=item_type, excluded_directories={".pbi"})
+        exclude_path = r".*[/\\]\.pbi[/\\]?.*"
+        fabric_workspace_obj._publish_item(item_name=item_name, item_type=item_type, exclude_path=exclude_path)


### PR DESCRIPTION
This pull request includes updates to the formatting configuration and improvements to the `fabric_cicd` module. The most important changes include adding Prettier configuration files, updating VSCode settings for formatting, and refactoring the `_publish_item` method to use a regex for excluding paths.

### Formatting Configuration:

* [`.prettierignore`](diffhunk://#diff-b640b344ee7f3f03d2a443795a5d0708ef50e2e6e34214109ab2aad13ad6ba98R1): Added `sample/workspace/` to ignore list.
* [`.prettierrc`](diffhunk://#diff-663ade211b3a1552162de21c4031fcd16be99407aae5ceecbb491a2efc43d5d2R1-R7): Added Prettier configuration with specific formatting rules.
* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L3-R5): Updated VSCode settings to use Prettier as the default formatter and enable format on save. Removed redundant formatter settings for JSON, Markdown, and YAML. [[1]](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L3-R5) [[2]](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L30-L41) [[3]](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L52-R42)

### `fabric_cicd` Module Improvements:

* `src/fabric_cicd/_items/_report.py` and `src/fabric_cicd/_items/_semanticmodel.py`: Updated `publish_reports` and `publish_semanticmodels` functions to use `exclude_path` regex instead of `excluded_directories`. [[1]](diffhunk://#diff-2425d325e32b5437c7d3128f26fd3fdd053139c38844675e5e42b380a6a69f41L18-R19) [[2]](diffhunk://#diff-ee81cdea1efaa1e8aabad00796ac4cd50f7fd4bb92d4a8ee87d6cfa7b8bff18bL18-R19)
* [`src/fabric_cicd/fabric_workspace.py`](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L326-R350): Refactored `_publish_item` method to use `exclude_path` regex for excluding paths and removed unnecessary metadata updates. [[1]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L326-R350) [[2]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L390-L406) [[3]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L487-R470)