### PR TITLE
v0.1.18

### DIFF
--- a/src/fabric_cicd/changelog.md
+++ b/src/fabric_cicd/changelog.md
@@ -6,6 +6,12 @@ The following contains all major, minor, and patch version release notes.
 -   📝 Documentation Update
 -   ⚡ Internal Optimization
 
+## Version 0.1.18
+
+<span class="md-h2-subheader">Release Date: 2025-05-14</span>
+
+-   🔧 Fix bug with check environment publish state when `publish_item_name_exclude_regex` is `None` ([#295](https://github.com/microsoft/fabric-cicd/issues/295))
+
 ## Version 0.1.17
 
 <span class="md-h2-subheader">Release Date: 2025-05-13</span>

--- a/src/fabric_cicd/changelog.md
+++ b/src/fabric_cicd/changelog.md
@@ -10,7 +10,7 @@ The following contains all major, minor, and patch version release notes.
 
 <span class="md-h2-subheader">Release Date: 2025-05-14</span>
 
--   🔧 Fix bug with check environment publish state when `publish_item_name_exclude_regex` is `None` ([#295](https://github.com/microsoft/fabric-cicd/issues/295))
+-   🔧 Fix bug with checking environment publish state ([#295](https://github.com/microsoft/fabric-cicd/issues/295))
 
 ## Version 0.1.17
 

--- a/src/fabric_cicd/changelog.md
+++ b/src/fabric_cicd/changelog.md
@@ -10,7 +10,7 @@ The following contains all major, minor, and patch version release notes.
 
 <span class="md-h2-subheader">Release Date: 2025-05-14</span>
 
--   🔧 Fix bug with checking environment publish state ([#295](https://github.com/microsoft/fabric-cicd/issues/295))
+-   🔧 Fix bug with check environment publish state ([#295](https://github.com/microsoft/fabric-cicd/issues/295))
 
 ## Version 0.1.17
 

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -4,7 +4,7 @@
 """Constants for the fabric-cicd package."""
 
 # General
-VERSION = "0.1.17"
+VERSION = "0.1.18"
 DEFAULT_WORKSPACE_ID = "00000000-0000-0000-0000-000000000000"
 DEFAULT_API_ROOT_URL = "https://api.powerbi.com"
 FEATURE_FLAG = set()


### PR DESCRIPTION
This pull request updates the `fabric-cicd` package to version `0.1.18` and includes a bug fix along with the corresponding documentation updates.

### Version update:

* [`src/fabric_cicd/constants.py`](diffhunk://#diff-91c2d32be351f155f090c4bd57ebe3c10e646edbc1b663e2a72b697f956a949cL7-R7): Updated the `VERSION` constant from `0.1.17` to `0.1.18`.

### Bug fix and release notes:

* [`src/fabric_cicd/changelog.md`](diffhunk://#diff-375b3b0713fcf6f8212d7f9bd6eccf4ca9b73db611c469827967823acca6279aR9-R14): Added release notes for version `0.1.18`, including a fix for a bug related to checking the environment publish state when `publish_item_name_exclude_regex` is `None`.