### PR TITLE
Fix examples link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Section Overview:
 
 -   [Home](https://microsoft.github.io/fabric-cicd/latest/)
 -   [How To](https://microsoft.github.io/fabric-cicd/latest/how_to/)
--   [Examples Samples](https://microsoft.github.io/fabric-cicd/latest/example/)
+-   [Examples](https://microsoft.github.io/fabric-cicd/latest/example/)
 -   [Contribution](https://microsoft.github.io/fabric-cicd/latest/contribution/)
 -   [Changelog](https://microsoft.github.io/fabric-cicd/latest/changelog/)
 -   [About](https://microsoft.github.io/fabric-cicd/latest/help/) - Inclusive of Support & Security Policies


### PR DESCRIPTION
This pull request includes a minor edit to the `README.md` file. The change simplifies the wording of a navigation link by renaming "Examples Samples" to "Examples" for clarity.