### PR TITLE
Resolves #113 Parameterization Refactor fix logging

### DIFF
--- a/src/fabric_cicd/_parameter/_parameter.py
+++ b/src/fabric_cicd/_parameter/_parameter.py
@@ -163,6 +163,7 @@ class Parameter:
         if param_name not in self.environment_parameter:
             return False, "parameter not found"
 
+        msg_list = []
         param_count = len(self.environment_parameter[param_name])
         multiple_param = param_count > 1
         if multiple_param:
@@ -187,11 +188,14 @@ class Parameter:
                     return False, msg
                 logger.debug(PARAMETER_MSGS["passed"].format(msg))
 
-        # Validate environment keys in replace_value
-        if self.environment != "N/A":
-            is_valid, msg = self._validate_environment(param_name, parameter_dict["replace_value"])
-            if not is_valid:
-                logger.warning(msg)
+            # Validate environment keys in replace_value
+            if self.environment != "N/A":
+                is_valid, msg = self._validate_environment(param_name, parameter_dict["replace_value"])
+                if not is_valid:
+                    msg_list.append(msg)
+
+        if len(msg_list) > 0:
+            logger.warning(msg_list[0])
 
         return True, PARAMETER_MSGS["valid parameter"].format(param_name)
 

--- a/src/fabric_cicd/_parameter/_parameter.py
+++ b/src/fabric_cicd/_parameter/_parameter.py
@@ -91,7 +91,7 @@ class Parameter:
                 # Otherwise, return False with error message
                 logger.error(PARAMETER_MSGS["failed"].format(msg))
                 return False
-            logger.info(PARAMETER_MSGS["passed"].format(msg))
+            logger.debug(PARAMETER_MSGS["passed"].format(msg))
 
         # Return True if all validation steps pass
         logger.info("Parameter file validation passed")
@@ -115,7 +115,7 @@ class Parameter:
                     return False, validation_errors
 
                 self.environment_parameter = yaml.full_load(yaml_content)
-                logger.info(PARAMETER_MSGS["passed"].format("YAML content is valid"))
+                logger.debug(PARAMETER_MSGS["passed"].format("YAML content is valid"))
                 return True, PARAMETER_MSGS["valid load"]
         except yaml.YAMLError as e:
             return False, PARAMETER_MSGS["invalid load"].format(e)
@@ -166,16 +166,14 @@ class Parameter:
         param_count = len(self.environment_parameter[param_name])
         multiple_param = param_count > 1
         if multiple_param:
-            logger.info(f"{param_count} {param_name} parameters found")
+            logger.debug(f"{param_count} {param_name} parameters found")
 
         validation_steps = [
             ("keys", lambda param_dict: self._validate_parameter_keys(param_name, list(param_dict.keys()))),
             ("required values", lambda param_dict: self._validate_required_values(param_name, param_dict)),
             (
                 "replace_value",
-                lambda param_dict: self._validate_replace_value(
-                    param_name, param_dict["replace_value"], multiple_param, param_num
-                ),
+                lambda param_dict: self._validate_replace_value(param_name, param_dict["replace_value"]),
             ),
             ("optional values", lambda param_dict: self._validate_optional_values(param_name, param_dict)),
         ]
@@ -188,6 +186,12 @@ class Parameter:
                 if not is_valid:
                     return False, msg
                 logger.debug(PARAMETER_MSGS["passed"].format(msg))
+
+        # Validate environment keys in replace_value
+        if self.environment != "N/A":
+            is_valid, msg = self._validate_environment(param_name, parameter_dict["replace_value"])
+            if not is_valid:
+                logger.warning(msg)
 
         return True, PARAMETER_MSGS["valid parameter"].format(param_name)
 
@@ -218,17 +222,8 @@ class Parameter:
 
         return True, PARAMETER_MSGS["valid required values"].format(param_name)
 
-    def _validate_replace_value(
-        self, param_name: str, replace_value: dict, multiple_param: bool, param_num: int
-    ) -> tuple[bool, str]:
+    def _validate_replace_value(self, param_name: str, replace_value: dict) -> tuple[bool, str]:
         """Validate the replace_value dictionary."""
-        # Validate environment keys in replace_value
-        if self.environment != "N/A":
-            new_param_name = param_name + " " + str(param_num) if multiple_param else param_name
-            is_valid, msg = self._validate_environment(new_param_name, replace_value)
-            if not is_valid:
-                logger.warning(msg)
-
         # Validate replace_value dictionary values
         if param_name == "find_replace":
             is_valid, msg = self._validate_find_replace_replace_value(replace_value)
