### PR TITLE
Onboard Workspace Folders

### DIFF
--- a/src/fabric_cicd/_common/_item.py
+++ b/src/fabric_cicd/_common/_item.py
@@ -22,6 +22,7 @@ class Item:
     logical_id: str = field(default="")
     path: Path = field(default_factory=Path)
     item_files: list = field(default_factory=list)
+    folder_id: str = field(default="")
     IMMUTABLE_FIELDS: ClassVar[set] = {"type", "name", "description"}
 
     def __setattr__(self, key: str, value: any) -> None:
@@ -36,6 +37,11 @@ class Item:
             msg = f"item {key} is immutable"
             raise AttributeError(msg)
         super().__setattr__(key, value)
+
+    @property
+    def relative_path(self) -> str:
+        """Return the relative path of the file."""
+        return str(self.file_path.relative_to(self.item_path).as_posix())
 
     def collect_item_files(self) -> None:
         """Collect all files in the item path."""

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -115,8 +115,6 @@ class FabricWorkspace:
 
         # Initialize dictionaries to store repository and deployed items
         self._refresh_parameter_file()
-        self._refresh_deployed_items()
-        self._refresh_repository_items()
 
     def _refresh_parameter_file(self) -> None:
         """Load parameters if file is present."""
@@ -173,6 +171,9 @@ class FabricWorkspace:
                 item_name = item_metadata["metadata"]["displayName"]
                 item_logical_id = item_metadata["config"]["logicalId"]
                 item_path = directory
+                relative_path = f"/{directory.relative_to(self.repository_directory).as_posix()}"
+                relative_parent_path = "/".join(relative_path.split("/")[:-1])
+                item_folder_id = self.repository_folders.get(relative_parent_path, "")
 
                 # Get the GUID if the item is already deployed
                 item_guid = self.deployed_items.get(item_type, {}).get(item_name, Item("", "", "", "")).guid
@@ -182,8 +183,15 @@ class FabricWorkspace:
 
                 # Add the item to the repository_items dictionary
                 self.repository_items[item_type][item_name] = Item(
-                    item_type, item_name, item_description, item_guid, item_logical_id, item_path
+                    type=item_type,
+                    name=item_name,
+                    description=item_description,
+                    guid=item_guid,
+                    logical_id=item_logical_id,
+                    path=item_path,
+                    folder_id=item_folder_id,
                 )
+
                 self.repository_items[item_type][item_name].collect_item_files()
 
     def _refresh_deployed_items(self) -> None:
@@ -199,13 +207,20 @@ class FabricWorkspace:
             item_description = item["description"]
             item_name = item["displayName"]
             item_guid = item["id"]
+            item_folder_id = item.get("folderId", None)
 
             # Add an empty dictionary if the item type hasn't been added yet
             if item_type not in self.deployed_items:
                 self.deployed_items[item_type] = {}
 
             # Add item details to the deployed_items dictionary
