### PR TITLE
Onboard Warehouse: Empty Item and Collation Support

### DIFF
--- a/docs/how_to/item_types.md
+++ b/docs/how_to/item_types.md
@@ -25,6 +25,15 @@
 -   **Schemas are not deployed** unless the schema has a shortcut present.
 -   **Unpublish** is disabled by default, enable with feature flag `enable_lakehouse_unpublish`.
 
+## Warehouses
+
+-   **Parameterization:**
+    -   The `find_replace` section in the `parameter.yml` file is not applied.
+-   **Warehouse content is not deployed** deployment is of the empty item only, warehouse DDL must be deployed separately via dacpac or other tools such as dbt.
+-   **Case insensitive collation is supported** custom collation must be manually edited in the `.platform` file creation payload. See [How to: Create a warehouse with case-insensitive (CI) collation
+    ](https://learn.microsoft.com/en-us/fabric/data-warehouse/collation) for more details.
+-   **Unpublish** is disabled by default, enable with feature flag `enable_warehouse_unpublish`.
+
 ## Mirrored Database
 
 -   **Parameterization:**

--- a/sample/workspace/Default.Warehouse/.platform
+++ b/sample/workspace/Default.Warehouse/.platform
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/gitIntegration/platformProperties/2.0.0/schema.json",
+  "metadata": {
+    "type": "Warehouse",
+    "displayName": "Default"
+  },
+  "config": {
+    "version": "2.0",
+    "logicalId": "4f344f2d-b51a-a14e-4706-c94957a91175"
+  }
+}

--- a/sample/workspace/DefaultCaseInsensitive.Warehouse/.platform
+++ b/sample/workspace/DefaultCaseInsensitive.Warehouse/.platform
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/gitIntegration/platformProperties/2.0.0/schema.json",
+  "metadata": {
+    "type": "Warehouse",
+    "displayName": "DefaultCaseInsensitive",
+    "creationPayload": {
+      "defaultCollation": "Latin1_General_100_CI_AS_KS_WS_SC_UTF8"
+    }
+  },
+  "config": {
+    "version": "2.0",
+    "logicalId": "0e63f8ad-3b03-4f91-8d5e-b33750b3beec"
+  }
+}

--- a/src/fabric_cicd/_items/__init__.py
+++ b/src/fabric_cicd/_items/__init__.py
@@ -18,6 +18,7 @@ from fabric_cicd._items._notebook import publish_notebooks
 from fabric_cicd._items._report import publish_reports
 from fabric_cicd._items._semanticmodel import publish_semanticmodels
 from fabric_cicd._items._variablelibrary import publish_variablelibraries
