### PR TITLE
Resolves #110 Need more examples for Find_replace docs page

### DIFF
--- a/docs/how_to/parameterization.md
+++ b/docs/how_to/parameterization.md
@@ -43,11 +43,11 @@ Note: In this example, the lakehouse workspace id in the notebook file is also r
 ```yaml
 find_replace:
     "123e4567-e89b-12d3-a456-426614174000": # lakehouse guid to be replaced
-        PPE: f47ac10b-58cc-4372-a567-0e02b2c3d479 # PPE lakehouse guid
-        PROD: 9b2e5f4c-8d3a-4f1b-9c3e-2d5b6e4a7f8c # PROD lakehouse guid
+        PPE: "f47ac10b-58cc-4372-a567-0e02b2c3d479" # PPE lakehouse guid
+        PROD: "9b2e5f4c-8d3a-4f1b-9c3e-2d5b6e4a7f8c" # PROD lakehouse guid
     "8f5c0cec-a8ea-48cd-9da4-871dc2642f4c": # workspace id to be replaced
-        PPE: d4e5f6a7-b8c9-4d1e-9f2a-3b4c5d6e7f8a # PPE workspace id
-        PROD: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d # PROD workspace id
+        PPE: "d4e5f6a7-b8c9-4d1e-9f2a-3b4c5d6e7f8a" # PPE workspace id
+        PROD: "a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d" # PROD workspace id
 ```
 
 ### notebook-content.py

