### PR TITLE
Resolves #145 - Support for Mirrored Database

### DIFF
--- a/docs/how_to/item_types.md
+++ b/docs/how_to/item_types.md
@@ -28,7 +28,7 @@
 -   **Parameterization:**
     -   The `find_replace` section in the `parameter.yml` file is not applied.
 -   **Initial deployment** for Azure SQL Database or Azure SQL Managed Instance requires manual granting of System Assigned Managed Identity (SAMI) Read and Write permission to the mirrored database for replication to be succesful after deployment. ref -> ([Prerequisites](https://learn.microsoft.com/en-us/fabric/database/mirrored-database/mirrored-database-rest-api#create-mirrored-database))
--   **Unpublish** a warning is shown for any default Semantic Models created by the Mirror Database. This is a current limitation of the Fabric API and can be ignored.
+-   **Unpublish** - a warning is shown for any default Semantic Models created by the Mirror Database. This is a current limitation of the Fabric API and can be ignored.
 
 ## Notebooks
 

--- a/docs/how_to/item_types.md
+++ b/docs/how_to/item_types.md
@@ -23,6 +23,13 @@
 -   **Shortcuts** are not deployed with Lakehouses.
 -   **Unpublish** is disabled by default, enable with feature flag `enable_lakehouse_unpublish`
 
+## Mirrored Database
+
+-   **Parameterization:**
+    -   The `find_replace` section in the `parameter.yml` file is not applied.
+-   **Initial deployment** for Azure SQL Database or Azure SQL Managed Instance requires manual granting of System Assigned Managed Identity (SAMI) Read and Write permission to the mirrored database for replication to be succesful after deployment. ref -> ([Prerequisites](https://learn.microsoft.com/en-us/fabric/database/mirrored-database/mirrored-database-rest-api#create-mirrored-database))
+-   **Unpublish** a warning is shown for any default Semantic Models created by the Mirror Database. This is a current limitation of the Fabric API and can be ignored.
+
 ## Notebooks
 
 -   **Parameterization:**

--- a/docs/how_to/item_types.md
+++ b/docs/how_to/item_types.md
@@ -27,7 +27,7 @@
 
 -   **Parameterization:**
     -   The `find_replace` section in the `parameter.yml` file is not applied.
--   **Initial deployment** for Azure SQL Database or Azure SQL Managed Instance requires manual granting of System Assigned Managed Identity (SAMI) Read and Write permission to the mirrored database for replication to be succesful after deployment. ref -> ([Prerequisites](https://learn.microsoft.com/en-us/fabric/database/mirrored-database/mirrored-database-rest-api#create-mirrored-database))
+-   **Initial deployment** for Azure SQL Database or Azure SQL Managed Instance requires manual granting of System Assigned Managed Identity (SAMI) Read and Write permission to the mirrored database for replication to be successful after deployment. ref -> ([Prerequisites](https://learn.microsoft.com/en-us/fabric/database/mirrored-database/mirrored-database-rest-api#create-mirrored-database))
 -   **Unpublish** - a warning is shown for any default Semantic Models created by the Mirror Database. This is a current limitation of the Fabric API and can be ignored.
 
 ## Notebooks

--- a/sample/workspace/MirroredDatabase_1.MirroredDatabase/.platform
+++ b/sample/workspace/MirroredDatabase_1.MirroredDatabase/.platform
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/gitIntegration/platformProperties/2.0.0/schema.json",
+  "metadata": {
+    "type": "MirroredDatabase",
+    "displayName": "MirroredDatabase_1"
+  },
+  "config": {
+    "version": "2.0",
+    "logicalId": "7b1dcb5e-9744-86a5-447a-67e0a4bef6f8"
+  }
+}

--- a/sample/workspace/MirroredDatabase_1.MirroredDatabase/mirroring.json
+++ b/sample/workspace/MirroredDatabase_1.MirroredDatabase/mirroring.json
@@ -1,0 +1,15 @@
+{
+  "properties": {
+    "source": {
+      "type": "GenericMirror",
+      "typeProperties": null
+    },
+    "target": {
+      "type": "MountedRelationalDatabase",
+      "typeProperties": {
+        "format": "Delta",
+        "defaultSchema": "dbo"
+      }
+    }
+  }
+}

--- a/src/fabric_cicd/_items/__init__.py
+++ b/src/fabric_cicd/_items/__init__.py
@@ -7,6 +7,7 @@ from fabric_cicd._items._datapipeline import (
 )
 from fabric_cicd._items._environment import publish_environments
 from fabric_cicd._items._lakehouse import publish_lakehouses
+from fabric_cicd._items._mirroreddatabase import publish_mirroreddatabase
 from fabric_cicd._items._notebook import publish_notebooks
 from fabric_cicd._items._report import publish_reports
 from fabric_cicd._items._semanticmodel import publish_semanticmodels
@@ -15,6 +16,7 @@ __all__ = [
     "publish_datapipelines",
     "publish_environments",
     "publish_lakehouses",
+    "publish_mirroreddatabase",
     "publish_notebooks",
     "publish_reports",
     "publish_semanticmodels",

--- a/src/fabric_cicd/_items/_mirroreddatabase.py
+++ b/src/fabric_cicd/_items/_mirroreddatabase.py
@@ -1,0 +1,18 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import logging
+
+"""
+Functions to process and deploy Mirrored Database item.
+"""
+
+logger = logging.getLogger(__name__)
+
+
+def publish_mirroreddatabase(fabric_workspace_obj):
+    """Publishes all Mirrored Database items from the repository."""
+    item_type = "MirroredDatabase"
+
+    for item_name in fabric_workspace_obj.repository_items.get(item_type, {}):
+        fabric_workspace_obj._publish_item(item_name=item_name, item_type=item_type)

--- a/src/fabric_cicd/_items/_mirroreddatabase.py
+++ b/src/fabric_cicd/_items/_mirroreddatabase.py
@@ -1,17 +1,22 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+"""Functions to process and deploy Mirrored Database item."""
+
 import logging
 
-"""
-Functions to process and deploy Mirrored Database item.
-"""
+from fabric_cicd import FabricWorkspace
 
 logger = logging.getLogger(__name__)
 
 
-def publish_mirroreddatabase(fabric_workspace_obj):
-    """Publishes all Mirrored Database items from the repository."""
+def publish_mirroreddatabase(fabric_workspace_obj: FabricWorkspace) -> None:
+    """
+    Publishes all Mirrored Database items from the repository.
+
+    Args:
+        fabric_workspace_obj: The FabricWorkspace object containing the items to be published.
+    """
     item_type = "MirroredDatabase"
 
     for item_name in fabric_workspace_obj.repository_items.get(item_type, {}):

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -25,8 +25,23 @@ logger = logging.getLogger(__name__)
 class FabricWorkspace:
     """A class to manage and publish workspace items to the Fabric API."""
 
-    ACCEPTED_ITEM_TYPES_UPN = ("DataPipeline", "Environment", "Notebook", "Report", "SemanticModel", "Lakehouse")
-    ACCEPTED_ITEM_TYPES_NON_UPN = ("Environment", "Notebook", "Report", "SemanticModel", "Lakehouse")
+    ACCEPTED_ITEM_TYPES_UPN = (
+        "DataPipeline",
+        "Environment",
+        "Notebook",
+        "Report",
+        "SemanticModel",
+        "Lakehouse",
+        "MirroredDatabase",
+    )
+    ACCEPTED_ITEM_TYPES_NON_UPN = (
+        "Environment",
+        "Notebook",
+        "Report",
+        "SemanticModel",
+        "Lakehouse",
+        "MirroredDatabase",
+    )
 
     def __init__(
         self,

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -38,6 +38,9 @@ def publish_all_items(fabric_workspace_obj: FabricWorkspace) -> None:
     if "Lakehouse" in fabric_workspace_obj.item_type_in_scope:
         _print_header("Publishing Lakehouses")
         items.publish_lakehouses(fabric_workspace_obj)
+    if "MirroredDatabase" in fabric_workspace_obj.item_type_in_scope:
+        _print_header("Publishing MirroredDatabase")
+        items.publish_mirroreddatabase(fabric_workspace_obj)
     if "Environment" in fabric_workspace_obj.item_type_in_scope:
         _print_header("Publishing Environments")
         items.publish_environments(fabric_workspace_obj)
@@ -100,7 +103,7 @@ def unpublish_all_orphan_items(fabric_workspace_obj: FabricWorkspace, item_name_
 
     # Define order to unpublish items
     unpublish_order = []
-    for x in ["DataPipeline", "Report", "SemanticModel", "Notebook", "Environment", "Lakehouse"]:
+    for x in ["DataPipeline", "Report", "SemanticModel", "Notebook", "Environment", "MirroredDatabase", "Lakehouse"]:
         if x in fabric_workspace_obj.item_type_in_scope and (
             x != "Lakehouse" or "enable_lakehouse_unpublish" in feature_flag
         ):


### PR DESCRIPTION
This pull request introduces support for Mirrored Database items in the Fabric CI/CD pipeline. The changes include updates to documentation, configuration files, and the addition of new functions to handle the publishing and unpublishing of Mirrored Database items.

Key changes include:

### Documentation Updates:
* Added a new section for Mirrored Database in `docs/how_to/item_types.md`, detailing parameterization, initial deployment requirements, and unpublish warnings.

### Configuration Files:
* Added a new configuration file `sample/workspace/MirroredDatabase_1.MirroredDatabase/.platform` to define the metadata and configuration for Mirrored Database items.
* Added a new configuration file `sample/workspace/MirroredDatabase_1.MirroredDatabase/mirroring.json` to specify the properties of the source and target for the Mirrored Database.

### Codebase Updates:
* Included the `publish_mirroreddatabase` function in the `src/fabric_cicd/_items/__init__.py` imports and `__all__` list. [[1]](diffhunk://#diff-94d858110d4e75a68135b9975f58e289c7db48793b5bf7bc56c08efad59f3e34R10) [[2]](diffhunk://#diff-94d858110d4e75a68135b9975f58e289c7db48793b5bf7bc56c08efad59f3e34R19)
* Added a new module `src/fabric_cicd/_items/_mirroreddatabase.py` to define the `publish_mirroreddatabase` function for processing and deploying Mirrored Database items.
* Updated the `FabricWorkspace` class in `src/fabric_cicd/fabric_workspace.py` to include `MirroredDatabase` in the accepted item types.
* Modified the `publish_all_items` and `unpublish_all_orphan_items` functions in `src/fabric_cicd/publish.py` to handle Mirrored Database items. [[1]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R41-R43) [[2]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704L103-R106)