### PR TITLE
Resolves #133 DataPipeline SPN Support

### DIFF
--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -34,14 +34,7 @@ class FabricWorkspace:
         "Lakehouse",
         "MirroredDatabase",
     )
-    ACCEPTED_ITEM_TYPES_NON_UPN = (
-        "Environment",
-        "Notebook",
-        "Report",
-        "SemanticModel",
-        "Lakehouse",
-        "MirroredDatabase",
-    )
+    ACCEPTED_ITEM_TYPES_NON_UPN = ACCEPTED_ITEM_TYPES_UPN
 
     def __init__(
         self,


### PR DESCRIPTION
This pull request includes a change to the `FabricWorkspace` class in the `src/fabric_cicd/fabric_workspace.py` file to simplify the code by reusing an existing tuple.

Codebase simplification:

* [`src/fabric_cicd/fabric_workspace.py`](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L37-R37): Modified the `ACCEPTED_ITEM_TYPES_NON_UPN` tuple to reuse the `ACCEPTED_ITEM_TYPES_UPN` tuple, removing redundancy in the code.