### PR TITLE
Fixes #295 When publish environments in v. 0.1.17 (publish_item_name_exclude_regex is None)

### DIFF
--- a/src/fabric_cicd/_items/_environment.py
+++ b/src/fabric_cicd/_items/_environment.py
@@ -94,9 +94,14 @@ def check_environment_publish_state(fabric_workspace_obj: FabricWorkspace, initi
 
     environments = fabric_workspace_obj.repository_items.get("Environment", {})
 
-    logger.info(
-        f"Checking Environment Publish State for {[k for k in environments if not re.search(fabric_workspace_obj.publish_item_name_exclude_regex, k)]}"
-    )
+    filtered_environments = [
+        k
+        for k in environments
+        if not fabric_workspace_obj.publish_item_name_exclude_regex
+        or not re.search(fabric_workspace_obj.publish_item_name_exclude_regex, k)
+    ]
+
+    logger.info(f"Checking Environment Publish State for {filtered_environments}")
 
     while ongoing_publish:
         ongoing_publish = False


### PR DESCRIPTION
This pull request refactors the logging and filtering logic in the `check_environment_publish_state` function to improve readability and handle cases where the `publish_item_name_exclude_regex` might be `None`.

### Refactoring and readability improvements:

* [`src/fabric_cicd/_items/_environment.py`](diffhunk://#diff-d21d8d1ab1b91c6581949c76a61d12d3f838509ef127b4ae5144feb5bc23bd8aL97-R104): Refactored the filtering logic for environments into a new `filtered_environments` variable, improving readability and ensuring the code handles cases where `publish_item_name_exclude_regex` is `None`. Updated the logging statement to use the new variable.