-            self.deployed_items[item_type][item_name] = Item(item_type, item_name, item_description, item_guid)
+            self.deployed_items[item_type][item_name] = Item(
+                type=item_type,
+                name=item_name,
+                description=item_description,
+                guid=item_guid,
+                folder_id=item_folder_id,
+            )
 
     def _replace_logical_ids(self, raw_file: str) -> str:
         """
@@ -392,6 +407,8 @@ class FabricWorkspace:
         is_deployed = bool(item_guid)
 
         if not is_deployed:
+            combined_body = {**combined_body, **{"folderId": item.folder_id}}
+
             # Create a new item if it does not exist
             # https://learn.microsoft.com/en-us/rest/api/fabric/core/items/create-item
             item_create_response = self.endpoint.invoke(
@@ -422,6 +439,16 @@ class FabricWorkspace:
                 max_retries=max_retries,
             )
 
+        if is_deployed and self.deployed_items[item_type][item_name].folder_id != item.folder_id:
+            # Move the item to the correct folder if it has been moved
+            # https://learn.microsoft.com/en-us/rest/api/fabric/core/items/move-item
+            self.endpoint.invoke(
+                method="POST",
+                url=f"{self.base_api_url}/items/{item_guid}/move",
+                body={"targetFolderId": f"{item.folder_id}"},
+                max_retries=max_retries,
+            )
+
         # skip_publish_logging provided in kwargs to suppress logging if further processing is to be done
         if not kwargs.get("skip_publish_logging", False):
             logger.info("Published")
@@ -447,3 +474,163 @@ class FabricWorkspace:
             logger.info("Unpublished")
         except Exception as e:
             logger.warning(f"Failed to unpublish {item_type} '{item_name}'.  Raw exception: {e}")
+
+    def _refresh_deployed_folders(self) -> None:
+        """
+        Converts the folder list payload into a structure of folder name and their ids
+
+        output should be like this:
+        {
+            "/Pipeline": "323eaa75-d70b-498c-8544-6c4219bf336e",
+            "/Notebook": "f802fd90-c70e-4d77-b079-538f617646d3",
+            "/Notebook/Processing": "36ed1a63-be82-4a7a-9364-2e4ff3a66b31"
+        }
+
+        """
+        self.deployed_folders = {}
+        request_url = f"{self.base_api_url}/folders"
+        folders = []
+
+        while request_url:
+            # https://learn.microsoft.com/en-us/rest/api/fabric/core/folders/list-folders
+            response = self.endpoint.invoke(method="GET", url=request_url)
+
+            # Handle cases where the response body is empty
+            folder_response = response["body"].get("value", [])
+            folders.extend(folder for folder in folder_response)
+
+            request_url = response["header"].get("continuationUri", None)
+
+        # Create a lookup table for folders by their ID
+        folder_lookup = {folder["id"]: folder for folder in folders}
+
+        # Build the folder hierarchy
+        folder_hierarchy = {}
+
+        def get_full_path(folder: dict) -> str:
+            """Recursively build the full path for a folder"""
+            parent_id = folder.get("parentFolderId")
+            if parent_id:
+                parent_folder = folder_lookup.get(parent_id)
+                if parent_folder:
+                    return f"{get_full_path(parent_folder)}/{folder['displayName']}"
+            return f"/{folder['displayName']}"
+
+        for folder in folders:
+            full_path = get_full_path(folder)
+            folder_hierarchy[full_path] = folder["id"]
+
+        self.deployed_folders = folder_hierarchy
+
+    def _refresh_repository_folders(self) -> dict:
+        """
+        Converts the folder list payload into a structure of folder name and their ids,
+        skipping empty folders or folders that only contain other empty folders.
+
+        output should be like this:
+        {
+            "/Pipeline": "",
+            "/Notebook": "",
+            "/Notebook/Processing": ""
+        }
+        """
+        self.repository_folders = {}
+
+        root_path = self.repository_directory
+        folder_hierarchy = {}
+
+        def is_empty(folder: Path) -> bool:
+            """Checks if a folder is empty or contains only other empty folders (recursively)."""
+            for item in folder.iterdir():
+                if item.is_file():
+                    return False
+                if item.is_dir() and not is_empty(item):
+                    return False
+            return True
+
+        # Walk through the directory structure
+        for folder in root_path.rglob("*"):
+            if folder.is_dir():  # Only process directories
+                # Check if a `.platform` file exists directly beneath the folder
+                if (folder / ".platform").exists():
+                    # Skip this folder and its subfolders
+                    continue
+
+                # Check if any parent folder has already been excluded
+                if any((parent / ".platform").exists() for parent in folder.parents if parent != root_path):
+                    continue
+
+                # Skip empty folders or folders containing only empty subfolders
+                if is_empty(folder):
+                    continue
+
+                # Build the relative path from the root and convert it to the desired format
+                relative_path = f"/{folder.relative_to(root_path).as_posix()}"
+                folder_hierarchy[relative_path] = ""
+
+        self.repository_folders = folder_hierarchy
+
+    def _publish_folders(self) -> None:
+        """Publishes all folders from the repository."""
+        # Sort folders by the number of '/' in their paths (ascending order)
+        sorted_folders = sorted(self.repository_folders.keys(), key=lambda path: path.count("/"))
+        logger.info("Publishing Workspace Folders")
+        for folder_path in sorted_folders:
+            if folder_path in self.deployed_folders:
+                # Folder already deployed, update local hierarchy
+                self.repository_folders[folder_path] = self.deployed_folders[folder_path]
+                logger.debug(f"Folder exists: {folder_path}")
+                continue
+
+            # Publish the folder
+            folder_name = folder_path.split("/")[-1]
+            folder_parent_path = "/".join(folder_path.split("/")[:-1])
+            folder_parent_id = self.repository_folders.get(folder_parent_path, None)
+
+            request_body = {"displayName": folder_name}
+            if folder_parent_id:
+                request_body["parentFolderId"] = folder_parent_id
+
+            request_url = f"{self.base_api_url}/folders"
+            response = self.endpoint.invoke(method="POST", url=request_url, body=request_body)
+
+            # Update local hierarchy with the new folder ID
+            self.repository_folders[folder_path] = response["body"]["id"]
+            logger.debug(f"Published folder: {folder_path}")
+
+        logger.info("Published")
+
+    def _unpublish_folders(self) -> None:
+        """Unublishes all empty folders in workspace."""
+        # Sort folders by the number of '/' in their paths (descending order)
+        sorted_folder_ids = [
+            self.deployed_folders[key]
+            for key in sorted(self.deployed_folders.keys(), key=lambda path: path.count("/"), reverse=True)
+        ]
+
+        logger.info("Unpublishing Workspace Folders")
+
+        ## any folder that is not in folderid_dict is an orphaned folder
+
+        # Get folders with items
+        deployed_folder_ids_with_items = []
+
+        for items in self.deployed_items.values():
+            for item in items.values():
+                deployed_folder_ids_with_items.append(item.folder_id)
+
+        # Pop all folders
+
+        for folder_id in sorted_folder_ids:
+            if folder_id not in deployed_folder_ids_with_items:
+                # Folder deployed, but not in repository
+
+                # Delete the folder from the workspace
+                # https://learn.microsoft.com/en-us/rest/api/fabric/core/folders/delete-folder
+                try:
+                    self.endpoint.invoke(method="DELETE", url=f"{self.base_api_url}/folders/{folder_id}")
+                    logger.debug(f"Unpublished folder: {folder_id}")
+                except Exception as e:
+                    logger.warning(f"Failed to unpublish folder {folder_id}.  Raw exception: {e}")
+
+        logger.info("Unpublished")

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -39,6 +39,13 @@ def publish_all_items(fabric_workspace_obj: FabricWorkspace, item_name_exclude_r
         >>> publish_all_items(workspace)
     """
     fabric_workspace_obj = validate_fabric_workspace_obj(fabric_workspace_obj)