--- a/docs/how_to/parameterization.md
+++ b/docs/how_to/parameterization.md
@@ -6,7 +6,7 @@ Raise a [feature request](https://github.com/microsoft/fabric-cicd/issues/new?te
 
 ## find_replace
 
-For generic find-and-replace operations. This will replace every instance of a specified string in every file. Specify the `find` value as the key and the `replace` value for each environment. See the [Example](example.md) page for a complete yaml file.
+For generic find-and-replace operations. This will replace every instance of a specified string in every file. Specify the `find` value as the key and the `replace` value for each environment. See example at the end for a complete yaml file.
 
 Note: A common use case for this function is to replace connection strings. I.e. find and replace a connection guid referenced in data pipeline.
 
@@ -28,4 +28,11 @@ spark_pool:
     <instance-pool-id>:
         type: <Capacity-or-Workspace>
         name: <pool-name>
+```
+
+## Parameter.yml File
+
+<!--prettier-ignore-->
+```yml
+{% include "../../sample/workspace/parameter.yml" %}
 ```

--- a/docs/how_to/parameterization.md
+++ b/docs/how_to/parameterization.md
@@ -30,11 +30,11 @@ spark_pool:
         name: <pool-name>
 ```
 
-## find_replace Example
+## Example Use Case
 
-`Hello World` notebook is attached to the `Hello_World_LH` lakehouse. When deploying `Hello World` from a feature workspace to environment workspaces PPE and PROD, the attached lakehouse needs to be updated to point to the correct lakehouse in the respective environments.
+When deploying the `Example` notebook from a feature workspace to PPE and PROD environments, the attached `Example_LH` lakehouse needs to be updated to point to the correct lakehouse in the respective environments.
 
-In the `notebook-content.py` file, the referenced lakehouse GUID `123e4567-e89b-12d3-a456-426614174000` needs to be replaced with the GUID of the `Hello_World_LH` lakehouse found in the PPE/PROD workspace. This replacement is handled by finding all instances of the GUID supplied by `Parameters.yml` in all files in the repository directory and replacing it with the GUID associated with the deployed environment.
+In the `notebook-content.py` file, the referenced lakehouse GUID `123e4567-e89b-12d3-a456-426614174000` must be replaced with the corresponding GUID for the `Example_LH` lakehouse in the target environment. This replacement is managed by the library, which finds all instances of the GUID specified in `Parameters.yml` within the repository files and replaces it with the GUID for the deployed environment.
 
 Note: In this example, a `find_replace` operation would also be required to update the lakehouse workspace ID found in the notebook file.
 
@@ -64,7 +64,7 @@ find_replace:
 # META   "dependencies": {
 # META     "lakehouse": {
 # META       "default_lakehouse": "123e4567-e89b-12d3-a456-426614174000",
-# META       "default_lakehouse_name": "Hello_World_LH",
+# META       "default_lakehouse_name": "Example_LH",
 # META       "default_lakehouse_workspace_id": "8f5c0cec-a8ea-48cd-9da4-871dc2642f4c"
 # META     },
 # META     "environment": {
@@ -76,7 +76,19 @@ find_replace:
 
 # CELL ********************
 
-print("Hello World")
+print("Example notebook")
+
+# METADATA ********************
+
+# META {
+# META   "language": "python",
+# META   "language_group": "synapse_pyspark"
+# META }
+
+# CELL ********************
+
+df = spark.sql("SELECT * FROM Example_LH.Table1 LIMIT 1000")
+display(df)
 
 # METADATA ********************
 

--- a/docs/how_to/parameterization.md
+++ b/docs/how_to/parameterization.md
@@ -32,7 +32,7 @@ spark_pool:
 
 ## Example Use Case
 
-When deploying the `Example` notebook from a feature workspace to PPE or PROD environments, the attached `Example_LH` lakehouse needs to be updated to point to the correct lakehouse in the respective environments.
+When deploying the `Example` notebook from a feature workspace to PPE or PROD environments, the attached `Example_LH` lakehouse id needs to be updated. This update ensures the notebook points to the correct lakehouse in the respective environments.
 
 In the `notebook-content.py` file, the referenced lakehouse guid `123e4567-e89b-12d3-a456-426614174000` must be replaced with the corresponding guid for `Example_LH` lakehouse in the target environment. This replacement is managed by the library, which takes the `find_replace` input in `Parameter.yml` and finds every instance of the guid string within the repository files and replaces it with the guid string for the deployed environment.
 

--- a/docs/how_to/parameterization.md
+++ b/docs/how_to/parameterization.md
@@ -42,10 +42,10 @@ Note: In this example, the lakehouse workspace id in the notebook file is also r
 
 ```yaml
 find_replace:
-    123e4567-e89b-12d3-a456-426614174000: # lakehouse guid to be replaced
+    "123e4567-e89b-12d3-a456-426614174000": # lakehouse guid to be replaced
         PPE: f47ac10b-58cc-4372-a567-0e02b2c3d479 # PPE lakehouse guid
         PROD: 9b2e5f4c-8d3a-4f1b-9c3e-2d5b6e4a7f8c # PROD lakehouse guid
-    8f5c0cec-a8ea-48cd-9da4-871dc2642f4c: # workspace id to be replaced
+    "8f5c0cec-a8ea-48cd-9da4-871dc2642f4c": # workspace id to be replaced
         PPE: d4e5f6a7-b8c9-4d1e-9f2a-3b4c5d6e7f8a # PPE workspace id
         PROD: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d # PROD workspace id
 ```

--- a/docs/how_to/parameterization.md
+++ b/docs/how_to/parameterization.md
@@ -34,9 +34,9 @@ spark_pool:
 
 When deploying the `Example` notebook from a feature workspace to PPE and PROD environments, the attached `Example_LH` lakehouse needs to be updated to point to the correct lakehouse in the respective environments.
 
-In the `notebook-content.py` file, the referenced lakehouse GUID `123e4567-e89b-12d3-a456-426614174000` must be replaced with the corresponding GUID for the `Example_LH` lakehouse in the target environment. This replacement is managed by the library, which finds all instances of the GUID specified in `Parameters.yml` within the repository files and replaces it with the GUID for the deployed environment.
+In the `notebook-content.py` file, the referenced lakehouse GUID `123e4567-e89b-12d3-a456-426614174000` must be replaced with the corresponding GUID for the `Example_LH` lakehouse in the target environment. This replacement is managed by the library, which takes the `find_replace` input in `Parameter.yml` to find all instances of the GUID string within the repository files and replaces it with the GUID for the deployed environment.
 
-Note: In this example, a `find_replace` operation would also be required to update the lakehouse workspace ID found in the notebook file.
+Note: In this example, the lakehouse workspace ID in the notebook file is also replaced using `Parameter.yml`.
 
 ### Parameters.yml
 

--- a/docs/how_to/parameterization.md
+++ b/docs/how_to/parameterization.md
@@ -6,7 +6,7 @@ Raise a [feature request](https://github.com/microsoft/fabric-cicd/issues/new?te
 
 ## find_replace
 
-For generic find-and-replace operations. This will replace every instance of a specified string in every file. Specify the `find` value as the key and the `replace` value for each environment. See the [Example](example.md) page for a complete yaml file.
+For generic find-and-replace operations. This will replace every instance of a specified string in every file. Specify the `find` value as the key and the `replace` value for each environment. See the [Example](example.md) page for a complete yaml file and an example use case below.
 
 Note: A common use case for this function is to replace connection strings. I.e. find and replace a connection guid referenced in data pipeline.
 
@@ -34,20 +34,20 @@ spark_pool:
 
 When deploying the `Example` notebook from a feature workspace to PPE and PROD environments, the attached `Example_LH` lakehouse needs to be updated to point to the correct lakehouse in the respective environments.
 
-In the `notebook-content.py` file, the referenced lakehouse GUID `123e4567-e89b-12d3-a456-426614174000` must be replaced with the corresponding GUID for the `Example_LH` lakehouse in the target environment. This replacement is managed by the library, which takes the `find_replace` input in `Parameter.yml` to find all instances of the GUID string within the repository files and replaces it with the GUID for the deployed environment.
+In the `notebook-content.py` file, the referenced lakehouse guid `123e4567-e89b-12d3-a456-426614174000` must be replaced with the corresponding guid for `Example_LH` lakehouse in the target environment. This replacement is managed by the library, which takes the `find_replace` input in `Parameter.yml` and finds every instance of the guid string within the repository files and replaces it with the guid string for the deployed environment.
 
-Note: In this example, the lakehouse workspace ID in the notebook file is also replaced using `Parameter.yml`.
+Note: In this example, the lakehouse workspace id in the notebook file is also replaced using `Parameter.yml`.
 
 ### Parameters.yml
 
 ```yaml
 find_replace:
-    123e4567-e89b-12d3-a456-426614174000: # lakehouse GUID to be replaced
-        PPE: f47ac10b-58cc-4372-a567-0e02b2c3d479 # PPE lakehouse GUID
-        PROD: 9b2e5f4c-8d3a-4f1b-9c3e-2d5b6e4a7f8c # PROD lakehouse GUID
-    8f5c0cec-a8ea-48cd-9da4-871dc2642f4c: # workspace ID to be replaced
-        PPE: d4e5f6a7-b8c9-4d1e-9f2a-3b4c5d6e7f8a # PPE workspace ID
-        PROD: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d # PROD workspace ID
+    123e4567-e89b-12d3-a456-426614174000: # lakehouse guid to be replaced
+        PPE: f47ac10b-58cc-4372-a567-0e02b2c3d479 # PPE lakehouse guid
+        PROD: 9b2e5f4c-8d3a-4f1b-9c3e-2d5b6e4a7f8c # PROD lakehouse guid
+    8f5c0cec-a8ea-48cd-9da4-871dc2642f4c: # workspace id to be replaced
+        PPE: d4e5f6a7-b8c9-4d1e-9f2a-3b4c5d6e7f8a # PPE workspace id
+        PROD: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d # PROD workspace id
 ```
 
 ### notebook-content.py

--- a/docs/how_to/parameterization.md
+++ b/docs/how_to/parameterization.md
@@ -6,7 +6,7 @@ Raise a [feature request](https://github.com/microsoft/fabric-cicd/issues/new?te
 
 ## find_replace
 
-For generic find-and-replace operations. This will replace every instance of a specified string in every file. Specify the `find` value as the key and the `replace` value for each environment. See example at the end for a complete yaml file.
+For generic find-and-replace operations. This will replace every instance of a specified string in every file. Specify the `find` value as the key and the `replace` value for each environment. Refer to the example for a complete yaml file at the end of this page or see the [Example](example.md) page.
 
 Note: A common use case for this function is to replace connection strings. I.e. find and replace a connection guid referenced in data pipeline.
 
@@ -35,4 +35,53 @@ spark_pool:
 <!--prettier-ignore-->
 ```yml
 {% include "../../sample/workspace/parameter.yml" %}
+```
+
+## find_replace Use Case Example
+
+'Hello World' notebook is attached to 'Hello_World_LH' lakehouse. When deploying 'Hello World' from a feature workspace to environment workspaces PPE and PROD, the attached lakehouse needs to be updated to point to the correct lakehouse in the respective environments. In the .py notebook file, the lakehouse Id references the following GUID 123e4567-e89b-12d3-a456-426614174000 which needs to be replaced with the GUID of the 'Hello_World_LH' lakehouse found in PPE/PROD workspace. Through parameterization, a brute force replacement is handled by finding all instances of the string '123e4567-e89b-12d3-a456-426614174000' in all files and replacing it with the string associated with the deployed environment.
+
+### Parameters.yml
+
+```yaml
+find_replace:
+    123e4567-e89b-12d3-a456-426614174000: # 'Hello_World_LH' GUID to be replaced
+        PPE: f47ac10b-58cc-4372-a567-0e02b2c3d479 # 'Hello_World_LH' GUID in PPE
+        PROD: 9b2e5f4c-8d3a-4f1b-9c3e-2d5b6e4a7f8c # 'Hello_World_LH' GUID in PROD
+```
+
+### notebook-content.py
+
+```python
+# Fabric notebook source
+
+# METADATA ********************
+
+# META {
+# META   "kernel_info": {
+# META     "name": "synapse_pyspark"
+# META   },
+# META   "dependencies": {
+# META     "lakehouse": {
+# META       "default_lakehouse": "123e4567-e89b-12d3-a456-426614174000",
+# META       "default_lakehouse_name": "Hello_World_LH",
+# META       "default_lakehouse_workspace_id": "8f5c0cec-a8ea-48cd-9da4-871dc2642f4c"
+# META     },
+# META     "environment": {
+# META       "environmentId": "a277ea4a-e87f-8537-4ce0-39db11d4aade",
+# META       "workspaceId": "00000000-0000-0000-0000-000000000000"
+# META     }
+# META   }
+# META }
+
+# CELL ********************
+
+print("Hello World")
+
+# METADATA ********************
+
+# META {
+# META   "language": "python",
+# META   "language_group": "synapse_pyspark"
+# META }
 ```

--- a/docs/how_to/parameterization.md
+++ b/docs/how_to/parameterization.md
@@ -32,7 +32,7 @@ spark_pool:
 
 ## Example Use Case
 
-When deploying the `Example` notebook from a feature workspace to PPE and PROD environments, the attached `Example_LH` lakehouse needs to be updated to point to the correct lakehouse in the respective environments.
+When deploying the `Example` notebook from a feature workspace to PPE or PROD environments, the attached `Example_LH` lakehouse needs to be updated to point to the correct lakehouse in the respective environments.
 
 In the `notebook-content.py` file, the referenced lakehouse guid `123e4567-e89b-12d3-a456-426614174000` must be replaced with the corresponding guid for `Example_LH` lakehouse in the target environment. This replacement is managed by the library, which takes the `find_replace` input in `Parameter.yml` and finds every instance of the guid string within the repository files and replaces it with the guid string for the deployed environment.
 

--- a/docs/how_to/parameterization.md
+++ b/docs/how_to/parameterization.md
@@ -6,7 +6,7 @@ Raise a [feature request](https://github.com/microsoft/fabric-cicd/issues/new?te
 
 ## find_replace
 
-For generic find-and-replace operations. This will replace every instance of a specified string in every file. Specify the `find` value as the key and the `replace` value for each environment. Refer to the example for a complete yaml file at the end of this page or see the [Example](example.md) page.
+For generic find-and-replace operations. This will replace every instance of a specified string in every file. Specify the `find` value as the key and the `replace` value for each environment. See the [Example](example.md) page for a complete yaml file.
 
 Note: A common use case for this function is to replace connection strings. I.e. find and replace a connection guid referenced in data pipeline.
 
@@ -30,24 +30,24 @@ spark_pool:
         name: <pool-name>
 ```
 
-## Parameter.yml File
+## find_replace Example
 
-<!--prettier-ignore-->
-```yml
-{% include "../../sample/workspace/parameter.yml" %}
-```
+`Hello World` notebook is attached to the `Hello_World_LH` lakehouse. When deploying `Hello World` from a feature workspace to environment workspaces PPE and PROD, the attached lakehouse needs to be updated to point to the correct lakehouse in the respective environments.
 
-## find_replace Use Case Example
+In the `notebook-content.py` file, the referenced lakehouse GUID `123e4567-e89b-12d3-a456-426614174000` needs to be replaced with the GUID of the `Hello_World_LH` lakehouse found in the PPE/PROD workspace. This replacement is handled by finding all instances of the GUID supplied by `Parameters.yml` in all files in the repository directory and replacing it with the GUID associated with the deployed environment.
 
-'Hello World' notebook is attached to 'Hello_World_LH' lakehouse. When deploying 'Hello World' from a feature workspace to environment workspaces PPE and PROD, the attached lakehouse needs to be updated to point to the correct lakehouse in the respective environments. In the .py notebook file, the lakehouse Id references the following GUID 123e4567-e89b-12d3-a456-426614174000 which needs to be replaced with the GUID of the 'Hello_World_LH' lakehouse found in PPE/PROD workspace. Through parameterization, a brute force replacement is handled by finding all instances of the string '123e4567-e89b-12d3-a456-426614174000' in all files and replacing it with the string associated with the deployed environment.
+Note: In this example, a `find_replace` operation would also be required to update the lakehouse workspace ID found in the notebook file.
 
 ### Parameters.yml
 
 ```yaml
 find_replace:
-    123e4567-e89b-12d3-a456-426614174000: # 'Hello_World_LH' GUID to be replaced
-        PPE: f47ac10b-58cc-4372-a567-0e02b2c3d479 # 'Hello_World_LH' GUID in PPE
-        PROD: 9b2e5f4c-8d3a-4f1b-9c3e-2d5b6e4a7f8c # 'Hello_World_LH' GUID in PROD
+    123e4567-e89b-12d3-a456-426614174000: # lakehouse GUID to be replaced
+        PPE: f47ac10b-58cc-4372-a567-0e02b2c3d479 # PPE lakehouse GUID
+        PROD: 9b2e5f4c-8d3a-4f1b-9c3e-2d5b6e4a7f8c # PROD lakehouse GUID
+    8f5c0cec-a8ea-48cd-9da4-871dc2642f4c: # workspace ID to be replaced
+        PPE: d4e5f6a7-b8c9-4d1e-9f2a-3b4c5d6e7f8a # PPE workspace ID
+        PROD: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d # PROD workspace ID
 ```
 
 ### notebook-content.py

--- a/sample/workspace/parameter.yml
+++ b/sample/workspace/parameter.yml
@@ -1,8 +1,8 @@
 find_replace:
     # SQL Connection Guid
     "db52be81-c2b2-4261-84fa-840c67f4bbd0":
-        PPE: 81bbb339-8d0b-46e8-bfa6-289a159c0733
-        PROD: 5d6a1b16-447f-464a-b959-45d0fed35ca0
+        PPE: "81bbb339-8d0b-46e8-bfa6-289a159c0733"
+        PROD: "5d6a1b16-447f-464a-b959-45d0fed35ca0"
 
 spark_pool:
     # CapacityPool_Large


### PR DESCRIPTION
This pull request includes updates to the `docs/how_to/parameterization.md` file to provide a more comprehensive example of the `find_replace` functionality. The changes add a detailed use case and example configurations for replacing connection strings in different environments.

Documentation improvements:

* [`docs/how_to/parameterization.md`](diffhunk://#diff-9cdd02ee5f5219c5426160beb19ff83c624221fd6db2ac6f8bf923d6ebb6f0ffL9-R9): Added an example use case to illustrate the `find_replace` functionality, including a sample `Parameters.yml` configuration and a `notebook-content.py` file to demonstrate how lakehouse and workspace IDs are replaced during deployment. [[1]](diffhunk://#diff-9cdd02ee5f5219c5426160beb19ff83c624221fd6db2ac6f8bf923d6ebb6f0ffL9-R9) [[2]](diffhunk://#diff-9cdd02ee5f5219c5426160beb19ff83c624221fd6db2ac6f8bf923d6ebb6f0ffR32-R99)