### PR TITLE
Resolves #135 - Increase reserved name wait time.

### DIFF
--- a/src/fabric_cicd/_common/_fabric_endpoint.py
+++ b/src/fabric_cicd/_common/_fabric_endpoint.py
@@ -245,8 +245,9 @@ def _handle_response(
     ):
         handle_retry(
             attempt=iteration_count,
-            base_delay=2.5,
+            base_delay=30,
             max_retries=5,
+            response_retry_after=300,
             prepend_message="Item name is reserved.",
         )
 

--- a/tests/test__fabric_endpoint.py
+++ b/tests/test__fabric_endpoint.py
@@ -357,7 +357,7 @@ def test_handle_response_item_display_name_already_in_use(setup_mocks):
     dl, mock_requests = setup_mocks
     response = Mock(status_code=400, headers={"x-ms-public-api-error-code": "ItemDisplayNameAlreadyInUse"})
     _handle_response(response, "GET", "http://example.com", "{}", False, 1)
-    expected = "Item name is reserved. Checking again in 5 seconds (Attempt 1/5)..."
+    expected = "Item name is reserved. Checking again in 60 seconds (Attempt 1/5)..."
     assert dl.messages == [expected]
 
 


### PR DESCRIPTION
This pull request includes changes to the retry logic in the `_handle_response` function and updates the corresponding test to reflect these changes. The most important changes are:

Retry logic adjustments:

* [`src/fabric_cicd/_common/_fabric_endpoint.py`](diffhunk://#diff-df48b77e163b4a13c97f80408ad6640fca48ffdc60c19e085b4c73589933178cL248-R250): Increased the `base_delay` from 2.5 seconds to 30 seconds and added a new parameter `response_retry_after` set to 300 seconds in the `handle_retry` function call.

Test updates:

* [`tests/test__fabric_endpoint.py`](diffhunk://#diff-d5975d64f0adde0e560b6984da9e6c82903b4d6c09da96d60e3051c37465497aL360-R360): Updated the expected retry message to reflect the new delay, changing the wait time from 5 seconds to 60 seconds.