### PR TITLE
Fix pre-build constants

### DIFF
--- a/docs/config/pre-build/update_item_types.py
+++ b/docs/config/pre-build/update_item_types.py
@@ -4,7 +4,7 @@ from pathlib import Path
 root_directory = Path(__file__).resolve().parent.parent.parent.parent
 sys.path.insert(0, str(root_directory / "src"))
 
-from fabric_cicd.constants import ACCEPTED_ITEM_TYPES
+from fabric_cicd.constants import ACCEPTED_ITEM_TYPES_UPN
 
 
 def on_page_markdown(markdown, **kwargs):
@@ -12,7 +12,7 @@ def on_page_markdown(markdown, **kwargs):
         start_index = markdown.index("<!--BEGIN-SUPPORTED-ITEM-TYPES-->\n") + len("<!--BEGIN-SUPPORTED-ITEM-TYPES-->\n")
         end_index = markdown.index("<!--END-SUPPORTED-ITEM-TYPES-->\n")
 
-        supported_item_types = ACCEPTED_ITEM_TYPES
+        supported_item_types = ACCEPTED_ITEM_TYPES_UPN
         markdown_content = "\n".join([f"-   {item}" for item in supported_item_types])
 
         new_markdown = markdown[:start_index] + markdown_content + markdown[end_index:]


### PR DESCRIPTION
This pull request includes a change to the `docs/config/pre-build/update_item_types.py` file to update the item types used in the documentation.

* Updated the import and usage of item types from `ACCEPTED_ITEM_TYPES` to `ACCEPTED_ITEM_TYPES_UPN` to reflect the new constant name.