### PR TITLE
Resolves #277 - Operations not being skipped w/ regex_exclude on publish

### DIFF
--- a/src/fabric_cicd/_common/_item.py
+++ b/src/fabric_cicd/_common/_item.py
@@ -24,6 +24,7 @@ class Item:
     item_files: list = field(default_factory=list)
     folder_id: str = field(default="")
     IMMUTABLE_FIELDS: ClassVar[set] = {"type", "name", "description"}
+    publish_status: str = field(default="published")
 
     def __setattr__(self, key: str, value: any) -> None:
         """

--- a/src/fabric_cicd/_common/_item.py
+++ b/src/fabric_cicd/_common/_item.py
@@ -24,7 +24,7 @@ class Item:
     item_files: list = field(default_factory=list)
     folder_id: str = field(default="")
     IMMUTABLE_FIELDS: ClassVar[set] = {"type", "name", "description"}
-    publish_status: str = field(default="published")
+    skip_publish: bool = field(default=False)
 
     def __setattr__(self, key: str, value: any) -> None:
         """

--- a/src/fabric_cicd/_items/_environment.py
+++ b/src/fabric_cicd/_items/_environment.py
@@ -5,6 +5,7 @@
 
 import logging
 import os
+import re
 from pathlib import Path
 
 import dpath
@@ -29,13 +30,15 @@ def publish_environments(fabric_workspace_obj: FabricWorkspace) -> None:
     check_environment_publish_state(fabric_workspace_obj, True)
 
     item_type = "Environment"
-    for item_name in fabric_workspace_obj.repository_items.get(item_type, {}):
+    for item_name, item in fabric_workspace_obj.repository_items.get(item_type, {}).items():
         # Only deploy the shell for environments
         fabric_workspace_obj._publish_item(
             item_name=item_name,
             item_type=item_type,
             skip_publish_logging=True,
         )
+        if item.skip_publish:
+            continue
         _publish_environment_metadata(fabric_workspace_obj, item_name=item_name)
 
 
@@ -91,7 +94,9 @@ def check_environment_publish_state(fabric_workspace_obj: FabricWorkspace, initi
 
     environments = fabric_workspace_obj.repository_items.get("Environment", {})
 
-    logger.info(f"Checking Environment Publish State for {[k for k in environments]}")
+    logger.info(
+        f"Checking Environment Publish State for {[k for k in environments if not re.search(fabric_workspace_obj.publish_item_name_exclude_regex, k)]}"
+    )
 
     while ongoing_publish:
         ongoing_publish = False

--- a/src/fabric_cicd/_items/_lakehouse.py
+++ b/src/fabric_cicd/_items/_lakehouse.py
@@ -42,6 +42,10 @@ def publish_lakehouses(fabric_workspace_obj: FabricWorkspace) -> None:
             skip_publish_logging=True,
         )
 
+        # Check if the item is published to avoid any post publish actions
+        if item.skip_publish:
+            continue
+
         check_sqlendpoint_provision_status(fabric_workspace_obj, item)
 
         logger.info(f"{constants.INDENT}Published")
@@ -49,6 +53,9 @@ def publish_lakehouses(fabric_workspace_obj: FabricWorkspace) -> None:
     # Need all lakehouses published first to protect interrelationships
     if "enable_shortcut_publish" in constants.FEATURE_FLAG:
         for item_obj in fabric_workspace_obj.repository_items.get(item_type, {}).values():
+            # Check if the item is published to avoid any post publish actions
+            if item.skip_publish:
+                continue
             process_shortcuts(fabric_workspace_obj, item_obj)
 
 
