### PR TITLE
Implements #200 - Add Workspace Name in FabricWorkspaceObject

### DIFF
--- a/src/fabric_cicd/_common/_validate_input.py
+++ b/src/fabric_cicd/_common/_validate_input.py
@@ -125,6 +125,7 @@ def validate_workspace_name(input_value: str) -> str:
 
     return input_value
 
+
 def validate_workspace_id_or_name(workspace_name: str, workspace_id: str) -> None:
     """
     Validate if either workspace_id or workspace_name has been defined.
@@ -136,6 +137,7 @@ def validate_workspace_id_or_name(workspace_name: str, workspace_id: str) -> Non
     if workspace_name == "N/A" and workspace_id == "N/A":
         msg = "Either workspace_name or workspace_id must be specified."
         raise InputError(msg, logger)
+
 
 def validate_environment(input_value: str) -> str:
     """

--- a/src/fabric_cicd/_common/_validate_input.py
+++ b/src/fabric_cicd/_common/_validate_input.py
@@ -114,6 +114,29 @@ def validate_workspace_id(input_value: str) -> str:
     return input_value
 
 
+def validate_workspace_name(input_value: str) -> str:
+    """
+    Validate the workspace name.
+
+    Args:
+        input_value: The input value to validate.
+    """
+    validate_data_type("string", "workspace_name", input_value)
+
+    return input_value
+
+def validate_workspace_id_or_name(workspace_name: str, workspace_id: str) -> None:
+    """
+    Validate if either workspace_id or workspace_name has been defined.
+
+    Args:
+        workspace_name: The workspace name to validate.
+        workspace_id: The workspace ID to validate.
+    """
+    if workspace_name == "N/A" and workspace_id == "N/A":
+        msg = "Either workspace_name or workspace_id must be specified."
+        raise InputError(msg, logger)
+
 def validate_environment(input_value: str) -> str:
     """
     Validate the environment.

--- a/src/fabric_cicd/_common/_validate_input.py
+++ b/src/fabric_cicd/_common/_validate_input.py
@@ -126,19 +126,6 @@ def validate_workspace_name(input_value: str) -> str:
     return input_value
 
 
-def validate_workspace_id_or_name(workspace_name: str, workspace_id: str) -> None:
-    """
-    Validate if either workspace_id or workspace_name has been defined.
-
-    Args:
-        workspace_name: The workspace name to validate.
-        workspace_id: The workspace ID to validate.
-    """
-    if workspace_name == "N/A" and workspace_id == "N/A":
-        msg = "Either workspace_name or workspace_id must be specified."
-        raise InputError(msg, logger)
-
-
 def validate_environment(input_value: str) -> str:
     """
     Validate the environment.

--- a/src/fabric_cicd/_items/_report.py
+++ b/src/fabric_cicd/_items/_report.py
@@ -44,7 +44,11 @@ def func_process_file(workspace_obj: FabricWorkspace, item_obj: Item, file_obj: 
     """
     if file_obj.name == "definition.pbir":
         definition_body = json.loads(file_obj.contents)
-        if "datasetReference" in definition_body and "byPath" in definition_body["datasetReference"] and definition_body["datasetReference"]["byPath"] is not None:
+        if (
+            "datasetReference" in definition_body
+            and "byPath" in definition_body["datasetReference"]
+            and definition_body["datasetReference"]["byPath"] is not None
+        ):
             model_rel_path = definition_body["datasetReference"]["byPath"]["path"]
             model_path = str((item_obj.path / model_rel_path).resolve())
             model_id = workspace_obj._convert_path_to_id("SemanticModel", model_path)

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -4,7 +4,7 @@
 """Constants for the fabric-cicd package."""
 
 # General
-VERSION = "0.1.14"
+VERSION = "0.1.15"
 DEFAULT_WORKSPACE_ID = "00000000-0000-0000-0000-000000000000"
 DEFAULT_API_ROOT_URL = "https://api.powerbi.com"
 FEATURE_FLAG = set()


### PR DESCRIPTION
This pull request introduces support for specifying a workspace by name in addition to the existing support for specifying a workspace by ID, along with other minor improvements. The key changes include updates to the `FabricWorkspace` class to handle the new `workspace_name` parameter, validation logic for workspace names, and a new method to resolve workspace IDs from names.

### Enhancements to `FabricWorkspace`:

* Added an optional `workspace_name` parameter to the `FabricWorkspace` class, allowing users to specify a workspace by name. If both `workspace_id` and `workspace_name` are provided, `workspace_id` takes precedence. (`src/fabric_cicd/fabric_workspace.py`, [src/fabric_cicd/fabric_workspace.pyL31-R44](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L31-R44))
* Introduced a `_resolve_workspace_id` method that resolves a workspace ID from a given workspace name by querying the API. If the name cannot be resolved, an `InputError` is raised. (`src/fabric_cicd/fabric_workspace.py`, [src/fabric_cicd/fabric_workspace.pyL117-R151](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L117-R151))
* Updated the constructor to validate and set the `workspace_id` based on either the provided `workspace_id` or the resolved value from `workspace_name`. (`src/fabric_cicd/fabric_workspace.py`, [src/fabric_cicd/fabric_workspace.pyL99-R119](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L99-R119))
* Adjusted the `base_api_url` initialization to use the resolved `workspace_id` if applicable. (`src/fabric_cicd/fabric_workspace.py`, [src/fabric_cicd/fabric_workspace.pyL117-R151](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L117-R151))

### Validation improvements:

* Added a new `validate_workspace_name` function to validate the workspace name input. (`src/fabric_cicd/_common/_validate_input.py`, [src/fabric_cicd/_common/_validate_input.pyR117-R128](diffhunk://#diff-b8a669357b50d9b4d808c610b3e17e12321db4f234259b95ba4350adcca0ecd8R117-R128))
* Included `validate_workspace_name` in the `FabricWorkspace` constructor for validation. (`src/fabric_cicd/fabric_workspace.py`, [src/fabric_cicd/fabric_workspace.pyR99](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0R99))

### Minor updates:

* Updated imports in `fabric_workspace.py` to include the `InputError` exception, which is now used for error handling. (`src/fabric_cicd/fabric_workspace.py`, [src/fabric_cicd/fabric_workspace.pyL18-R18](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L18-R18))
* Reformatted a conditional statement in `_report.py` for better readability. (`src/fabric_cicd/_items/_report.py`, [src/fabric_cicd/_items/_report.pyL47-R51](diffhunk://#diff-2425d325e32b5437c7d3128f26fd3fdd053139c38844675e5e42b380a6a69f41L47-R51))