+
+    fabric_workspace_obj._refresh_deployed_folders()
+    fabric_workspace_obj._refresh_repository_folders()
+    fabric_workspace_obj._publish_folders()
+    fabric_workspace_obj._refresh_deployed_items()
+    fabric_workspace_obj._refresh_repository_items()
+
     if item_name_exclude_regex:
         logger.warning(
             "Using item_name_exclude_regex is risky as it can prevent needed dependencies from being deployed.  Use at your own risk."
@@ -106,6 +113,7 @@ def unpublish_all_orphan_items(fabric_workspace_obj: FabricWorkspace, item_name_
     regex_pattern = check_regex(item_name_exclude_regex)
 
     fabric_workspace_obj._refresh_deployed_items()
+    fabric_workspace_obj._refresh_repository_items()
     _print_header("Unpublishing Orphaned Items")
 
     # Define order to unpublish items
@@ -156,6 +164,9 @@ def unpublish_all_orphan_items(fabric_workspace_obj: FabricWorkspace, item_name_
 
         for item_name in to_delete_list:
             fabric_workspace_obj._unpublish_item(item_name=item_name, item_type=item_type)
+
+    fabric_workspace_obj._refresh_deployed_items()
+    fabric_workspace_obj._unpublish_folders()
 
 
 def _print_header(message: str) -> None:

--- a/tests/test_fabric_workspace.py
+++ b/tests/test_fabric_workspace.py
@@ -90,14 +90,24 @@ def patched_fabric_workspace(mock_endpoint):
         refresh_items_patch = patch.object(
             FabricWorkspace, "_refresh_deployed_items", new=lambda self: setattr(self, "deployed_items", {})
         )
+        refresh_folders_patch = patch.object(
+            FabricWorkspace, "_refresh_deployed_folders", new=lambda self: setattr(self, "deployed_folders", {})
+        )
 
-        with fabric_endpoint_patch, refresh_items_patch:
-            return FabricWorkspace(
+        with fabric_endpoint_patch, refresh_items_patch, refresh_folders_patch:
+            workspace = FabricWorkspace(
                 workspace_id=workspace_id,
                 repository_directory=repository_directory,
                 item_type_in_scope=item_type_in_scope,
                 **kwargs,
             )
+            # Call refresh methods to populate workspace data
+            workspace._refresh_deployed_folders()
+            workspace._refresh_repository_folders()
+            workspace._refresh_deployed_items()
+            workspace._refresh_repository_items()
+
+            return workspace
 
     return _create_workspace
 


### PR DESCRIPTION
This pull request includes significant updates to the `fabric_cicd` module to enhance folder management and item publishing processes. The changes introduce new methods for handling folders and update existing methods to incorporate folder-related logic.

### Enhancements to folder management:

* [`src/fabric_cicd/fabric_workspace.py`](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0R477-R636): Added methods `_refresh_deployed_folders`, `_refresh_repository_folders`, `_publish_folders`, and `_unpublish_folders` to manage folder structures and synchronization between the repository and deployed environments.
* [`src/fabric_cicd/publish.py`](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R42-R48): Updated `publish_all_items` and `unpublish_all_orphan_items` functions to refresh and publish/unpublish folders as part of the item publishing process. [[1]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R42-R48) [[2]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R116) [[3]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R168-R170)

### Updates to item handling:

* [`src/fabric_cicd/_common/_item.py`](diffhunk://#diff-17da534a20198c5129cf833667e9b49cbee24482df11bfff019a2e6134bd8fc8R25): Added a `folder_id` attribute to the `Item` class and a `relative_path` property to compute the relative path of an item. [[1]](diffhunk://#diff-17da534a20198c5129cf833667e9b49cbee24482df11bfff019a2e6134bd8fc8R25) [[2]](diffhunk://#diff-17da534a20198c5129cf833667e9b49cbee24482df11bfff019a2e6134bd8fc8R41-R45)
* [`src/fabric_cicd/fabric_workspace.py`](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0R174-R176): Modified `_refresh_repository_items` and `_refresh_deployed_items` methods to include `folder_id` when creating `Item` instances. [[1]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0R174-R176) [[2]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0R210-R223)
* [`src/fabric_cicd/fabric_workspace.py`](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0R410-R411): Updated `_publish_item` method to handle folder IDs when creating or moving items. [[1]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0R410-R411) [[2]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0R442-R451)

### Test updates:

* [`tests/test_fabric_workspace.py`](diffhunk://#diff-38a69298c91571d1f1a72285d551b8e0ceaebe1ba66bd7bfc7a537620b4bfa3aR93-R110): Added patches for `_refresh_deployed_folders` in test setup and ensured folder refresh methods are called to populate workspace data.