### PR TITLE
Resolve CodeQL Violations

### DIFF
--- a/src/fabric_cicd/_parameter/_utils.py
+++ b/src/fabric_cicd/_parameter/_utils.py
@@ -76,7 +76,7 @@ def validate_parameter_file(
     endpoint = FabricEndpoint(
         # if credential is not defined, use DefaultAzureCredential
         token_credential=(
-            DefaultAzureCredential() if token_credential is None else validate_token_credential(token_credential)
+            DefaultAzureCredential() if token_credential is None else validate_token_credential(token_credential) # CodeQL [SM05139] Public library needing to have a default auth when user doesn't provide token.  Not internal Azure product. 
         )
     )
     # Initialize the Parameter object with the validated inputs

--- a/src/fabric_cicd/_parameter/_utils.py
+++ b/src/fabric_cicd/_parameter/_utils.py
@@ -76,7 +76,8 @@ def validate_parameter_file(
     endpoint = FabricEndpoint(
         # if credential is not defined, use DefaultAzureCredential
         token_credential=(
-            DefaultAzureCredential() if token_credential is None else validate_token_credential(token_credential) # CodeQL [SM05139] Public library needing to have a default auth when user doesn't provide token.  Not internal Azure product. 
+            # CodeQL [SM05139] Public library needing to have a default auth when user doesn't provide token.  Not internal Azure product.
+            DefaultAzureCredential() if token_credential is None else validate_token_credential(token_credential)
         )
     )
     # Initialize the Parameter object with the validated inputs

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -103,7 +103,8 @@ class FabricWorkspace:
         self.endpoint = FabricEndpoint(
             # if credential is not defined, use DefaultAzureCredential
             token_credential=(
-                DefaultAzureCredential() if token_credential is None else validate_token_credential(token_credential) # CodeQL [SM05139] Public library needing to have a default auth when user doesn't provide token.  Not internal Azure product. 
+                # CodeQL [SM05139] Public library needing to have a default auth when user doesn't provide token.  Not internal Azure product.
+                DefaultAzureCredential() if token_credential is None else validate_token_credential(token_credential)
             )
         )
 

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -103,7 +103,7 @@ class FabricWorkspace:
         self.endpoint = FabricEndpoint(
             # if credential is not defined, use DefaultAzureCredential
             token_credential=(
-                DefaultAzureCredential() if token_credential is None else validate_token_credential(token_credential)
+                DefaultAzureCredential() if token_credential is None else validate_token_credential(token_credential) # CodeQL [SM05139] Public library needing to have a default auth when user doesn't provide token.  Not internal Azure product. 
             )
         )
 


### PR DESCRIPTION
This pull request includes updates to ensure compliance with CodeQL recommendations by adding comments explaining the use of a default authentication mechanism when no token is provided. The changes affect two methods in the `fabric_cicd` package.

### CodeQL compliance updates:

* [`src/fabric_cicd/_parameter/_utils.py`](diffhunk://#diff-08e7f8767bb7d280f82e88a77521554115ad781c1dceb4ff0a7b450d38a684abL79-R79): Added a comment in the `validate_parameter_file` method to clarify the use of `DefaultAzureCredential` as the default authentication mechanism when no token is provided. This ensures the public library adheres to best practices for authentication.
* [`src/fabric_cicd/fabric_workspace.py`](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L106-R106): Added a similar comment in the `__init__` method to explain the use of `DefaultAzureCredential` for default authentication in the `FabricEndpoint` initialization.