### PR TITLE
Resolves #173 - Onboard New Environment API

### DIFF
--- a/docs/how_to/optional_feature.md
+++ b/docs/how_to/optional_feature.md
@@ -6,10 +6,11 @@ fabric-cicd has an expected default flow; however, there will always be cases wh
 
 For scenarios that aren't supported by default, fabric-cicd offers `feature-flags`. Below is an exhaustive list of currently supported features.
 
-| Flag Name                    | Description                                         |
-| ---------------------------- | --------------------------------------------------- |
-| `enable_lakehouse_unpublish` | Set to enable the deletion of Lakehouses            |
-| `disable_print_identity`     | Set to disable printing the executing identity name |
+| Flag Name                     | Description                                         |
+| ----------------------------- | --------------------------------------------------- |
+| `enable_lakehouse_unpublish`  | Set to enable the deletion of Lakehouses            |
+| `disable_print_identity`      | Set to disable printing the executing identity name |
+| `disable_legacy_environments` | Set to migrate to new Environment API               |
 
 <span class="md-h3-nonanchor">Example</span>
 
@@ -17,6 +18,7 @@ For scenarios that aren't supported by default, fabric-cicd offers `feature-flag
 from fabric_cicd import append_feature_flag
 append_feature_flag("enable_lakehouse_unpublish")
 append_feature_flag("disable_print_identity")
+append_feature_flag("disable_legacy_environments")
 ```
 
 ## Debugging

--- a/src/fabric_cicd/_common/_fabric_endpoint.py
+++ b/src/fabric_cicd/_common/_fabric_endpoint.py
@@ -182,7 +182,7 @@ def _handle_response(
         url = response.headers.get("Location")
         method = "GET"
         body = "{}"
-        response_json = response.json()
+        response_json = response.json() if response.content else None
 
         if long_running:
             status = response_json.get("status")
@@ -204,8 +204,8 @@ def _handle_response(
             else:
                 handle_retry(
                     attempt=iteration_count - 1,
-                    base_delay=0.5,
-                    response_retry_after=retry_after,
+                    base_delay=kwargs.get("base_delay", 0.5),
+                    response_retry_after=kwargs.get("retry_after", retry_after),
                     max_retries=kwargs.get("max_retries", 5),
                     prepend_message="Operation in progress.",
                 )

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -416,7 +416,10 @@ class FabricWorkspace:
         metadata_body = {"displayName": item_name, "type": item_type}
 
         # Only shell deployment, no definition support
-        shell_only_publish = item_type in constants.SHELL_ONLY_PUBLISH
+        if "disable_legacy_environments" in constants.FEATURE_FLAG:
+            shell_only_publish = item_type in ["Lakehouse"]
+        else:  # TODO: remove this when legacy environments are deprecated
+            shell_only_publish = item_type in ["Environment", "Lakehouse"]
 
         if kwargs.get("creation_payload"):
             creation_payload = {"creationPayload": kwargs["creation_payload"]}


### PR DESCRIPTION
This pull request introduces several changes to improve the handling of feature flags and the management of legacy environments in the `fabric-cicd` project. The most important changes include updates to documentation, enhancements to the response handling in `_fabric_endpoint.py`, and modifications to the environment publishing process.

### Documentation updates:
* [`docs/how_to/optional_feature.md`](diffhunk://#diff-c6d5a0fcefe940477d9234afcbed07e3a42c359ef09ebf0093905ea3c9c7f8f1L10-R21): Added a new feature flag `disable_legacy_environments` to the list of supported features and provided an example usage.

### Response handling improvements:
* [`src/fabric_cicd/_common/_fabric_endpoint.py`](diffhunk://#diff-df48b77e163b4a13c97f80408ad6640fca48ffdc60c19e085b4c73589933178cL185-R185): Improved the `_handle_response` method to handle empty response content and added support for customizable retry parameters. [[1]](diffhunk://#diff-df48b77e163b4a13c97f80408ad6640fca48ffdc60c19e085b4c73589933178cL185-R185) [[2]](diffhunk://#diff-df48b77e163b4a13c97f80408ad6640fca48ffdc60c19e085b4c73589933178cL207-R208)

### Environment publishing enhancements:
* [`src/fabric_cicd/_items/_environment.py`](diffhunk://#diff-d21d8d1ab1b91c6581949c76a61d12d3f838509ef127b4ae5144feb5bc23bd8aL13-R13): Added a new import for `constants` and introduced logic to handle the `disable_legacy_environments` feature flag during the environment publishing process. Also, added a new method `_publish_environment` to publish compute settings and libraries for a given environment item. [[1]](diffhunk://#diff-d21d8d1ab1b91c6581949c76a61d12d3f838509ef127b4ae5144feb5bc23bd8aL13-R13) [[2]](diffhunk://#diff-d21d8d1ab1b91c6581949c76a61d12d3f838509ef127b4ae5144feb5bc23bd8aR38-R74)
* [`src/fabric_cicd/fabric_workspace.py`](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L419-R422): Updated the `_publish_item` method to respect the `disable_legacy_environments` feature flag when determining shell-only publishing items.