+from fabric_cicd._items._warehouse import publish_warehouses
 
 __all__ = [
     "check_environment_publish_state",
@@ -35,5 +36,6 @@ __all__ = [
     "publish_reports",
     "publish_semanticmodels",
     "publish_variablelibraries",
+    "publish_warehouses",
     "sort_datapipelines",
 ]

--- a/src/fabric_cicd/_items/_warehouse.py
+++ b/src/fabric_cicd/_items/_warehouse.py
@@ -1,0 +1,44 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Functions to process and deploy Warehouse item."""
+
+import json
+import logging
+
+from fabric_cicd import FabricWorkspace, constants
+
+logger = logging.getLogger(__name__)
+
+
+def publish_warehouses(fabric_workspace_obj: FabricWorkspace) -> None:
+    """
+    Publishes all warehouse items from the repository.
+
+    Args:
+        fabric_workspace_obj: The FabricWorkspace object containing the items to be published
+    """
+    item_type = "Warehouse"
+
+    for item_name, item in fabric_workspace_obj.repository_items.get(item_type, {}).items():
+        creation_payload = next(
+            (
+                json.loads(file.contents)["metadata"]["creationPayload"]
+                for file in item.item_files
+                if file.name == ".platform" and "creationPayload" in file.contents
+            ),
+            None,
+        )
+
+        fabric_workspace_obj._publish_item(
+            item_name=item_name,
+            item_type=item_type,
+            creation_payload=creation_payload,
+            skip_publish_logging=True,
+        )
+
+        # Check if the item is published to avoid any post publish actions
+        if item.skip_publish:
+            continue
+
+        logger.info(f"{constants.INDENT}Published")

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -32,7 +32,7 @@ ACCEPTED_ITEM_TYPES_NON_UPN = ACCEPTED_ITEM_TYPES_UPN
 
 # Publish
 MAX_RETRY_OVERRIDE = {"SemanticModel": 10, "Report": 10, "Eventstream": 10, "KQLDatabase": 10, "VariableLibrary": 7}
-SHELL_ONLY_PUBLISH = ["Environment", "Lakehouse"]
+SHELL_ONLY_PUBLISH = ["Environment", "Lakehouse", "Warehouse"]
 
 # REGEX Constants
 VALID_GUID_REGEX = r"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -26,6 +26,7 @@ ACCEPTED_ITEM_TYPES_UPN = (
     "KQLQueryset",
     "Reflex",
     "Eventstream",
+    "Warehouse",
 )
 ACCEPTED_ITEM_TYPES_NON_UPN = ACCEPTED_ITEM_TYPES_UPN
 

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -107,6 +107,8 @@ def publish_all_items(fabric_workspace_obj: FabricWorkspace, item_name_exclude_r
     if "Eventstream" in fabric_workspace_obj.item_type_in_scope:
         print_header("Publishing Eventstreams")
         items.publish_eventstreams(fabric_workspace_obj)
+    if "Warehouse" in fabric_workspace_obj.item_type_in_scope:
+        items.publish_warehouses(fabric_workspace_obj)
 
     # Check Environment Publish
     if "Environment" in fabric_workspace_obj.item_type_in_scope:

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -156,7 +156,7 @@ def unpublish_all_orphan_items(fabric_workspace_obj: FabricWorkspace, item_name_
 
     # Define order to unpublish items
     unpublish_order = []
-    for x in [
+    for item_type in [
         "Eventstream",
         "Reflex",
         "KQLQueryset",
@@ -169,12 +169,19 @@ def unpublish_all_orphan_items(fabric_workspace_obj: FabricWorkspace, item_name_
         "Environment",
         "MirroredDatabase",
         "Lakehouse",
+        "Warehouse",
         "VariableLibrary",
     ]:
-        if x in fabric_workspace_obj.item_type_in_scope and (
-            x != "Lakehouse" or "enable_lakehouse_unpublish" in constants.FEATURE_FLAG
-        ):
-            unpublish_order.append(x)
+        # Lakehouses and Warehouses can only be unpublished if their feature flags are set
+        if item_type in fabric_workspace_obj.item_type_in_scope:
+            if item_type == "Lakehouse":
+                if "enable_lakehouse_unpublish" in constants.FEATURE_FLAG:
+                    unpublish_order.append(item_type)
+            elif item_type == "Warehouse":
+                if "enable_warehouse_unpublish" in constants.FEATURE_FLAG:
+                    unpublish_order.append(item_type)
+            else:
+                unpublish_order.append(item_type)
 
     for item_type in unpublish_order:
         deployed_names = set(fabric_workspace_obj.deployed_items.get(item_type, {}).keys())


### PR DESCRIPTION
This pull request introduces support to deploy empty Warehouse items allowing for the temporary unblock of issue #204. This will allow Warehouse users the ability to deploy items via `fabric-cicd` and bring their own tools for any project DDL code that must be deployed.

### Codebase Enhancements:

- Introduced a new publish_warehouses function in src/fabric_cicd/_items/_warehouse.py to handle the publishing of empty Warehouse items. These changes will dynamically support additional collations as they become supported in the future.
- Updated src/fabric_cicd/_items/__init__.py to include publish_warehouses in the module exports and imports.
- Added Warehouse to the list of accepted item types in src/fabric_cicd/constants.py.
- Modified the publish_all_items function in src/fabric_cicd/publish.py to include logic for publishing Warehouse items if they are in scope.
- Disabled unpublish Warehouse by default
- Added feature flag `enable_warehouse_unpublish` to override unpublish default

### Documentation Updates:
- Added a new section in docs/how_to/item_types.md to document Warehouse parameterization and initial deployment requirements. This includes details about how connections are managed and parameterized during deployment. 

### Configuration for Warehouse:
- Added sample/workspace/Default.Warehouse/.platform to define metadata and configuration for an empty Warehouse item with standard case sensitive collation (Latin1_General_100_BIN2_UTF8 by default).
- Added sample/workspace/DefaultCaseInsensitive.Warehouse/.platform to define metadata and configuration for an empty Warehouse item with custom case insensitive collation (Latin1_General_100_CI_AS_KS_WS_SC_UTF8).

