### PR TITLE
Fixes #186 Workspace Id not updated in data pipelines

### DIFF
--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -299,11 +299,16 @@ class FabricWorkspace:
         # Replace all instances of default feature branch workspace ID with target workspace ID
         target_workspace_id = self.workspace_id
 
-        workspace_id_match = re.search(WORKSPACE_ID_REFERENCE_REGEX, raw_file)
-        if workspace_id_match:
-            workspace_id = workspace_id_match.group(2)
-            if workspace_id == DEFAULT_WORKSPACE_ID:
-                raw_file = raw_file.replace(DEFAULT_WORKSPACE_ID, target_workspace_id)
+        # Use re.sub to replace all matches
+        raw_file = re.sub(
+            WORKSPACE_ID_REFERENCE_REGEX,
+            lambda match: (
+                match.group(0).replace(DEFAULT_WORKSPACE_ID, target_workspace_id)
+                if match.group(2) == DEFAULT_WORKSPACE_ID
+                else match.group(0)
+            ),
+            raw_file,
+        )
 
         # For DataPipeline item, additional replacements may be required
         if item_type == "DataPipeline":


### PR DESCRIPTION
This pull request includes an enhancement to the `src/fabric_cicd/fabric_workspace.py` file to improve the efficiency of replacing workspace IDs in a given file. The most important change is the modification of the `_replace_workspace_ids` method to use `re.sub` for more efficient and concise replacement of default workspace IDs.

Codebase simplification:

* [`src/fabric_cicd/fabric_workspace.py`](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L302-R311): Modified the `_replace_workspace_ids` method to use `re.sub` for replacing all instances of the default feature branch workspace ID with the target workspace ID. This change simplifies the code and ensures all matches are replaced in one operation.