### PR TITLE
Add Publish Regex Example

### DIFF
--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -40,7 +40,7 @@ def publish_all_items(fabric_workspace_obj: FabricWorkspace, item_name_exclude_r
         >>> publish_all_items(workspace)
 
         With regex name exclusion
-        >>> from fabric_cicd import FabricWorkspace, publish_all_items, unpublish_all_orphan_items
+        >>> from fabric_cicd import FabricWorkspace, publish_all_items
         >>> workspace = FabricWorkspace(
         ...     workspace_id="your-workspace-id",
         ...     repository_directory="/path/to/repo",

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -38,6 +38,16 @@ def publish_all_items(fabric_workspace_obj: FabricWorkspace, item_name_exclude_r
         ...     item_type_in_scope=["Environment", "Notebook", "DataPipeline"]
         ... )
         >>> publish_all_items(workspace)
+
+        With regex name exclusion
+        >>> from fabric_cicd import FabricWorkspace, publish_all_items, unpublish_all_orphan_items
+        >>> workspace = FabricWorkspace(
+        ...     workspace_id="your-workspace-id",
+        ...     repository_directory="/path/to/repo",
+        ...     item_type_in_scope=["Environment", "Notebook", "DataPipeline"]
+        ... )
+        >>> exclude_regex = ".*_do_not_publish"
+        >>> publish_all_items(workspace, exclude_regex)
     """
     fabric_workspace_obj = validate_fabric_workspace_obj(fabric_workspace_obj)
 


### PR DESCRIPTION
This pull request adds an example to the docstring of the `publish_all_items` function in `src/fabric_cicd/publish.py` to demonstrate how to use the function with a regex for excluding item names.

Documentation improvement:

* Added a new example to the `publish_all_items` function docstring, showing how to use the `item_name_exclude_r` parameter with a regex pattern (e.g., `.*_do_not_publish`) to exclude specific items during publishing. (`[src/fabric_cicd/publish.pyR41-R50](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R41-R50)`)