### PR TITLE
Resolves #273 Bug when determining orphan workspace folders to unpublish

### DIFF
--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -634,34 +634,57 @@ class FabricWorkspace:
         logger.info(f"{constants.INDENT}Published")
 
     def _unpublish_folders(self) -> None:
-        """Unublishes all empty folders in workspace."""
+        """Unpublishes all empty folders in workspace."""
         # Sort folders by the number of '/' in their paths (descending order)
-        sorted_folders = sorted(self.deployed_folders.keys(), key=lambda path: path.count("/"), reverse=True)
-        sorted_folder_ids = [self.deployed_folders[folder_path] for folder_path in sorted_folders]
-        logger.info("Unpublishing Workspace Folders")
+        sorted_folder_ids = [
+            self.deployed_folders[key]
+            for key in sorted(self.deployed_folders.keys(), key=lambda path: path.count("/"), reverse=True)
+        ]
 
         ## Any folder that neither contains items nor is an ancestor of a folder
-        ## containing items is considered orphaned.
+        ## containing items is considered orphaned
 
-        # Create a set of folders that contain items, and therefore can't be deleted
-        deployed_folder_ids_with_items = {
-            item.folder_id for items in self.deployed_items.values() for item in items.values()
+        # Create a set of folders that contain items
+        unorphaned_folders = {
+            item.folder_id for items in self.deployed_items.values() for item in items.values() if item.folder_id
         }
-        # Add parent folders of folders with items to the set
-        for folder_path in sorted_folders:
-            folder_id = self.deployed_folders[folder_path]
-            if folder_id in deployed_folder_ids_with_items:
-                path_parts = folder_path.split("/")
-                for i in range(1, len(path_parts)):
-                    parent_path = "/".join(path_parts[:i])
-                    parent_folder_id = self.deployed_folders.get(parent_path)
-                    if parent_folder_id:
-                        deployed_folder_ids_with_items.add(parent_folder_id)
+        # Skip deletion if all deployed folders are unorphaned
+        if unorphaned_folders == set(sorted_folder_ids):
+            return
+
+        # Create a reversed mapping for folder_id to folder_path lookups
+        folder_id_to_path_mapping = {folder_id: folder_path for folder_path, folder_id in self.deployed_folders.items()}
+
+        # Create a copy of the unorphaned_folders set to safely iterate while modifying the original set
+        folder_lookup = unorphaned_folders.copy()
+
+        # For each folder containing items, identify and protect all its ancestor folders from deletion
+        for folder_id in folder_lookup:
+            if folder_id in folder_id_to_path_mapping:
+                # Get the folder path
+                folder_path = folder_id_to_path_mapping[folder_id]
+
+            # Move up the folder hierarchy and add all ancestor folders
+            current_folder_path = folder_path
+            while current_folder_path != "/":
+                # Get the parent folder path
+                current_folder_path = current_folder_path.rsplit("/", 1)[0] or "/"
+
+                # Get the folder_id for this path and add to the unorphaned_folder set
+                parent_folder_id = self.deployed_folders.get(current_folder_path)
+                if parent_folder_id:
+                    unorphaned_folders.add(parent_folder_id)
+
+        # Check if deletion can be skipped after update to unorphaned_folder set
+        if unorphaned_folders == set(sorted_folder_ids):
+            return
+
+        logger.info("Unpublishing Workspace Folders")
 
         # Pop all folders
 
         for folder_id in sorted_folder_ids:
-            if folder_id not in deployed_folder_ids_with_items:
+            if folder_id not in unorphaned_folders:
                 # Folder deployed, but not in repository
 
                 # Delete the folder from the workspace

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -640,8 +640,8 @@ class FabricWorkspace:
         sorted_folder_ids = [self.deployed_folders[folder_path] for folder_path in sorted_folders]
         logger.info("Unpublishing Workspace Folders")
 
-        ## Any folder that does not contain an item or does not parent folders
-        ## containing an item in its hierarchy is an orphaned folder
+        ## Any folder that neither contains items nor is an ancestor of a folder
+        ## containing items is considered orphaned.
 
         # Create a set of folders that contain items, and therefore can't be deleted
         deployed_folder_ids_with_items = {

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -223,5 +223,6 @@ def unpublish_all_orphan_items(fabric_workspace_obj: FabricWorkspace, item_name_
             fabric_workspace_obj._unpublish_item(item_name=item_name, item_type=item_type)
 
     fabric_workspace_obj._refresh_deployed_items()
+    fabric_workspace_obj._refresh_deployed_folders()
     if "disable_workspace_folder_publish" not in constants.FEATURE_FLAG:
         fabric_workspace_obj._unpublish_folders()


### PR DESCRIPTION
This pull request includes updates to improve the handling of folder and item unpublishing in the `fabric_cicd` module. The most important changes involve optimizing the logic for determining orphaned folders and ensuring that folder metadata is refreshed during the unpublishing process.

### Improvements to folder unpublishing logic:
* [`src/fabric_cicd/fabric_workspace.py`](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L639-R659): Refactored the `_unpublish_folders` method to improve clarity and efficiency. The logic now uses a set to track folders containing items and their parent folders, ensuring that only orphaned folders are unregistered.

### Metadata refresh enhancements:
* [`src/fabric_cicd/publish.py`](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R226): Added a call to `_refresh_deployed_folders` in the `unpublish_all_orphan_items` function to ensure folder metadata is up-to-date before unpublishing operations.