### PR TITLE
Resolves #146 Move MaxRetry to Constants

### DIFF
--- a/devtools/debug_local.py
+++ b/devtools/debug_local.py
@@ -15,6 +15,7 @@ from fabric_cicd import (
     FabricWorkspace,
     append_feature_flag,
     change_log_level,
+    constants,
     publish_all_items,
     unpublish_all_orphan_items,
 )
@@ -41,14 +42,14 @@ item_type_in_scope = ["DataPipeline", "Notebook", "Environment", "SemanticModel"
 # tenant_id = "your-tenant-id"
 # token_credential = ClientSecretCredential(client_id=client_id, client_secret=client_secret, tenant_id=tenant_id)
 
+constants.DEFAULT_API_ROOT_URL = "https://msitapi.fabric.microsoft.com"
+
 # Initialize the FabricWorkspace object with the required parameters
 target_workspace = FabricWorkspace(
     workspace_id=workspace_id,
     environment=environment,
     repository_directory=repository_directory,
     item_type_in_scope=item_type_in_scope,
-    # Override base url in rare cases where it's different
-    base_api_url="https://msitapi.fabric.microsoft.com/",
     # Uncomment to use SPN auth
     # token_credential=token_credential,
 )

--- a/devtools/debug_local.py
+++ b/devtools/debug_local.py
@@ -24,7 +24,7 @@ from fabric_cicd import (
 # change_log_level()
 
 # Uncomment to add feature flag
-# append_feature_flag("disable_executing_identity")
+append_feature_flag("disable_print_identity")
 
 # The defined environment values should match the names found in the parameter.yml file
 workspace_id = "8f5c0cec-a8ea-48cd-9da4-871dc2642f4c"

--- a/docs/config/pre-build/update_item_types.py
+++ b/docs/config/pre-build/update_item_types.py
@@ -4,7 +4,7 @@ from pathlib import Path
 root_directory = Path(__file__).resolve().parent.parent.parent.parent
 sys.path.insert(0, str(root_directory / "src"))
 
-from fabric_cicd import FabricWorkspace
+from fabric_cicd.constants import ACCEPTED_ITEM_TYPES
 
 
 def on_page_markdown(markdown, **kwargs):
@@ -12,7 +12,7 @@ def on_page_markdown(markdown, **kwargs):
         start_index = markdown.index("<!--BEGIN-SUPPORTED-ITEM-TYPES-->\n") + len("<!--BEGIN-SUPPORTED-ITEM-TYPES-->\n")
         end_index = markdown.index("<!--END-SUPPORTED-ITEM-TYPES-->\n")
 
-        supported_item_types = FabricWorkspace.ACCEPTED_ITEM_TYPES_UPN
+        supported_item_types = ACCEPTED_ITEM_TYPES
         markdown_content = "\n".join([f"-   {item}" for item in supported_item_types])
 
         new_markdown = markdown[:start_index] + markdown_content + markdown[end_index:]

--- a/src/fabric_cicd/__init__.py
+++ b/src/fabric_cicd/__init__.py
@@ -6,14 +6,13 @@
 import logging
 import sys
 
+import fabric_cicd.constants  # required for overwriting constant
 from fabric_cicd._common._check_utils import check_version
 from fabric_cicd._common._logging import configure_logger, exception_handler
 from fabric_cicd.fabric_workspace import FabricWorkspace
 from fabric_cicd.publish import publish_all_items, unpublish_all_orphan_items
 
 logger = logging.getLogger(__name__)
-
-feature_flag = set()
 
 
 def append_feature_flag(feature: str) -> None:
@@ -28,8 +27,7 @@ def append_feature_flag(feature: str) -> None:
         >>> from fabric_cicd import append_feature_flag
         >>> append_feature_flag("enable_lakehouse_unpublish")
     """
-    global feature_flag
-    feature_flag.add(feature)
+    fabric_cicd.constants.FEATURE_FLAG.add(feature)
 
 
 def change_log_level(level: str = "DEBUG") -> None:

--- a/src/fabric_cicd/_common/_fabric_endpoint.py
+++ b/src/fabric_cicd/_common/_fabric_endpoint.py
@@ -17,6 +17,7 @@ from azure.core.exceptions import (
 )
 
 from fabric_cicd._common._exceptions import InvokeError, TokenError
+from fabric_cicd.constants import FEATURE_FLAG
 
 logger = logging.getLogger(__name__)
 
@@ -145,10 +146,7 @@ class FabricEndpoint:
 
 
 def _log_executing_identity(msg: str) -> None:
-    # Import feature_flag here to avoid circular import
-    from fabric_cicd import feature_flag
-
-    if "disable_print_identity" not in feature_flag:
+    if "disable_print_identity" not in FEATURE_FLAG:
         logger.info(msg)
 
 

--- a/src/fabric_cicd/_common/_validate_input.py
+++ b/src/fabric_cicd/_common/_validate_input.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from azure.core.credentials import TokenCredential
 
 from fabric_cicd._common._exceptions import InputError
+from fabric_cicd.constants import ACCEPTED_ITEM_TYPES_NON_UPN, ACCEPTED_ITEM_TYPES_UPN, VALID_GUID_REGEX
 from fabric_cicd.fabric_workspace import FabricWorkspace
 
 logger = logging.getLogger(__name__)
@@ -54,8 +55,8 @@ def validate_item_type_in_scope(input_value: list, upn_auth: bool) -> list:
         input_value: The input value to validate.
         upn_auth: Whether UPN authentication is used.
     """
-    accepted_item_types_upn = FabricWorkspace.ACCEPTED_ITEM_TYPES_UPN
-    accepted_item_types_non_upn = FabricWorkspace.ACCEPTED_ITEM_TYPES_NON_UPN
+    accepted_item_types_upn = ACCEPTED_ITEM_TYPES_UPN
+    accepted_item_types_non_upn = ACCEPTED_ITEM_TYPES_NON_UPN
 
     accepted_item_types = accepted_item_types_upn if upn_auth else accepted_item_types_non_upn
 
@@ -97,26 +98,6 @@ def validate_repository_directory(input_value: str) -> Path:
     return directory
 
 
-def validate_base_api_url(input_value: str) -> str:
-    """
-    Validate the base API URL.
-
-    Args:
-        input_value: The input value to validate.
-    """
-    validate_data_type("string", "base_api_url", input_value)
-
-    if not re.match(r"^https:\/\/([a-zA-Z0-9]+)\.fabric\.microsoft\.com\/$", input_value):
-        msg = (
-            "The provided base_api_url does not follow the 'https://<word>.fabric.microsoft.com/' syntax. "
-            "Ensure the URL has a single word in between 'https://' and '.fabric.microsoft.com/', "
-            "and only contains alphanumeric characters."
-        )
-        raise InputError(msg, logger)
-
-    return input_value
-
-
 def validate_workspace_id(input_value: str) -> str:
     """
     Validate the workspace ID.
@@ -126,7 +107,7 @@ def validate_workspace_id(input_value: str) -> str:
     """
     validate_data_type("string", "workspace_id", input_value)
 
-    if not re.match(r"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$", input_value):
+    if not re.match(VALID_GUID_REGEX, input_value):
         msg = "The provided workspace_id is not a valid guid."
         raise InputError(msg, logger)
 

--- a/src/fabric_cicd/_items/_datapipeline.py
+++ b/src/fabric_cicd/_items/_datapipeline.py
@@ -15,6 +15,7 @@ from fabric_cicd import FabricWorkspace
 from fabric_cicd._common._exceptions import ParsingError
 from fabric_cicd._common._file import File
 from fabric_cicd._common._item import Item
+from fabric_cicd.constants import VALID_GUID_REGEX
 
 logger = logging.getLogger(__name__)
 
@@ -143,7 +144,7 @@ def _find_referenced_datapipelines(
     """
     item_type = "DataPipeline"
     reference_list = []
-    guid_pattern = re.compile(r"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$")
+    guid_pattern = re.compile(VALID_GUID_REGEX)
 
     # Use the dpath library to search through the dictionary for all values that match the GUID pattern
     for _, value in dpath.search(item_content_dict, "**", yielded=True):

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -21,7 +21,6 @@ ACCEPTED_ITEM_TYPES_NON_UPN = ACCEPTED_ITEM_TYPES_UPN
 MAX_RETRY_OVERRIDE = {"SemanticModel": 10, "Report": 10}
 SHELL_ONLY_PUBLISH = ["Environment", "Lakehouse"]
 
-
 # REGEX Constants
 VALID_GUID_REGEX = r"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
 WORKSPACE_ID_REFERENCE_REGEX = r'"(default_lakehouse_workspace_id|workspaceId)": "(.*?)"'

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -1,5 +1,31 @@
 """Constants for the fabric-cicd package."""
 
+# General
+DEFAULT_WORKSPACE_ID = "00000000-0000-0000-0000-000000000000"
+DEFAULT_API_ROOT_URL = "https://api.powerbi.com"
+FEATURE_FLAG = set()
+
+# Item Type
+ACCEPTED_ITEM_TYPES_UPN = (
+    "DataPipeline",
+    "Environment",
+    "Notebook",
+    "Report",
+    "SemanticModel",
+    "Lakehouse",
+    "MirroredDatabase",
+)
+ACCEPTED_ITEM_TYPES_NON_UPN = ACCEPTED_ITEM_TYPES_UPN
+
+# Publish
+MAX_RETRY_OVERRIDE = {"SemanticModel": 10, "Report": 10}
+SHELL_ONLY_PUBLISH = ["Environment", "Lakehouse"]
+
+
+# REGEX Constants
+VALID_GUID_REGEX = r"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+WORKSPACE_ID_REFERENCE_REGEX = r'"(default_lakehouse_workspace_id|workspaceId)": "(.*?)"'
+
 # Parameter file configs
 PARAMETER_FILE_NAME = "parameter.yml"
 

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Constants for the fabric-cicd package."""
 
 # General

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -296,13 +296,12 @@ class FabricWorkspace:
         """
         # Replace all instances of default feature branch workspace ID with target workspace ID
         target_workspace_id = self.workspace_id
-        default_workspace_id = DEFAULT_WORKSPACE_ID
 
         workspace_id_match = re.search(WORKSPACE_ID_REFERENCE_REGEX, raw_file)
         if workspace_id_match:
             workspace_id = workspace_id_match.group(2)
-            if workspace_id == default_workspace_id:
-                raw_file = raw_file.replace(default_workspace_id, target_workspace_id)
+            if workspace_id == DEFAULT_WORKSPACE_ID:
+                raw_file = raw_file.replace(DEFAULT_WORKSPACE_ID, target_workspace_id)
 
         # For DataPipeline item, additional replacements may be required
         if item_type == "DataPipeline":

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -14,10 +14,19 @@ import dpath
 from azure.core.credentials import TokenCredential
 from azure.identity import DefaultAzureCredential
 
+import fabric_cicd.constants  # required for overwriting constant
 from fabric_cicd._common._exceptions import ParameterFileError, ParsingError
 from fabric_cicd._common._fabric_endpoint import FabricEndpoint
 from fabric_cicd._common._item import Item
-from fabric_cicd.constants import PARAMETER_FILE_NAME
+from fabric_cicd.constants import (
+    DEFAULT_API_ROOT_URL,
+    DEFAULT_WORKSPACE_ID,
+    MAX_RETRY_OVERRIDE,
+    PARAMETER_FILE_NAME,
+    SHELL_ONLY_PUBLISH,
+    VALID_GUID_REGEX,
+    WORKSPACE_ID_REFERENCE_REGEX,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -25,25 +34,14 @@ logger = logging.getLogger(__name__)
 class FabricWorkspace:
     """A class to manage and publish workspace items to the Fabric API."""
 
-    ACCEPTED_ITEM_TYPES_UPN = (
-        "DataPipeline",
-        "Environment",
-        "Notebook",
-        "Report",
-        "SemanticModel",
-        "Lakehouse",
-        "MirroredDatabase",
-    )
-    ACCEPTED_ITEM_TYPES_NON_UPN = ACCEPTED_ITEM_TYPES_UPN
-
     def __init__(
         self,
         workspace_id: str,
         repository_directory: str,
         item_type_in_scope: list[str],
-        base_api_url: str = "https://api.fabric.microsoft.com/",
         environment: str = "N/A",
         token_credential: TokenCredential = None,
+        **kwargs,
     ) -> None:
         """
         Initializes the FabricWorkspace instance.
@@ -52,9 +50,9 @@ class FabricWorkspace:
             workspace_id: The ID of the workspace to interact with.
             repository_directory: Local directory path of the repository where items are to be deployed from.
             item_type_in_scope: Item types that should be deployed for a given workspace.
-            base_api_url: Base URL for the Fabric API. Defaults to the Fabric API endpoint.
             environment: The environment to be used for parameterization.
             token_credential: The token credential to use for API requests.
+            kwargs: Additional keyword arguments.
 
         Examples:
             Basic usage
@@ -71,7 +69,6 @@ class FabricWorkspace:
             ...     workspace_id="your-workspace-id",
             ...     repository_directory="/your/path/to/repo",
             ...     item_type_in_scope=["Environment", "Notebook", "DataPipeline"],
-            ...     base_api_url="https://orgapi.fabric.microsoft.com",
             ...     environment="your-target-environment"
             ... )
 
@@ -92,7 +89,6 @@ class FabricWorkspace:
             ... )
         """
         from fabric_cicd._common._validate_input import (
-            validate_base_api_url,
             validate_environment,
             validate_item_type_in_scope,
             validate_repository_directory,
@@ -112,8 +108,17 @@ class FabricWorkspace:
         self.workspace_id = validate_workspace_id(workspace_id)
         self.repository_directory: Path = validate_repository_directory(repository_directory)
         self.item_type_in_scope = validate_item_type_in_scope(item_type_in_scope, upn_auth=self.endpoint.upn_auth)
-        self.base_api_url = f"{validate_base_api_url(base_api_url)}/v1/workspaces/{workspace_id}"
         self.environment = validate_environment(environment)
+
+        # temporarily support base_api_url until deprecated
+        if "base_api_url" in kwargs:
+            logger.warning(
+                """Setting base_api_url will be deprecated in a future version, please use the below moving forward:
+                >>> import fabric_cicd.constants
+                >>> constants.DEFAULT_API_ROOT_URL = '<your_base_api_url>'\n"""
+            )
+            fabric_cicd.constants.DEFAULT_API_ROOT_URL = kwargs["base_api_url"]
+        self.base_api_url = f"{DEFAULT_API_ROOT_URL}/v1/workspaces/{workspace_id}"
 
         # Initialize dictionaries to store repository and deployed items
         self._refresh_parameter_file()
@@ -291,11 +296,13 @@ class FabricWorkspace:
         """
         # Replace all instances of default feature branch workspace ID with target workspace ID
         target_workspace_id = self.workspace_id
-        default_workspace_string = '"workspaceId": "00000000-0000-0000-0000-000000000000"'
-        target_workspace_string = f'"workspaceId": "{target_workspace_id}"'
+        default_workspace_id = DEFAULT_WORKSPACE_ID
 
-        if default_workspace_string in raw_file:
-            raw_file = raw_file.replace(default_workspace_string, target_workspace_string)
+        workspace_id_match = re.search(WORKSPACE_ID_REFERENCE_REGEX, raw_file)
+        if workspace_id_match:
+            workspace_id = workspace_id_match.group(2)
+            if workspace_id == default_workspace_id:
+                raw_file = raw_file.replace(default_workspace_id, target_workspace_id)
 
         # For DataPipeline item, additional replacements may be required
         if item_type == "DataPipeline":
@@ -314,7 +321,7 @@ class FabricWorkspace:
         """
         # Create a dictionary from the raw file
         item_content_dict = json.loads(raw_file)
-        guid_pattern = re.compile(r"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$")
+        guid_pattern = re.compile(VALID_GUID_REGEX)
 
         # Activities mapping dictionary: {Key: activity_name, Value: [item_type, item_id_name]}
         activities_mapping = {"RefreshDataflow": ["Dataflow", "dataflowId"]}
@@ -399,12 +406,12 @@ class FabricWorkspace:
         item_guid = item.guid
         item_files = item.item_files
 
-        max_retries = 10 if item_type == "SemanticModel" else 5
+        max_retries = MAX_RETRY_OVERRIDE.get(item_type, 5)
 
         metadata_body = {"displayName": item_name, "type": item_type}
 
         # Only shell deployment, no definition support
-        shell_only_publish = item_type in ["Environment", "Lakehouse"]
+        shell_only_publish = item_type in SHELL_ONLY_PUBLISH
 
         if kwargs.get("creation_payload"):
             creation_payload = {"creationPayload": kwargs["creation_payload"]}

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -12,6 +12,7 @@ import fabric_cicd._items as items
 from fabric_cicd._common._validate_input import (
     validate_fabric_workspace_obj,
 )
+from fabric_cicd.constants import FEATURE_FLAG
 from fabric_cicd.fabric_workspace import FabricWorkspace
 
 logger = logging.getLogger(__name__)
@@ -98,14 +99,11 @@ def unpublish_all_orphan_items(fabric_workspace_obj: FabricWorkspace, item_name_
     fabric_workspace_obj._refresh_deployed_items()
     _print_header("Unpublishing Orphaned Items")
 
-    # Import feature_flag here to avoid circular import
-    from fabric_cicd import feature_flag
-
     # Define order to unpublish items
     unpublish_order = []
     for x in ["DataPipeline", "Report", "SemanticModel", "Notebook", "Environment", "MirroredDatabase", "Lakehouse"]:
         if x in fabric_workspace_obj.item_type_in_scope and (
-            x != "Lakehouse" or "enable_lakehouse_unpublish" in feature_flag
+            x != "Lakehouse" or "enable_lakehouse_unpublish" in FEATURE_FLAG
         ):
             unpublish_order.append(x)
 


### PR DESCRIPTION
This pull request includes several changes to the `fabric_cicd` package, primarily focusing on refactoring the use of constants and improving code maintainability. The most important changes include moving constants to a dedicated file, updating the usage of these constants throughout the codebase, and deprecating the `base_api_url` parameter in the `FabricWorkspace` class.

Refactoring and constants management:

* [`src/fabric_cicd/constants.py`](diffhunk://#diff-91c2d32be351f155f090c4bd57ebe3c10e646edbc1b663e2a72b697f956a949cR3-R28): Introduced a new file to store constants such as `ACCEPTED_ITEM_TYPES_UPN`, `FEATURE_FLAG`, and `VALID_GUID_REGEX`.

Code updates to use the new constants:

* [`docs/config/pre-build/update_item_types.py`](diffhunk://#diff-dfc7e72547f63f32daeff960bb1258340b2453b0627b20204ddb67e7267cdfefL7-R15): Updated to use `ACCEPTED_ITEM_TYPES` from the constants file instead of `FabricWorkspace.ACCEPTED_ITEM_TYPES_UPN`.
* [`src/fabric_cicd/__init__.py`](diffhunk://#diff-364c25e03dde1816a460702e5c0224b29c1bd8d185d9eea1089520dd040c9849R9-L17): Modified to import and use constants from the new constants file. [[1]](diffhunk://#diff-364c25e03dde1816a460702e5c0224b29c1bd8d185d9eea1089520dd040c9849R9-L17) [[2]](diffhunk://#diff-364c25e03dde1816a460702e5c0224b29c1bd8d185d9eea1089520dd040c9849L31-R30)
* [`src/fabric_cicd/_common/_fabric_endpoint.py`](diffhunk://#diff-df48b77e163b4a13c97f80408ad6640fca48ffdc60c19e085b4c73589933178cR20): Updated to use `FEATURE_FLAG` from the constants file. [[1]](diffhunk://#diff-df48b77e163b4a13c97f80408ad6640fca48ffdc60c19e085b4c73589933178cR20) [[2]](diffhunk://#diff-df48b77e163b4a13c97f80408ad6640fca48ffdc60c19e085b4c73589933178cL148-R149)
* [`src/fabric_cicd/_common/_validate_input.py`](diffhunk://#diff-b8a669357b50d9b4d808c610b3e17e12321db4f234259b95ba4350adcca0ecd8R17): Updated to use `ACCEPTED_ITEM_TYPES_UPN`, `ACCEPTED_ITEM_TYPES_NON_UPN`, and `VALID_GUID_REGEX` from the constants file. [[1]](diffhunk://#diff-b8a669357b50d9b4d808c610b3e17e12321db4f234259b95ba4350adcca0ecd8R17) [[2]](diffhunk://#diff-b8a669357b50d9b4d808c610b3e17e12321db4f234259b95ba4350adcca0ecd8L57-R59) [[3]](diffhunk://#diff-b8a669357b50d9b4d808c610b3e17e12321db4f234259b95ba4350adcca0ecd8L129-R110)

Deprecation and improvements in `FabricWorkspace` class:

* [`src/fabric_cicd/fabric_workspace.py`](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0R17-R44): Deprecated the `base_api_url` parameter and updated the class to use `DEFAULT_API_ROOT_URL` from the constants file. Added a warning for future deprecation of `base_api_url`. [[1]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0R17-R44) [[2]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L55-R55) [[3]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L74) [[4]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L95) [[5]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L115-R122) [[6]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L294-R305) [[7]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L317-R324) [[8]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L402-R414)

Other updates:

* [`src/fabric_cicd/publish.py`](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R15): Updated to use `FEATURE_FLAG` from the constants file. [[1]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R15) [[2]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704L101-R106)