### PR TITLE
Resolves #127 - Share changelog with version check

### DIFF
--- a/src/fabric_cicd/_common/_check_utils.py
+++ b/src/fabric_cicd/_common/_check_utils.py
@@ -4,6 +4,7 @@
 """Utility functions for checking file types and versions."""
 
 import logging
+import re
 from importlib.metadata import version as lib_version
 from pathlib import Path
 
@@ -17,19 +18,75 @@ from fabric_cicd._common._exceptions import FileTypeError
 logger = logging.getLogger(__name__)
 
 
+def parse_changelog(changelog_path: Path | None = None) -> dict[str, list[str]]:
+    """Parse the changelog file and return a dictionary of versions with their changes.
+
+    Args:
+        changelog_path: Path to the changelog file. If None, uses the default path
+            relative to the module.
+    """
+    if changelog_path is None:
+        changelog_path = Path(__file__).parent.parent.parent.parent / "docs" / "changelog.md"
+
+    if not changelog_path.exists():
+        return {}
+
+    with Path.open(changelog_path, encoding="utf-8") as f:
+        content = f.read()
+
+    version_pattern = r"## Version (\d+\.\d+\.\d+).*?(?=## Version|\Z)"
+    changelog_dict = {}
+
+    for match in re.finditer(version_pattern, content, re.DOTALL):
+        version_num = match.group(1)
+        section_content = match.group(0)
+
+        bullet_points = []
+        for line in section_content.split("\n"):
+            line = line.strip()
+            if line.startswith("-"):
+                bullet_points.append(line)
+
+        changelog_dict[version_num] = bullet_points
+
+    return changelog_dict
+
+
 def check_version() -> None:
     """Check the current version of the fabric-cicd package and compare it with the latest version."""
     try:
         current_version = lib_version("fabric-cicd")
         response = requests.get("https://pypi.org/pypi/fabric-cicd/json")
         latest_version = response.json()["info"]["version"]
+
         if version.parse(current_version) < version.parse(latest_version):
             msg = (
                 f"{Fore.BLUE}[notice]{Style.RESET_ALL} A new release of fabric-cicd is available: "
-                f"{Fore.RED}{current_version}{Style.RESET_ALL} -> {Fore.GREEN}{latest_version}{Style.RESET_ALL}"
+                f"{Fore.RED}{current_version}{Style.RESET_ALL} -> {Fore.GREEN}{latest_version}{Style.RESET_ALL}\n"
             )
+
+            # Get changelog entries for versions between current and latest
+            changelog_entries = parse_changelog()
+            if changelog_entries:
+                msg += f"{Fore.BLUE}[notice]{Style.RESET_ALL} What's new:\n\n"
+
+                for ver_str, bullet_points in changelog_entries.items():
+                    ver = version.parse(ver_str)
+                    if version.parse(current_version) < ver <= version.parse(latest_version):
+                        msg += f"{Fore.YELLOW}Version {ver_str}{Style.RESET_ALL}\n"
+                        for point in bullet_points:
+                            msg += f"  {point}\n"
+                        msg += "\n"
+
+            msg += (
+                f"{Fore.BLUE}[notice]{Style.RESET_ALL} View the full changelog at: "
+                f"{Fore.CYAN}https://microsoft.github.io/fabric-cicd/latest/changelog/{Style.RESET_ALL}"
+            )
+
             print(msg)
-    except:
+    except Exception as e:
+        # Silently handle errors, but log them if debug is needed
+        logger.debug(f"Error checking version: {e}")
         pass
 
 


### PR DESCRIPTION
This pull request introduces a new utility function to parse the changelog and integrates it into the version check process. The most important changes include the addition of the `parse_changelog` function, updates to the `check_version` function to display changelog entries, and the import of the `re` module.

Enhancements to changelog handling:

* [`src/fabric_cicd/_common/_check_utils.py`](diffhunk://#diff-ed3713e24dab32c1a8de7fc474ab489877af35d51d709421fe8a708d7dc6221fR21-R89): Added the `parse_changelog` function to parse the changelog file and return a dictionary of versions with their changes.
* [`src/fabric_cicd/_common/_check_utils.py`](diffhunk://#diff-ed3713e24dab32c1a8de7fc474ab489877af35d51d709421fe8a708d7dc6221fR21-R89): Updated the `check_version` function to use `parse_changelog` and display changelog entries for versions between the current and latest version.

Codebase improvements:

* [`src/fabric_cicd/_common/_check_utils.py`](diffhunk://#diff-ed3713e24dab32c1a8de7fc474ab489877af35d51d709421fe8a708d7dc6221fR7): Imported the `re` module to support regular expression operations in the `parse_changelog` function.