### PR TITLE
Resolves #237 - Reduce Environment Publish Time

### DIFF
--- a/src/fabric_cicd/_items/__init__.py
+++ b/src/fabric_cicd/_items/__init__.py
@@ -5,7 +5,7 @@ from fabric_cicd._items._datapipeline import (
     publish_datapipelines,
     sort_datapipelines,
 )
-from fabric_cicd._items._environment import publish_environments
+from fabric_cicd._items._environment import check_environment_publish_state, publish_environments
 from fabric_cicd._items._lakehouse import publish_lakehouses
 from fabric_cicd._items._mirroreddatabase import publish_mirroreddatabase
 from fabric_cicd._items._notebook import publish_notebooks
@@ -14,6 +14,7 @@ from fabric_cicd._items._semanticmodel import publish_semanticmodels
 from fabric_cicd._items._variablelibrary import publish_variablelibraries
 
 __all__ = [
+    "check_environment_publish_state",
     "publish_datapipelines",
     "publish_environments",
     "publish_lakehouses",

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -80,6 +80,11 @@ def publish_all_items(fabric_workspace_obj: FabricWorkspace, item_name_exclude_r
         print_header("Publishing DataPipelines")
         items.publish_datapipelines(fabric_workspace_obj)
 
+    # Check Environment Publish
+    if "Environment" in fabric_workspace_obj.item_type_in_scope:
+        print_header("Checking Environment Publish State")
+        items.check_environment_publish_state(fabric_workspace_obj)
+
 
 def unpublish_all_orphan_items(fabric_workspace_obj: FabricWorkspace, item_name_exclude_regex: str = "^$") -> None:
     """


### PR DESCRIPTION
This pull request includes changes to enhance the environment publishing process within the `fabric_cicd` module. The most important changes include the addition of a new function to check the environment publish state, modifications to the `publish_environments` function, and updates to the environment metadata publishing process.

### Enhancements to environment publishing:

* [`src/fabric_cicd/_items/__init__.py`](diffhunk://#diff-94d858110d4e75a68135b9975f58e289c7db48793b5bf7bc56c08efad59f3e34L8-R8): Added `check_environment_publish_state` import and included it in the `__all__` list to make it publicly accessible. [[1]](diffhunk://#diff-94d858110d4e75a68135b9975f58e289c7db48793b5bf7bc56c08efad59f3e34L8-R8) [[2]](diffhunk://#diff-94d858110d4e75a68135b9975f58e289c7db48793b5bf7bc56c08efad59f3e34R17)

* [`src/fabric_cicd/_items/_environment.py`](diffhunk://#diff-d21d8d1ab1b91c6581949c76a61d12d3f838509ef127b4ae5144feb5bc23bd8aR29-R31): Updated the `publish_environments` function to check for ongoing publishes before starting a new one.

* [`src/fabric_cicd/_items/_environment.py`](diffhunk://#diff-d21d8d1ab1b91c6581949c76a61d12d3f838509ef127b4ae5144feb5bc23bd8aL60-L62): Modified `_publish_environment_metadata` to remove the check for ongoing publish and adjusted logging to indicate when a publish is submitted. [[1]](diffhunk://#diff-d21d8d1ab1b91c6581949c76a61d12d3f838509ef127b4ae5144feb5bc23bd8aL60-L62) [[2]](diffhunk://#diff-d21d8d1ab1b91c6581949c76a61d12d3f838509ef127b4ae5144feb5bc23bd8aL74-R125)

* [`src/fabric_cicd/_items/_environment.py`](diffhunk://#diff-d21d8d1ab1b91c6581949c76a61d12d3f838509ef127b4ae5144feb5bc23bd8aL74-R125): Renamed and refactored `_check_environment_publish_state` to `check_environment_publish_state`, allowing it to check the state of all environments and handle retries more effectively.

* [`src/fabric_cicd/publish.py`](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R83-R87): Added a call to `check_environment_publish_state` in the `publish_all_items` function to ensure the environment publish state is checked during the publishing process.