### PR TITLE
updates to support, variable library support in parameters and a some…

### DIFF
--- a/src/fabric_cicd/_parameter/_parameter.py
+++ b/src/fabric_cicd/_parameter/_parameter.py
@@ -36,6 +36,10 @@ class Parameter:
             "maximum": {"instance_pool_id", "replace_value", "item_name"},
         },
         "spark_pool_replace_value": {"type", "name"},
+        "variable_libraries": {
+            "minimum": {"library_name", "variables"},
+            "maximum": {"library_name", "variables"},
+        },
     }
 
     def __init__(
@@ -151,7 +155,7 @@ class Parameter:
 
     def _validate_parameter_names(self) -> tuple[bool, str]:
         """Validate the parameter names in the parameter dictionary."""
-        params = list(self.PARAMETER_KEYS.keys())[:2]
+        params = list(self.PARAMETER_KEYS.keys())[:4]
         for param in self.environment_parameter:
             if param not in params:
                 return False, constants.PARAMETER_MSGS["invalid name"].format(param)

--- a/src/fabric_cicd/_parameter/_utils.py
+++ b/src/fabric_cicd/_parameter/_utils.py
@@ -19,6 +19,35 @@ import fabric_cicd.constants as constants
 logger = logging.getLogger(__name__)
 
 
+def replace_key_value(
+    file_content: Union[str, dict, list], replacements: dict, key_check: str = "name", keys_to_update: list = None
+) -> Union[str, dict, list]:
+    """
+    Recursively replaces keys or values in a file's content based on the replacements dictionary.
+
+    Args:
+        file_content: The content of the file as a string, dict, or list.
+        replacements: A dictionary where keys are the values to find and values are the replacements.
+        key_check: The key to check in the replacements dictionary.
+        keys_to_update: A list of keys to update in the file content.
+
+    Returns:
+        Updated file content with replacements applied.
+    """
+    if keys_to_update is None:
+        keys_to_update = []
+    if isinstance(file_content, dict):
+        for content_variables in replacements:
+            if file_content.get(key_check) == content_variables[key_check]:
+                for update_key in keys_to_update:
+                    file_content[update_key] = content_variables.get(update_key)
+        return file_content
+    if isinstance(file_content, list):
+        return [replace_key_value(item, replacements, key_check, keys_to_update) for item in file_content]
+    # If the content is not a string, dict, or list, return it as is
+    return file_content
+
+
 def replace_variables_in_parameter_file(raw_file: str) -> str:
     """
     A function to replace tokens in the parameter.yml file with environment variables.


### PR DESCRIPTION
I have added the ability to define cicd parameterization for Variable Libraries, and a somewhat generic approach to key value replacement for item definitions that are defined as json. 

the yaml for variable libs would look like

`variable_libraries:
  - PPE:
      - library_name: dsi-vars
        variables:
          - name: var_test
            note: ''
            type: String
            value: test_value_again
          - name: var_string
            note: ''
            type: String
            value: test_string_var`

PR is lacking documentation updates, but wanted to get it in front of you to see if it was something you wanted to pursue, otherwise I will just use it myself