### PR TITLE
Resolves #221 & #222 - Fix Subfolders in Root

### DIFF
--- a/devtools/debug_local.py
+++ b/devtools/debug_local.py
@@ -38,8 +38,6 @@ item_type_in_scope = [
     "Lakehouse",
     "VariableLibrary",
     "DataPipeline",
-    "Notebook",
-    "Environment",
     "SemanticModel",
     "Report",
 ]
@@ -64,8 +62,8 @@ target_workspace = FabricWorkspace(
 
 # Uncomment to publish
 # Publish all items defined in item_type_in_scope
-# publish_all_items(target_workspace)
+publish_all_items(target_workspace)
 
 # Uncomment to unpublish
 # Unpublish all items defined in scope not found in repository
-# unpublish_all_orphan_items(target_workspace, item_name_exclude_regex=r"^DEBUG.*")
+unpublish_all_orphan_items(target_workspace, item_name_exclude_regex=r"^DEBUG.*")

--- a/devtools/debug_local.py
+++ b/devtools/debug_local.py
@@ -38,6 +38,8 @@ item_type_in_scope = [
     "Lakehouse",
     "VariableLibrary",
     "DataPipeline",
+    "Notebook",
+    "Environment",
     "SemanticModel",
     "Report",
 ]
@@ -62,8 +64,8 @@ target_workspace = FabricWorkspace(
 
 # Uncomment to publish
 # Publish all items defined in item_type_in_scope
-publish_all_items(target_workspace)
+# publish_all_items(target_workspace)
 
 # Uncomment to unpublish
 # Unpublish all items defined in scope not found in repository
-unpublish_all_orphan_items(target_workspace, item_name_exclude_regex=r"^DEBUG.*")
+# unpublish_all_orphan_items(target_workspace, item_name_exclude_regex=r"^DEBUG.*")

--- a/docs/how_to/optional_feature.md
+++ b/docs/how_to/optional_feature.md
@@ -14,8 +14,6 @@ For scenarios that aren't supported by default, fabric-cicd offers `feature-flag
 | `enable_environment_variable_replacement` | Set to enable the use of pipeline variables          |
 | `disable_workspace_folder_publish`        | Set to disable deploying workspace sub folders       |
 
-enable_workspace_folder_publish
-
 <span class="md-h3-nonanchor">Example</span>
 
 ```python

--- a/docs/how_to/optional_feature.md
+++ b/docs/how_to/optional_feature.md
@@ -7,11 +7,14 @@ fabric-cicd has an expected default flow; however, there will always be cases wh
 For scenarios that aren't supported by default, fabric-cicd offers `feature-flags`. Below is an exhaustive list of currently supported features.
 
 | Flag Name                                 | Description                                          |
-| ------------------------------------------| ---------------------------------------------------- |
+| ----------------------------------------- | ---------------------------------------------------- |
 | `enable_lakehouse_unpublish`              | Set to enable the deletion of Lakehouses             |
 | `disable_print_identity`                  | Set to disable printing the executing identity name  |
 | `enable_shortcut_publish`                 | Set to enable deploying shortcuts with the lakehouse |
 | `enable_environment_variable_replacement` | Set to enable the use of pipeline variables          |
+| `disable_workspace_folder_publish`        | Set to disable deploying workspace sub folders       |
+
+enable_workspace_folder_publish
 
 <span class="md-h3-nonanchor">Example</span>
 

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -40,9 +40,11 @@ def publish_all_items(fabric_workspace_obj: FabricWorkspace, item_name_exclude_r
     """
     fabric_workspace_obj = validate_fabric_workspace_obj(fabric_workspace_obj)
 
-    fabric_workspace_obj._refresh_deployed_folders()
-    fabric_workspace_obj._refresh_repository_folders()
-    fabric_workspace_obj._publish_folders()
+    if "disable_workspace_folder_publish" not in constants.FEATURE_FLAG:
+        fabric_workspace_obj._refresh_deployed_folders()
+        fabric_workspace_obj._refresh_repository_folders()
+        fabric_workspace_obj._publish_folders()
+
     fabric_workspace_obj._refresh_deployed_items()
     fabric_workspace_obj._refresh_repository_items()
 
@@ -166,7 +168,8 @@ def unpublish_all_orphan_items(fabric_workspace_obj: FabricWorkspace, item_name_
             fabric_workspace_obj._unpublish_item(item_name=item_name, item_type=item_type)
 
     fabric_workspace_obj._refresh_deployed_items()
-    fabric_workspace_obj._unpublish_folders()
+    if "disable_workspace_folder_publish" not in constants.FEATURE_FLAG:
+        fabric_workspace_obj._unpublish_folders()
 
 
 def _print_header(message: str) -> None:


### PR DESCRIPTION
This pull request introduces a new feature flag `disable_workspace_folder_publish` and updates the codebase to support this feature. The changes span across several files to ensure that the new flag is properly integrated and functional.

### Feature Flag Integration:

* [`docs/how_to/optional_feature.md`](diffhunk://#diff-c6d5a0fcefe940477d9234afcbed07e3a42c359ef09ebf0093905ea3c9c7f8f1L10-R17): Added `disable_workspace_folder_publish` to the list of feature flags.

### Codebase Updates:

* `src/fabric_cicd/fabric_workspace.py`: 
  - Initialized new dictionaries (`repository_folders`, `repository_items`, `deployed_folders`, `deployed_items`) in the `__init__` method.
  - Updated `_refresh_repository_items` method to check for the `disable_workspace_folder_publish` flag and adjust the item folder ID accordingly.
  - Modified `_publish_item` method to include a condition for the `disable_workspace_folder_publish` flag.
  - Refactored `_refresh_repository_folders` method to improve directory walking and folder hierarchy building, with additional checks for the `disable_workspace_folder_publish` flag.

* `src/fabric_cicd/publish.py`: 
  - Added checks for the `disable_workspace_folder_publish` flag in `publish_all_items` and `unpublish_all_orphan_items` methods to conditionally refresh and publish/unpublish folders. [[1]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R43-R47) [[2]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R171)