### PR TITLE
Add SDL Reviewer Policy

### DIFF
--- a/.github/policies/sdl.yml
+++ b/.github/policies/sdl.yml
@@ -1,0 +1,8 @@
+name: SDL
+description: Requires one reviewer for merges into main branch
+resource: repository
+where:
+configuration:
+    branchProtectionRules:
+        - branchNamePattern: "main"
+          requiredApprovingReviewsCount: 1


### PR DESCRIPTION
Add reviewer policy via yml as a workaround for current bug with SDL scan where org policies are not reflected.