### PR TITLE
v0.1.19

### DIFF
--- a/src/fabric_cicd/changelog.md
+++ b/src/fabric_cicd/changelog.md
@@ -6,6 +6,14 @@ The following contains all major, minor, and patch version release notes.
 -   📝 Documentation Update
 -   ⚡ Internal Optimization
 
+## Version 0.1.19
+
+<span class="md-h2-subheader">Release Date: 2025-05-21</span>
+
+-   ✨ Onboard SQL Database item type (shell-only deployment) ([#301](https://github.com/microsoft/fabric-cicd/issues/301))
+-   ✨ Onboard Warehouse item type (shell-only deployment) ([#204](https://github.com/microsoft/fabric-cicd/issues/204))
+-   🔧 Fix bug with unpublish workspace folders ([#273](https://github.com/microsoft/fabric-cicd/issues/273))
+
 ## Version 0.1.18
 
 <span class="md-h2-subheader">Release Date: 2025-05-14</span>

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -4,7 +4,7 @@
 """Constants for the fabric-cicd package."""
 
 # General
-VERSION = "0.1.18"
+VERSION = "0.1.19"
 DEFAULT_WORKSPACE_ID = "00000000-0000-0000-0000-000000000000"
 DEFAULT_API_ROOT_URL = "https://api.powerbi.com"
 FEATURE_FLAG = set()


### PR DESCRIPTION
This pull request updates the `fabric-cicd` package to version 0.1.19, introducing new features, a bug fix, and updating the version constant. Below are the key changes:

### Release Notes Update:
* Added release notes for version 0.1.19 in `src/fabric_cicd/changelog.md`, including:
  - Onboarding of SQL Database item type (shell-only deployment).
  - Onboarding of Warehouse item type (shell-only deployment).
  - Bug fix for unpublishing workspace folders.

### Version Constant Update:
* Updated the `VERSION` constant in `src/fabric_cicd/constants.py` from `0.1.18` to `0.1.19`.