### PR TITLE
Fixes #136, #132 - Support Relative Directories

### DIFF
--- a/docs/how_to/parameterization.md
+++ b/docs/how_to/parameterization.md
@@ -5,12 +5,12 @@ To handle environment-specific values committed to git, use a `parameter.yml` fi
 Example of parameter.yml location based on provided repository directory:
 
 ```python
-    from fabric_cicd import FabricWorkspace
-    workspace = FabricWorkspace(
-        workspace_id="your-workspace-id",
-        repository_directory="C:/dev/workspace",
-        item_type_in_scope=["Notebook"]
-    )
+from fabric_cicd import FabricWorkspace
+workspace = FabricWorkspace(
+    workspace_id="your-workspace-id",
+    repository_directory="C:/dev/workspace",
+    item_type_in_scope=["Notebook"]
+)
 ```
 
 ```

--- a/docs/how_to/parameterization.md
+++ b/docs/how_to/parameterization.md
@@ -22,8 +22,6 @@ C:/dev/workspace
     /parameter.yml
 ```
 
-The `parameter.yml` file should be located directly within the `reposistory_directory` field passed into the `FabricWorkspace` object.
-
 Raise a [feature request](https://github.com/microsoft/fabric-cicd/issues/new?template=2-feature.yml) for additional parameterization capabilities.
 
 ## Inputs

--- a/docs/how_to/parameterization.md
+++ b/docs/how_to/parameterization.md
@@ -1,6 +1,6 @@
 # Parameterization
 
-To handle environment-specific values committed to git, use a `parameter.yml` file. This file supports programmatically changing values based on the `environment` field passed into the `FabricWorkspace` object. If the environment value is not found in the `parameter.yml` file, any dependent replacements will be skipped. This file should sit within the same `repository_directory` folder specified in the FabricWorkspace object.
+To handle environment-specific values committed to git, use a `parameter.yml` file. This file supports programmatically changing values based on the `environment` field passed into the `FabricWorkspace` object. If the environment value is not found in the `parameter.yml` file, any dependent replacements will be skipped. This file should sit in the root of the `repository_directory` folder specified in the FabricWorkspace object.
 
 Example of parameter.yml location based on provided repository directory:
 

--- a/docs/how_to/parameterization.md
+++ b/docs/how_to/parameterization.md
@@ -1,6 +1,28 @@
 # Parameterization
 
-To handle environment-specific values committed to git, use a `parameter.yml` file. This file supports programmatically changing values based on the `environment` field passed into the `FabricWorkspace` object. If the environment value is not found in the `parameter.yml` file, any dependent replacements will be skipped. This file should sit within the same `workspace` folder specified in the FabricWorkspace object.
+To handle environment-specific values committed to git, use a `parameter.yml` file. This file supports programmatically changing values based on the `environment` field passed into the `FabricWorkspace` object. If the environment value is not found in the `parameter.yml` file, any dependent replacements will be skipped. This file should sit within the same `repository_directory` folder specified in the FabricWorkspace object.
+
+Example of parameter.yml location based on provided repository directory:
+
+```python
+    from fabric_cicd import FabricWorkspace
+    workspace = FabricWorkspace(
+        workspace_id="your-workspace-id",
+        repository_directory="C:/dev/workspace",
+        item_type_in_scope=["Notebook"]
+    )
+```
+
+```
+C:/dev/workspace
+    /HelloWorld.Notebook
+        ...
+    /GoodbyeWorld.Notebook
+        ...
+    /parameter.yml
+```
+
+The `parameter.yml` file should be located directly within the `reposistory_directory` field passed into the `FabricWorkspace` object.
 
 Raise a [feature request](https://github.com/microsoft/fabric-cicd/issues/new?template=2-feature.yml) for additional parameterization capabilities.
 

--- a/src/fabric_cicd/_common/_validate_input.py
+++ b/src/fabric_cicd/_common/_validate_input.py
@@ -74,20 +74,27 @@ def validate_item_type_in_scope(input_value: list, upn_auth: bool) -> list:
     return input_value
 
 
-def validate_repository_directory(input_value: str) -> str:
+def validate_repository_directory(input_value: str) -> Path:
     """
-    Validate the repository directory.
+    Validate the repository directory and convert string to Path object
 
     Args:
         input_value: The input value to validate.
     """
     validate_data_type("string", "repository_directory", input_value)
 
-    if not Path(input_value).is_dir():
+    directory = Path(input_value)
+
+    if not directory.is_dir():
         msg = f"The provided repository_directory '{input_value}' does not exist."
         raise InputError(msg, logger)
 
-    return input_value
+    if not directory.is_absolute():
+        absolute_directory = directory.resolve()
+        logger.info(f"Relative directory path '{directory}' resolved as '{absolute_directory}'")
+        directory = absolute_directory
+
+    return directory
 
 
 def validate_base_api_url(input_value: str) -> str:


### PR DESCRIPTION
This pull request includes several changes to improve the handling of file paths and directory validation in the `fabric_cicd` module. The most important changes include modifying the `validate_repository_directory` function to return a `Path` object, updating the `__init__` method to reflect this change, and refactoring various methods to use `Path` objects more consistently.

### Improvements to file path handling:

* [`src/fabric_cicd/_common/_validate_input.py`](diffhunk://#diff-b8a669357b50d9b4d808c610b3e17e12321db4f234259b95ba4350adcca0ecd8L77-R97): Modified `validate_repository_directory` to return a `Path` object instead of a string, and added logic to resolve relative paths to absolute paths.
* [`src/fabric_cicd/fabric_workspace.py`](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L105-R105): Updated the `__init__` method to set `self.repository_directory` as a `Path` object.
* [`src/fabric_cicd/fabric_workspace.py`](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L117-R122): Refactored `_refresh_parameter_file` to use the `/` operator for path joining and to open files using the `Path` object directly.
* [`src/fabric_cicd/fabric_workspace.py`](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L133-R133): Refactored `_refresh_repository_items` to use the `/` operator for path joining.
* [`src/fabric_cicd/fabric_workspace.py`](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0R227): Added a debug log statement in `_replace_parameters` to log parameter replacements.
* [`src/fabric_cicd/fabric_workspace.py`](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L321-R322): Simplified `_convert_path_to_id` to compare `Path` objects directly.