### PR TITLE
v0.1.15

### DIFF
--- a/src/fabric_cicd/changelog.md
+++ b/src/fabric_cicd/changelog.md
@@ -6,6 +6,15 @@ The following contains all major, minor, and patch version release notes.
 -   📝 Documentation Update
 -   ⚡ Internal Optimization
 
+## Version 0.1.15
+
+<span class="md-h2-subheader">Release Date: 2025-04-21</span>
+
+-   🔧 Fix folders moving with every publish ([#236](https://github.com/microsoft/fabric-cicd/issues/236))
+-   ⚡ Inrtoduce parallel deployments to reduce publish times ([#237](https://github.com/microsoft/fabric-cicd/issues/237))
+-   ⚡ Improvements to check version logic
+-   📝 Updated example section in docs
+
 ## Version 0.1.14
 
 <span class="md-h2-subheader">Release Date: 2025-04-09</span>

--- a/src/fabric_cicd/changelog.md
+++ b/src/fabric_cicd/changelog.md
@@ -11,9 +11,9 @@ The following contains all major, minor, and patch version release notes.
 <span class="md-h2-subheader">Release Date: 2025-04-21</span>
 
 -   🔧 Fix folders moving with every publish ([#236](https://github.com/microsoft/fabric-cicd/issues/236))
--   ⚡ Inrtoduce parallel deployments to reduce publish times ([#237](https://github.com/microsoft/fabric-cicd/issues/237))
+-   ⚡ Introduce parallel deployments to reduce publish times ([#237](https://github.com/microsoft/fabric-cicd/issues/237))
 -   ⚡ Improvements to check version logic
--   📝 Updated example section in docs
+-   📝 Updated Examples section in docs
 
 ## Version 0.1.14
 

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -4,7 +4,7 @@
 """Constants for the fabric-cicd package."""
 
 # General
-VERSION = "0.1.14"
+VERSION = "0.1.15"
 DEFAULT_WORKSPACE_ID = "00000000-0000-0000-0000-000000000000"
 DEFAULT_API_ROOT_URL = "https://api.powerbi.com"
 FEATURE_FLAG = set()


### PR DESCRIPTION
This pull request updates the `fabric-cicd` package to version 0.1.15, introduces release notes for the new version, and updates the version constant in the codebase.

### Code Update:
* Updated the `VERSION` constant in `src/fabric_cicd/constants.py` to reflect the new version, 0.1.15.