@@ -61,10 +68,6 @@ def check_sqlendpoint_provision_status(fabric_workspace_obj: FabricWorkspace, it
         item_obj: The item object to check the SQL endpoint status for
 
     """
-    # check if the item is published before checking SQL endpoint status
-    if item_obj.publish_status != "published":
-        return
-
     iteration = 1
 
     while True:
@@ -104,10 +107,6 @@ def process_shortcuts(fabric_workspace_obj: FabricWorkspace, item_obj: Item) -> 
         fabric_workspace_obj: The FabricWorkspace object containing the items to be published
         item_obj: The item object to publish shortcuts for
     """
-    # check if the item is published before processing shortcuts
-    if item_obj.publish_status != "published":
-        return
-
     deployed_shortcuts = list_deployed_shortcuts(fabric_workspace_obj, item_obj)
 
     shortcut_file_obj = next((file for file in item_obj.item_files if file.name == "shortcuts.metadata.json"), None)

--- a/src/fabric_cicd/_items/_variablelibrary.py
+++ b/src/fabric_cicd/_items/_variablelibrary.py
@@ -25,6 +25,8 @@ def publish_variablelibraries(fabric_workspace_obj: FabricWorkspace) -> None:
 
     for item_name in var_libraries:
         fabric_workspace_obj._publish_item(item_name=item_name, item_type=item_type)
+        if var_libraries[item_name].skip_publish:
+            continue
         activate_value_set(fabric_workspace_obj, var_libraries[item_name])
 
 

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -388,14 +388,16 @@ class FabricWorkspace:
             func_process_file: Custom function to process file contents. Defaults to None.
             **kwargs: Additional keyword arguments.
         """
+        item = self.repository_items[item_type][item_name]
+
         # Skip publishing if the item is excluded by the regex
         if self.publish_item_name_exclude_regex:
             regex_pattern = check_regex(self.publish_item_name_exclude_regex)
             if regex_pattern.match(item_name):
+                item.publish_status = "skipped"
                 logger.info(f"Skipping publishing of {item_type} '{item_name}' due to exclusion regex.")
                 return
 
-        item = self.repository_items[item_type][item_name]
         item_guid = item.guid
         item_files = item.item_files
 

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -406,7 +406,7 @@ class FabricWorkspace:
         if self.publish_item_name_exclude_regex:
             regex_pattern = check_regex(self.publish_item_name_exclude_regex)
             if regex_pattern.match(item_name):
-                item.publish_status = "skipped"
+                item.skip_publish = True
                 logger.info(f"Skipping publishing of {item_type} '{item_name}' due to exclusion regex.")
                 return
 


### PR DESCRIPTION
This pull request introduces a new `publish_status` attribute to the `Item` class and incorporates logic to utilize this attribute for conditional processing of lakehouse items. The changes improve the handling of item publication status and streamline the workflows for processing shortcuts and checking SQL endpoint statuses.

### Enhancements to item publication status:

* **`Item` class update**: Added a `publish_status` attribute with a default value of `"published"` to track the publication status of items. (`src/fabric_cicd/_common/_item.py`, [src/fabric_cicd/_common/_item.pyR27](diffhunk://#diff-17da534a20198c5129cf833667e9b49cbee24482df11bfff019a2e6134bd8fc8R27))
* **Conditional logic for SQL endpoint checks**: Updated the `check_sqlendpoint_provision_status` function to skip SQL endpoint status checks for items that are not published. (`src/fabric_cicd/_items/_lakehouse.py`, [[1]](diffhunk://#diff-beb0a265ced16a1b38260a40c7884c04c9dc568eab3db1afa9a7d665cd34c98cL55-R74) [[2]](diffhunk://#diff-beb0a265ced16a1b38260a40c7884c04c9dc568eab3db1afa9a7d665cd34c98cL82-R86)
* **Conditional logic for shortcut processing**: Modified the `process_shortcuts` function to skip processing shortcuts for items that are not published. (`src/fabric_cicd/_items/_lakehouse.py`, [src/fabric_cicd/_items/_lakehouse.pyR107-R110](diffhunk://#diff-beb0a265ced16a1b38260a40c7884c04c9dc568eab3db1afa9a7d665cd34c98cR107-R110))

### Workflow improvements:

* **Skip publishing excluded items**: Updated the `_publish_item` function to set the `publish_status` to `"skipped"` for items excluded by the regex, providing better visibility into skipped items. (`src/fabric_cicd/fabric_workspace.py`, [src/fabric_cicd/fabric_workspace.pyR391-L398](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0R391-L398))