### PR TITLE
Update Mirrored Database parametization

### DIFF
--- a/docs/how_to/item_types.md
+++ b/docs/how_to/item_types.md
@@ -26,7 +26,7 @@
 ## Mirrored Database
 
 -   **Parameterization:**
-    -   The `find_replace` section in the `parameter.yml` file is not applied.
+    -   Connections will always point to the original source database unless parameterized in the `find_replace` section of the `parameter.yml` file.
 -   **Initial deployment** for Azure SQL Database or Azure SQL Managed Instance requires manual granting of System Assigned Managed Identity (SAMI) Read and Write permission to the mirrored database for replication to be successful after deployment. ref -> ([Prerequisites](https://learn.microsoft.com/en-us/fabric/database/mirrored-database/mirrored-database-rest-api#create-mirrored-database))
 -   **Unpublish** - a warning is shown for any default Semantic Models created by the Mirror Database. This is a current limitation of the Fabric API and can be ignored.
 


### PR DESCRIPTION
This pull request includes an update to the documentation for the `Mirrored Database` section. The change clarifies the behavior of the `find_replace` section in the `parameter.yml` file.

Documentation update:

* [`docs/how_to/item_types.md`](diffhunk://#diff-2b5373cf38b50a290bee3f403778f7dff7cdc942ddbb39026b291da113dc6025L29-R29): Clarified that connections will always point to the original source database unless parameterized in the `find_replace` section of the `parameter.yml` file.