### PR TITLE
Resolves #121 Publish Regex Exclusion

### DIFF
--- a/src/fabric_cicd/_common/_check_utils.py
+++ b/src/fabric_cicd/_common/_check_utils.py
@@ -109,3 +109,18 @@ def check_file_type(file_path: Path) -> str:
         if kind.mime.startswith("image/"):
             return "image"
     return "text"
+
+
+def check_regex(regex: str) -> re.Pattern:
+    """
+    Check if a regex pattern is valid and returns the pattern.
+
+    Args:
+        regex: The regex pattern to match.
+    """
+    try:
+        regex_pattern = re.compile(regex)
+    except Exception as e:
+        msg = f"An error occurred with the regex provided: {e}"
+        raise ValueError(msg) from e
+    return regex_pattern


### PR DESCRIPTION
This pull request introduces several changes to enhance the functionality of the Fabric CICD project, particularly focusing on regex validation and item publishing control. The most important changes include the addition of a regex validation function, integration of this function into item publishing workflows, and updates to method signatures to support regex-based exclusions.

### Regex Validation and Integration:

* [`src/fabric_cicd/_common/_check_utils.py`](diffhunk://#diff-ed3713e24dab32c1a8de7fc474ab489877af35d51d709421fe8a708d7dc6221fR112-R126): Added a new function `check_regex` to validate regex patterns and return the compiled pattern.
* [`src/fabric_cicd/fabric_workspace.py`](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0R18): Imported the `check_regex` function and integrated it into the `_publish_item` method to skip publishing items that match the exclusion regex. [[1]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0R18) [[2]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0R406-R412)

### Method Signature Updates:

* [`src/fabric_cicd/publish.py`](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704L21-R29): Updated the `publish_all_items` function to accept an optional `item_name_exclude_regex` parameter and log a warning if used. [[1]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704L21-R29) [[2]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R42-R47)
* [`src/fabric_cicd/publish.py`](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704L94-R103): Updated the `unpublish_all_orphan_items` function to use the `check_regex` function for regex validation.

### Miscellaneous Updates:

* [`src/fabric_cicd/fabric_workspace.py`](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0R113): Added the `publish_item_name_exclude_regex` attribute to the `FabricWorkspace` class.
* [`src/fabric_cicd/fabric_workspace.py`](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0R482): Added a return statement at the end of the `_publish_item` method.