### PR TITLE
Fix Doc Publish

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -35,7 +35,7 @@ jobs:
                   git config user.email github-actions[bot]@users.noreply.github.com
                   git fetch --no-tags --prune --depth=1 origin +refs/heads/gh-pages:refs/remotes/origin/gh-pages
                   uv sync
-                  VERSION=$(python -c 'from fabric_cicd.constants import VERSION; print(VERSION)')
+                  VERSION=$(grep -oP '(?<=^VERSION = ").*(?=")' src/fabric_cicd/constants.py)
                   uv run mike deploy \
                     --update-aliases \
                     --branch gh-pages \


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/gh-pages.yml` file to improve the method of extracting the `VERSION` variable.

* [`.github/workflows/gh-pages.yml`](diffhunk://#diff-c04119feaeffc2c216f069aec66797f2f839a2074287060698e3a2440dec8d45L38-R38): Changed the method of extracting the `VERSION` variable to use `grep` instead of a Python command.