### PR TITLE
Fixes #236 - Folder Move Occurring Every Publish

### DIFF
--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -459,7 +459,7 @@ class FabricWorkspace:
                     max_retries=max_retries,
                 )
                 logger.debug(
-                    f"Moved {item_guid} from folder_id {self.deployed_items[item_type][item_name].folder_id} to folder_id {item.folder_id}"
+                    f"Moved {item.id} from folder_id {self.deployed_items[item_type][item_name].folder_id} to folder_id {item.folder_id}"
                 )
 
         # skip_publish_logging provided in kwargs to suppress logging if further processing is to be done

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -459,7 +459,7 @@ class FabricWorkspace:
                     max_retries=max_retries,
                 )
                 logger.debug(
-                    f"Moved {item.id} from folder_id {self.deployed_items[item_type][item_name].folder_id} to folder_id {item.folder_id}"
+                    f"Moved {item_guid} from folder_id {self.deployed_items[item_type][item_name].folder_id} to folder_id {item.folder_id}"
                 )
 
         # skip_publish_logging provided in kwargs to suppress logging if further processing is to be done

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -217,7 +217,7 @@ class FabricWorkspace:
             item_description = item["description"]
             item_name = item["displayName"]
             item_guid = item["id"]
-            item_folder_id = item.get("folderId", None)
+            item_folder_id = item.get("folderId", "")
 
             # Add an empty dictionary if the item type hasn't been added yet
             if item_type not in self.deployed_items:
@@ -457,6 +457,9 @@ class FabricWorkspace:
                     url=f"{self.base_api_url}/items/{item_guid}/move",
                     body={"targetFolderId": f"{item.folder_id}"},
                     max_retries=max_retries,
+                )
+                logger.debug(
+                    f"Moved {item_guid} from folder_id {self.deployed_items[item_type][item_name].folder_id} to folder_id {item.folder_id}"
                 )
 
         # skip_publish_logging provided in kwargs to suppress logging if further processing is to be done


### PR DESCRIPTION
This pull request includes changes to the `src/fabric_cicd/fabric_workspace.py` file to improve the handling of folder IDs and add debug logging for item movements. The most important changes include updating the default value for `item_folder_id` and adding a debug log statement when items are moved.

Improvements to folder ID handling:

* [`src/fabric_cicd/fabric_workspace.py`](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L220-R220): Changed the default value for `item_folder_id` from `None` to an empty string in the `_refresh_deployed_items` method.

Enhancements to logging:

* [`src/fabric_cicd/fabric_workspace.py`](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0R461-R463): Added a debug log statement in the `_publish_item` method to log the movement of items between folders, including the item GUID and folder IDs.