### PR TITLE
Resolves #164 Workspace ID replacement in data pipelines bug

### DIFF
--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -151,9 +151,6 @@ class FabricWorkspace:
                 if not any(directory.iterdir()):
                     logger.warning(f"Directory {directory.name} is empty.")
                     continue
-                # if not os.listdir(directory):
-                # logger.warning(f"Directory {directory.name} is empty.")
-                # continue
 
                 # Attempt to read metadata file
                 try:

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -148,9 +148,12 @@ class FabricWorkspace:
                 item_metadata_path = directory / ".platform"
 
                 # Print a warning and skip directory if empty
-                if not os.listdir(directory):
+                if not any(directory.iterdir()):
                     logger.warning(f"Directory {directory.name} is empty.")
                     continue
+                # if not os.listdir(directory):
+                # logger.warning(f"Directory {directory.name} is empty.")
+                # continue
 
                 # Attempt to read metadata file
                 try:

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -280,7 +280,7 @@ class FabricWorkspace:
         guid_pattern = re.compile(r"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$")
 
         # Activities mapping dictionary: {Key: activity_name, Value: [item_type, item_id_name]}
-        activities_mapping = {"RefreshDataflow": ["Dataflow", "dataflowId"], "Lakehouse": ["Lakehouse", "artifactId"]}
+        activities_mapping = {"RefreshDataflow": ["Dataflow", "dataflowId"]}
 
         # dpath library finds and replaces feature branch workspace IDs found in all levels of activities in the dictionary
         for path, activity_value in dpath.search(item_content_dict, "**/type", yielded=True):

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -280,11 +280,12 @@ class FabricWorkspace:
         guid_pattern = re.compile(r"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$")
 
         # Activities mapping dictionary: {Key: activity_name, Value: [item_type, item_id_name]}
-        activities_mapping = {"RefreshDataflow": ["Dataflow", "dataflowId"]}
+        activities_mapping = {"RefreshDataflow": ["Dataflow", "dataflowId"], "Lakehouse": ["Lakehouse", "artifactId"]}
 
         # dpath library finds and replaces feature branch workspace IDs found in all levels of activities in the dictionary
         for path, activity_value in dpath.search(item_content_dict, "**/type", yielded=True):
-            if activity_value in activities_mapping:
+            # Ensure the type value is a string and check if it is found in the activities mapping
+            if type(activity_value) == str and activity_value in activities_mapping:
                 # Split the path into components, create a path to 'workspaceId' and get the workspace ID value
                 path = path.split("/")
                 workspace_id_path = (*path[:-1], "typeProperties", "workspaceId")


### PR DESCRIPTION
This pull request includes a minor but important change to the `_replace_activity_workspace_ids` method in the `fabric_workspace.py` file. The change ensures that the type value is a string before checking if it is found in the activities mapping.

* [`src/fabric_cicd/fabric_workspace.py`](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L287-R288): Added a type check to ensure the `activity_value` is a string before checking if it is in the `activities_mapping`.