### PR TITLE
Fix Out of Order Table of Contents

### DIFF
--- a/docs/config/pre-build/section_toc.py
+++ b/docs/config/pre-build/section_toc.py
@@ -1,25 +1,58 @@
 from pathlib import Path
 import re
 
+import yaml
+
+def get_section_order(nav, current_dir_str):
+    """
+    Recursively find the order of markdown files in the current directory as defined in nav.
+    """
+    order = []
+    for item in nav:
+        if isinstance(item, dict):
+            for key, value in item.items():
+                if isinstance(value, list):
+                    # Recurse into subsections
+                    order += get_section_order(value, current_dir_str)
+                elif isinstance(value, str):
+                    path = Path(value)
+                    if str(path.parent).replace("\\", "/") == current_dir_str:
+                        order.append(path.name)
+        elif isinstance(item, str):
+            path = Path(item)
+            if str(path.parent).replace("\\", "/") == current_dir_str:
+                order.append(path.name)
+    return order
+
 def on_page_markdown(markdown, page, config, files):
     if "<!--BEGIN-SECTION-TOC-->\n" in markdown:
         start_index = markdown.index("<!--BEGIN-SECTION-TOC-->\n") + len("<!--BEGIN-SECTION-TOC-->\n")
         end_index = markdown.index("<!--END-SECTION-TOC-->\n")
 
-        # Get the current page path
         current_page_path = Path(page.file.abs_src_path)
         current_page_dir = current_page_path.parent
 
-        # Find all markdown files at the same level
-        toc = []
-        for md_file in current_page_dir.glob("*.md"):
-            if md_file == current_page_path:
-                continue
+        # Compute docs root (where mkdocs.yml lives)
+        mkdocs_yml = Path(config['config_file_path'])
+        docs_root = mkdocs_yml.parent
 
-            # Extract headers from the markdown file, excluding code blocks
+        # Get current dir relative to docs root, as string
+        current_dir_rel = str(current_page_dir.name)
+
+        # Load mkdocs.yml and extract nav order
+        with mkdocs_yml.open("r", encoding="utf-8") as f:
+            mkdocs_config = yaml.safe_load(f)
+        nav = mkdocs_config.get('nav', [])
+        section_order = get_section_order(nav, current_dir_rel)
+        
+
+        toc = []
+        for md_name in section_order:
+            md_file = current_page_dir / md_name
+            if not md_file.exists() or md_file == current_page_path:
+                continue
             with md_file.open("r", encoding="utf-8") as f:
                 content = f.read()
-                # Remove code blocks
                 content_no_code = re.sub(r"```.*?```", "", content, flags=re.DOTALL)
                 headers = re.findall(r"^(#{1,6})\s+(.*)", content_no_code, re.MULTILINE)
                 for header in headers:


### PR DESCRIPTION
This pull request introduces enhancements to the `on_page_markdown` function in `docs/config/pre-build/section_toc.py` to improve the generation of section-specific table of contents (TOC). The most notable changes include adding support for ordering markdown files based on the `nav` structure in `mkdocs.yml` and refactoring the logic to align with this new feature.

### Enhancements to TOC generation:

* **Support for `mkdocs.yml`-based ordering**: Added a new `get_section_order` function to recursively extract the order of markdown files from the `nav` structure in `mkdocs.yml`. This ensures that the TOC reflects the intended navigation hierarchy. (`[docs/config/pre-build/section_toc.pyR4-L22](diffhunk://#diff-63b7692ff1d1a38808672bbc1dec28f9b3ae609424e264f2fc32195e766522deR4-L22)`)
* **Integration with `on_page_markdown`**: Updated the `on_page_markdown` function to load and parse `mkdocs.yml`, compute the relative directory path, and use the `get_section_order` function to determine the correct file order for TOC generation. (`[docs/config/pre-build/section_toc.pyR4-L22](diffhunk://#diff-63b7692ff1d1a38808672bbc1dec28f9b3ae609424e264f2fc32195e766522deR4-L22)`)

### Code structure improvements:

* **Refactored markdown file handling**: Replaced the previous logic for finding markdown files with a more structured approach that uses the `section_order` from `mkdocs.yml`. This improves maintainability and ensures consistency with the navigation configuration. (`[docs/config/pre-build/section_toc.pyR4-L22](diffhunk://#diff-63b7692ff1d1a38808672bbc1dec28f9b3ae609424e264f2fc32195e766522deR4-L22)`)