### PR TITLE
Resolves #283 Deprecate old parameter file structure

### DIFF
--- a/docs/how_to/parameterization.md
+++ b/docs/how_to/parameterization.md
@@ -2,7 +2,7 @@
 
 To handle environment-specific values committed to git, use a `parameter.yml` file. This file supports programmatically changing values based on the `environment` field passed into the `FabricWorkspace` object. If the environment value is not found in the `parameter.yml` file, any dependent replacements will be skipped. This file should sit in the root of the `repository_directory` folder specified in the FabricWorkspace object.
 
-**Important Notice:** The `parameter.yml` file structure has been recently updated. Please refer to the documentation below for important changes. There is a grace period from **March 24, 2025** to **April 24, 2025** during which the old structure will still be supported, allowing users to migrate to the new structure.
+**Important Notice:** The `parameter.yml` file structure has been recently updated. Please refer to the documentation below for important changes.
 
 Example of parameter.yml location based on provided repository directory:
 
@@ -55,8 +55,8 @@ find_replace:
     # Lakehouse GUID
     - find_value: "db52be81-c2b2-4261-84fa-840c67f4bbd0"
       replace_value:
-        PPE: "$ENV:ppe_lakehouse"
-        PROD: "$ENV:prod_lakehouse"
+          PPE: "$ENV:ppe_lakehouse"
+          PROD: "$ENV:prod_lakehouse"
 ```
 
 ### `spark_pool`
@@ -123,7 +123,7 @@ find_replace:
     - find_value: "123e4567-e89b-12d3-a456-426614174000" # Lakehouse GUID
       replace_value:
           PPE: "f47ac10b-58cc-4372-a567-0e02b2c3d479" # PPE lakehouse GUID
-          PROD: "9b2e5f4c-8d3a-4f1b-9c3e-2d5b6e4a7f8c" # PROD lakehouse GUID 
+          PROD: "9b2e5f4c-8d3a-4f1b-9c3e-2d5b6e4a7f8c" # PROD lakehouse GUID
       item_type: "Notebook"
       item_name: ["Hello World", "Goodbye World"]
     - find_value: "replace_lakehouse_id"

--- a/sample/workspace/parameter.yml
+++ b/sample/workspace/parameter.yml
@@ -34,20 +34,3 @@ spark_pool:
            name: "WorkspacePool_Medium"
       # Optional field:
       item_name:
-
-# Legacy structure
-#find_replace:
-    # SQL Connection Guid
-    #"db52be81-c2b2-4261-84fa-840c67f4bbd0":
-        #PPE: "81bbb339-8d0b-46e8-bfa6-289a159c0733"
-        #PROD: "5d6a1b16-447f-464a-b959-45d0fed35ca0"
-
-#spark_pool:
-    # CapacityPool_Large
-    #"72c68dbc-0775-4d59-909d-a47896f4573b":
-        #type: "Capacity"
-        #name: "CapacityPool_Large"
-    # CapacityPool_Medium
-    #"e7b8f1c4-4a6e-4b8b-9b2e-8f1e5d6a9c3d":
-        #type: "Workspace"
-        #name: "WorkspacePool_Medium"

--- a/src/fabric_cicd/_items/_environment.py
+++ b/src/fabric_cicd/_items/_environment.py
@@ -12,7 +12,6 @@ import yaml
 
 from fabric_cicd import FabricWorkspace, constants
 from fabric_cicd._common._fabric_endpoint import handle_retry
-from fabric_cicd._parameter._utils import check_parameter_structure
 
 logger = logging.getLogger(__name__)
 
@@ -144,25 +143,15 @@ def _update_compute_settings(
         if "instance_pool_id" in yaml_body:
             pool_id = yaml_body["instance_pool_id"]
             if "spark_pool" in fabric_workspace_obj.environment_parameter:
-                structure_type = check_parameter_structure(fabric_workspace_obj.environment_parameter, "spark_pool")
                 parameter_dict = fabric_workspace_obj.environment_parameter["spark_pool"]
-                # Handle new parameter file format
-                if structure_type == "new":
-                    for key in parameter_dict:
-                        instance_pool_id = key["instance_pool_id"]
-                        replace_value = key["replace_value"]
-                        input_name = key.get("item_name")
-                        if instance_pool_id == pool_id and (input_name == item_name or not input_name):
-                            # replace any found references with specified environment value
-                            yaml_body["instancePool"] = replace_value[fabric_workspace_obj.environment]
-                            del yaml_body["instance_pool_id"]
-
-                # Handle original parameter file format
-                # TODO: Deprecate old structure handling by April 24, 2025
-                if structure_type == "old" and pool_id in parameter_dict:
-                    # replace any found references with specified environment value
-                    yaml_body["instancePool"] = parameter_dict[pool_id]
-                    del yaml_body["instance_pool_id"]
+                for key in parameter_dict:
+                    instance_pool_id = key["instance_pool_id"]
+                    replace_value = key["replace_value"]
+                    input_name = key.get("item_name")
+                    if instance_pool_id == pool_id and (input_name == item_name or not input_name):
+                        # replace any found references with specified environment value
+                        yaml_body["instancePool"] = replace_value[fabric_workspace_obj.environment]
+                        del yaml_body["instance_pool_id"]
 
         yaml_body = _convert_environment_compute_to_camel(fabric_workspace_obj, yaml_body)
 

--- a/src/fabric_cicd/_parameter/_parameter.py
+++ b/src/fabric_cicd/_parameter/_parameter.py
@@ -157,11 +157,8 @@ class Parameter:
             logger.debug(constants.PARAMETER_MSGS["validating"].format(step))
             is_valid, msg = validation_func()
             if not is_valid:
-                # Return True for specific not is_valid cases
-                if step in ("parameter file load", "parameter file structure") and msg in (
-                    "not found",
-                    "old structure",
-                ):
+                # Return True for specific not is_valid case
+                if step == "parameter file load" and msg == "not found":
                     logger.warning(constants.PARAMETER_MSGS["terminate"].format(msg))
                     return True
                 # Throw warning and discontinue validation check for absent parameter
@@ -180,11 +177,6 @@ class Parameter:
 
     def _validate_parameter_structure(self) -> tuple[bool, str]:
         """Validate the parameter file structure."""
-        # TODO: Deprecate old structure check in future versions
-        if check_parameter_structure(self.environment_parameter) == "old":
-            logger.warning(constants.PARAMETER_MSGS["old structure"])
-            logger.warning(constants.PARAMETER_MSGS["raise issue"])
-            return False, "old structure"
         if check_parameter_structure(self.environment_parameter) == "invalid":
             return False, constants.PARAMETER_MSGS["invalid structure"]
 

--- a/src/fabric_cicd/_parameter/_parameter.py
+++ b/src/fabric_cicd/_parameter/_parameter.py
@@ -14,7 +14,7 @@ import yaml
 
 import fabric_cicd.constants as constants
 from fabric_cicd._parameter._utils import (
-    check_parameter_structure,
+    is_valid_structure,
     process_input_path,
     replace_variables_in_parameter_file,
 )
@@ -177,7 +177,7 @@ class Parameter:
 
     def _validate_parameter_structure(self) -> tuple[bool, str]:
         """Validate the parameter file structure."""
-        if check_parameter_structure(self.environment_parameter) == "invalid":
+        if not is_valid_structure(self.environment_parameter):
             return False, constants.PARAMETER_MSGS["invalid structure"]
 
         return True, constants.PARAMETER_MSGS["valid structure"]

--- a/src/fabric_cicd/_parameter/_utils.py
+++ b/src/fabric_cicd/_parameter/_utils.py
@@ -90,10 +90,10 @@ def validate_parameter_file(
     return parameter_obj._validate_parameter_file()
 
 
-def check_parameter_structure(param_dict: dict, param_name: Optional[str] = None) -> str:
+def is_valid_structure(param_dict: dict, param_name: Optional[str] = None) -> bool:
     """
     Checks the parameter dictionary structure and determines if it
-    contains the new structure (i.e. a list of values when indexed by the key).
+    contains the valid structure (i.e. a list of values when indexed by the key).
 
     Args:
         param_dict: The parameter dictionary to check.
@@ -101,11 +101,13 @@ def check_parameter_structure(param_dict: dict, param_name: Optional[str] = None
     """
     # Check the structure of the specified parameter
     if param_name:
-        return _check_structure(param_dict.get(param_name))
+        return _check_parameter_structure(param_dict.get(param_name))
 
     # Otherwise, check the structure of the entire parameter dictionary
     param_structure = [
-        _check_structure(param_dict.get(name)) for name in ["find_replace", "spark_pool"] if param_dict.get(name)
+        _check_parameter_structure(param_dict.get(name))
+        for name in ["find_replace", "spark_pool"]
+        if param_dict.get(name)
     ]
     # Check structure if only one parameter is found
     if len(param_structure) == 1:
@@ -114,12 +116,12 @@ def check_parameter_structure(param_dict: dict, param_name: Optional[str] = None
     if len(param_structure) == 2 and param_structure[0] == param_structure[1]:
         return param_structure[0]
 
-    return "invalid"
+    return False
 
 
-def _check_structure(param_value: any) -> str:
+def _check_parameter_structure(param_value: any) -> bool:
     """Checks the structure of a parameter value"""
-    return "new" if isinstance(param_value, list) else "invalid"
+    return isinstance(param_value, list)
 
 
 def process_input_path(

--- a/src/fabric_cicd/_parameter/_utils.py
+++ b/src/fabric_cicd/_parameter/_utils.py
@@ -104,34 +104,22 @@ def check_parameter_structure(param_dict: dict, param_name: Optional[str] = None
         return _check_structure(param_dict.get(param_name))
 
     # Otherwise, check the structure of the entire parameter dictionary
-    find_replace_parameter = param_dict.get("find_replace")
-    spark_pool_parameter = param_dict.get("spark_pool")
+    param_structure = [
+        _check_structure(param_dict.get(name)) for name in ["find_replace", "spark_pool"] if param_dict.get(name)
+    ]
+    # Check structure if only one parameter is found
+    if len(param_structure) == 1:
+        return param_structure[0]
+    # Check structure if both parameters are found
+    if len(param_structure) == 2 and param_structure[0] == param_structure[1]:
+        return param_structure[0]
 
-    # If both parameters are present, check their structures
-    if find_replace_parameter and spark_pool_parameter:
-        find_replace_structure = _check_structure(find_replace_parameter)
-        spark_pool_structure = _check_structure(spark_pool_parameter)
-        # If both structures are the same, return the structure
-        if find_replace_structure == spark_pool_structure:
-            return find_replace_structure
-        return "invalid"
-
-    # If only one parameter is present, return its structure
-    if find_replace_parameter:
-        return _check_structure(find_replace_parameter)
-    if spark_pool_parameter:
-        return _check_structure(spark_pool_parameter)
     return "invalid"
 
 
 def _check_structure(param_value: any) -> str:
     """Checks the structure of a parameter value"""
-    if isinstance(param_value, list):
-        return "new"
-    # TODO: Remove this condition after deprecation (April 24, 2025)
-    if isinstance(param_value, dict):
-        return "old"
-    return "invalid"
+    return "new" if isinstance(param_value, list) else "invalid"
 
 
 def process_input_path(

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -52,8 +52,6 @@ PARAMETER_MSGS = {
     "invalid content": INVALID_YAML,
     "valid load": f"Successfully loaded {PARAMETER_FILE_NAME}",
     "invalid load": f"Error loading {PARAMETER_FILE_NAME} " + "{}",
-    "old structure": "The parameter file structure used will no longer be supported after April 24, 2025. Please migrate to the new structure",
-    "raise issue": "Raise a GitHub issue here: https://github.com/microsoft/fabric-cicd/issues for migration timeline issues",
     "invalid structure": "Invalid parameter file structure",
     "valid structure": "Parameter file structure is valid",
     "invalid name": "Invalid parameter name '{}' found in the parameter file",

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -289,7 +289,6 @@ class FabricWorkspace:
             item_obj: The Item object instance that provides the item type and item name.
         """
         from fabric_cicd._parameter._utils import (
-            check_parameter_structure,
             check_replacement,
             process_input_path,
         )
@@ -301,33 +300,21 @@ class FabricWorkspace:
         file_path = file_obj.file_path
 
         if "find_replace" in self.environment_parameter:
-            structure_type = check_parameter_structure(self.environment_parameter, param_name="find_replace")
             msg = "Replacing {} with {} in {}.{}"
 
-            # Handle new parameter file structure
-            if structure_type == "new":
-                for parameter_dict in self.environment_parameter["find_replace"]:
-                    find_value = parameter_dict["find_value"]
-                    replace_value = parameter_dict["replace_value"]
-                    input_type = parameter_dict.get("item_type")
-                    input_name = parameter_dict.get("item_name")
-                    input_path = process_input_path(self.repository_directory, parameter_dict.get("file_path"))
+            for parameter_dict in self.environment_parameter["find_replace"]:
+                find_value = parameter_dict["find_value"]
+                replace_value = parameter_dict["replace_value"]
+                input_type = parameter_dict.get("item_type")
+                input_name = parameter_dict.get("item_name")
+                input_path = process_input_path(self.repository_directory, parameter_dict.get("file_path"))
 
-                    # Perform replacement if a condition is met and replace any found references with specified environment value
-                    if (find_value in raw_file and self.environment in replace_value) and check_replacement(
-                        input_type, input_name, input_path, item_type, item_name, file_path
-                    ):
-                        raw_file = raw_file.replace(find_value, replace_value[self.environment])
-                        logger.debug(msg.format(find_value, replace_value[self.environment], item_name, item_type))
-
-            # Handle original parameter file structure
-            # TODO: Deprecate old structure handling by April 24, 2025
-            if structure_type == "old":
-                for key, parameter_dict in self.environment_parameter["find_replace"].items():
-                    if key in raw_file and self.environment in parameter_dict:
-                        # replace any found references with specified environment value
-                        raw_file = raw_file.replace(key, parameter_dict[self.environment])
-                        logger.debug(msg.format(key, parameter_dict, item_name, item_type))
+                # Perform replacement if a condition is met and replace any found references with specified environment value
+                if (find_value in raw_file and self.environment in replace_value) and check_replacement(
+                    input_type, input_name, input_path, item_type, item_name, file_path
+                ):
+                    raw_file = raw_file.replace(find_value, replace_value[self.environment])
+                    logger.debug(msg.format(find_value, replace_value[self.environment], item_name, item_type))
 
         return raw_file
 

--- a/tests/test_fabric_workspace.py
+++ b/tests/test_fabric_workspace.py
@@ -44,12 +44,15 @@ def create_parameter_file(dir_path, utf8_chars):
     """Create a parameter file with UTF-8 characters."""
     parameter_file_path = dir_path / "parameter.yml"
     parameter_content = {
-        "find_replace": {
-            f"Production {utf8_chars['mixed']}": {
-                utf8_chars["nordic"]: "12345678-1234-5678-abcd-1234567890ab",
-                utf8_chars["asian"]: "21345678-1234-5678-abcd-1234567890ab",
+        "find_replace": [
+            {
+                "find_value": f"Production {utf8_chars['mixed']}",
+                "replace_value": {
+                    utf8_chars["nordic"]: "12345678-1234-5678-abcd-1234567890ab",
+                    utf8_chars["asian"]: "21345678-1234-5678-abcd-1234567890ab",
+                },
             }
-        }
+        ]
     }
 
     with parameter_file_path.open("w", encoding="utf-8") as f:
@@ -128,9 +131,10 @@ def test_parameter_file_with_utf8_chars(
     key2 = utf8_test_chars["nordic"]
     key3 = utf8_test_chars["asian"]
 
-    assert key1 in workspace.environment_parameter["find_replace"]
-    assert key2 in workspace.environment_parameter["find_replace"][key1]
-    assert key3 in workspace.environment_parameter["find_replace"][key1]
+    for param_dict in workspace.environment_parameter.get("find_replace"):
+        assert key1 == param_dict["find_value"]
+        assert key2 in param_dict["replace_value"]
+        assert key3 in param_dict["replace_value"]
 
 
 def test_platform_metadata_with_utf8_chars(


### PR DESCRIPTION
This pull request removes support for the legacy structure of the `parameter.yml` file and updates the codebase to exclusively use the new structure. Key changes include removing legacy structure handling, simplifying parameter validation, and updating tests to align with the new format.

### Removal of Legacy Structure Handling:
* Removed all references to the legacy `parameter.yml` structure, including conditional checks for "old" structure types in `_update_compute_settings` and `_replace_parameters` methods in `src/fabric_cicd/_items/_environment.py` and `src/fabric_cicd/fabric_workspace.py`. [[1]](diffhunk://#diff-d21d8d1ab1b91c6581949c76a61d12d3f838509ef127b4ae5144feb5bc23bd8aL147-L150) [[2]](diffhunk://#diff-d21d8d1ab1b91c6581949c76a61d12d3f838509ef127b4ae5144feb5bc23bd8aL160-L166) [[3]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L304-L308) [[4]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L323-L331)
* Deleted the legacy structure validation logic in `check_parameter_structure` and `_validate_parameter_file` methods, and removed related warnings from `constants.py`. [[1]](diffhunk://#diff-08e7f8767bb7d280f82e88a77521554115ad781c1dceb4ff0a7b450d38a684abL107-R122) [[2]](diffhunk://#diff-663a11b92ff45fa9b30ab4086a71af3d0f87fce5a8da7967ff9a1197cc24d501L183-L187) [[3]](diffhunk://#diff-91c2d32be351f155f090c4bd57ebe3c10e646edbc1b663e2a72b697f956a949cL55-L56)

### Simplification of Parameter Validation:
* Simplified the `check_parameter_structure` function to only validate the new structure format (`list` type) and removed legacy-specific checks.
* Updated `_validate_parameter_file` to remove special handling for legacy structures. [[1]](diffhunk://#diff-663a11b92ff45fa9b30ab4086a71af3d0f87fce5a8da7967ff9a1197cc24d501L160-R161) [[2]](diffhunk://#diff-663a11b92ff45fa9b30ab4086a71af3d0f87fce5a8da7967ff9a1197cc24d501L183-L187)

### Updates to Documentation and Examples:
* Updated `docs/how_to/parameterization.md` to remove the grace period for migrating to the new structure, reflecting the deprecation of the legacy format.
* Cleaned up the `sample/workspace/parameter.yml` file by removing legacy structure examples.

### Test Updates:
* Refactored tests in `tests/test_fabric_workspace.py` to use the new `parameter.yml` structure, ensuring compatibility with the updated codebase. [[1]](diffhunk://#diff-38a69298c91571d1f1a72285d551b8e0ceaebe1ba66bd7bfc7a537620b4bfa3aL47-R55) [[2]](diffhunk://#diff-38a69298c91571d1f1a72285d551b8e0ceaebe1ba66bd7bfc7a537620b4bfa3aL131-R137)