### PR TITLE
v0.1.17

### DIFF
--- a/src/fabric_cicd/changelog.md
+++ b/src/fabric_cicd/changelog.md
@@ -6,6 +6,20 @@ The following contains all major, minor, and patch version release notes.
 -   📝 Documentation Update
 -   ⚡ Internal Optimization
 
+## Version 0.1.17
+
+<span class="md-h2-subheader">Release Date: 2025-05-13</span>
+
+-   💥 Deprecate old parameter file structure ([#283](https://github.com/microsoft/fabric-cicd/issues/283))
+-   ✨ Onboard CopyJob item type ([#122](https://github.com/microsoft/fabric-cicd/issues/122))
+-   ✨ Onboard Eventstream item type ([#170](https://github.com/microsoft/fabric-cicd/issues/170))
+-   ✨ Onboard Eventhouse/KQL Database item type ([#169](https://github.com/microsoft/fabric-cicd/issues/169))
+-   ✨ Onboard Data Activator item type ([#291](https://github.com/microsoft/fabric-cicd/issues/291))
+-   ✨ Onboard KQL Queryset item type ([#292](https://github.com/microsoft/fabric-cicd/issues/292))
+-   🔧 Fix post publish operations for skipped items ([#277](https://github.com/microsoft/fabric-cicd/issues/277))
+-   ⚡ New function `key_value_replace` for key-based replacement operations in JSON and YAML
+-   📝 Add publish regex example to demonstrate how to use the `publish_all_items` with regex for excluding item names
+
 ## Version 0.1.16
 
 <span class="md-h2-subheader">Release Date: 2025-04-25</span>

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -4,7 +4,7 @@
 """Constants for the fabric-cicd package."""
 
 # General
-VERSION = "0.1.16"
+VERSION = "0.1.17"
 DEFAULT_WORKSPACE_ID = "00000000-0000-0000-0000-000000000000"
 DEFAULT_API_ROOT_URL = "https://api.powerbi.com"
 FEATURE_FLAG = set()


### PR DESCRIPTION
This pull request updates the `fabric-cicd` package to version 0.1.17, introducing new features, deprecations, and fixes. The most notable changes include onboarding several new item types, deprecating the old parameter file structure, and adding a utility function for key-based replacements in JSON and YAML.

### Changelog Updates:
* Added release notes for version 0.1.17, including:
  - Deprecation of the old parameter file structure. ([#283](https://github.com/microsoft/fabric-cicd/issues/283))
  - Onboarding of new item types: CopyJob, Eventstream, Eventhouse/KQL Database, Data Activator, and KQL Queryset. ([#122](https://github.com/microsoft/fabric-cicd/issues/122), [#170](https://github.com/microsoft/fabric-cicd/issues/170), [#169](https://github.com/microsoft/fabric-cicd/issues/169), [#291](https://github.com/microsoft/fabric-cicd/issues/291), [#292](https://github.com/microsoft/fabric-cicd/issues/292))
  - Fix for post-publish operations on skipped items. ([#277](https://github.com/microsoft/fabric-cicd/issues/277))
  - Introduction of the `key_value_replace` function for key-based replacement operations in JSON and YAML.
  - Documentation update with a regex example for the `publish_all_items` feature.

### Version Update:
* Updated the `VERSION` constant in `src/fabric_cicd/constants.py` to reflect the new version 0.1.17.