### PR TITLE
Fixes #156 - Expand type hints support

### DIFF
--- a/src/fabric_cicd/_common/_check_utils.py
+++ b/src/fabric_cicd/_common/_check_utils.py
@@ -3,6 +3,8 @@
 
 """Utility functions for checking file types and versions."""
 
+from __future__ import annotations
+
 import logging
 import re
 from importlib.metadata import version as lib_version


### PR DESCRIPTION
This pull request includes a small change to the `src/fabric_cicd/_common/_check_utils.py` file. The change adds a future import statement to support forward compatibility with type annotations. 

* [`src/fabric_cicd/_common/_check_utils.py`](diffhunk://#diff-ed3713e24dab32c1a8de7fc474ab489877af35d51d709421fe8a708d7dc6221fR6-R7): Added `from __future__ import annotations` to support forward compatibility with type annotations.