@@ -378,7 +373,7 @@ class Parameter:
     def _validate_file_path(self, input_path: str) -> tuple[bool, str]:
         """Validate the file path exists."""
         # Convert input path to Path object
-        input_path_new = process_input_path(self.repository_directory, input_path, validation=True)
+        input_path_new = process_input_path(self.repository_directory, input_path)
 
         # Check if the file path exists
         if not input_path_new.exists():

--- a/src/fabric_cicd/_parameter/_utils.py
+++ b/src/fabric_cicd/_parameter/_utils.py
@@ -109,7 +109,7 @@ def _check_structure(param_value: any) -> str:
 
 
 def process_input_path(
-    repository_directory: Path, input_path: Union[str, list[str], None], validation: bool = False
+    repository_directory: Path, input_path: Union[str, list[str], None]
 ) -> Union[Path, list[Path], None]:
     """
     Processes the input_path value according to its type.
@@ -117,40 +117,36 @@ def process_input_path(
     Args:
         repository_directory: The directory of the repository.
         input_path: The input path value to process (None value, a string value, or list of string values).
-        validation: A flag to specify if the run context is for validation.
     """
     if not input_path:
         return input_path
 
     if isinstance(input_path, list):
-        return [_convert_value_to_path(repository_directory, path, validation) for path in input_path]
+        return [_convert_value_to_path(repository_directory, path) for path in input_path]
 
-    return _convert_value_to_path(repository_directory, input_path, validation)
+    return _convert_value_to_path(repository_directory, input_path)
 
 
-def _convert_value_to_path(repository_directory: Path, input_path: str, validation: bool = False) -> Path:
+def _convert_value_to_path(repository_directory: Path, input_path: str) -> Path:
     """
     Converts the input_path string value to a Path object
     and resolves a relative path as an absolute path, if present.
     """
-    # Set the logger function based on the validation flag
-    logger_func = logger.warning if validation else logger.debug
-
     if not Path(input_path).is_absolute():
         # Strip leading slashes or backslashes
         normalized_path = Path(input_path.lstrip("/\\"))
         # Set the absolute path
         absolute_path = repository_directory / normalized_path
         if absolute_path.exists():
-            logger_func(f"Relative path '{input_path}' resolved as '{absolute_path}'")
+            logger.debug(f"Relative path '{input_path}' resolved as '{absolute_path}'")
         else:
-            logger_func(f"Relative path '{input_path}' does not exist, provide a valid path")
+            logger.debug(f"Relative path '{input_path}' does not exist, provide a valid path")
 
         return absolute_path
 
     absolute_path = Path(input_path)
     if not absolute_path.exists():
-        logger_func(f"Absolute path '{input_path}' does not exist, provide a valid path")
+        logger.debug(f"Absolute path '{input_path}' does not exist, provide a valid path")
 
     return absolute_path
 


### PR DESCRIPTION
This pull request includes several changes to improve logging and simplify the parameter validation code in the `fabric_cicd` module. The primary changes involve adjusting the logging levels and removing unnecessary parameters from functions.

### Logging Improvements:
* Changed logging level from `info` to `debug` for validation success messages in `_validate_parameter_file`, `_validate_load_parameters_to_dict`, and `_validate_parameter` methods in `src/fabric_cicd/_parameter/_parameter.py`. [[1]](diffhunk://#diff-663a11b92ff45fa9b30ab4086a71af3d0f87fce5a8da7967ff9a1197cc24d501L94-R94) [[2]](diffhunk://#diff-663a11b92ff45fa9b30ab4086a71af3d0f87fce5a8da7967ff9a1197cc24d501L118-R118) [[3]](diffhunk://#diff-663a11b92ff45fa9b30ab4086a71af3d0f87fce5a8da7967ff9a1197cc24d501L169-R176)

### Code Simplification:
* Removed the `validation` parameter from the `process_input_path` and `_convert_value_to_path` functions in `src/fabric_cicd/_parameter/_utils.py`, simplifying the code by eliminating conditional logging.
* Removed the `validation` parameter from the `process_input_path` function call in `_validate_file_path` method in `src/fabric_cicd/_parameter/_parameter.py`.
* Simplified the `_validate_replace_value` method by removing the `multiple_param` and `param_num` parameters and moving the environment validation logic to the `_validate_parameter` method in `src/fabric_cicd/_parameter/_parameter.py`.

### Additional Validation:
* Added a new validation step for environment keys in the `replace_value` dictionary within the `_validate_parameter` method in `src/fabric_cicd/_parameter/_parameter.py`.