### PR TITLE
Release/v0.1.21

### DIFF
--- a/src/fabric_cicd/changelog.md
+++ b/src/fabric_cicd/changelog.md
@@ -6,6 +6,13 @@ The following contains all major, minor, and patch version release notes.
 -   📝 Documentation Update
 -   ⚡ Internal Optimization
 
+## Version 0.1.21
+
+<span class="md-h2-subheader">Release Date: 2025-06-18</span>
+
+-   🔧 Fix bug with workspace ID replacement in JSON files for pipeline deployments ([#345](https://github.com/microsoft/fabric-cicd/issues/345))
+-   ⚡ Increased max retry for Warehouses and Dataflows
+
 ## Version 0.1.20
 
 <span class="md-h2-subheader">Release Date: 2025-06-12</span>

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -4,7 +4,7 @@
 """Constants for the fabric-cicd package."""
 
 # General
-VERSION = "0.1.20"
+VERSION = "0.1.21"
 DEFAULT_WORKSPACE_ID = "00000000-0000-0000-0000-000000000000"
 DEFAULT_API_ROOT_URL = "https://api.powerbi.com"
 FEATURE_FLAG = set()
@@ -48,7 +48,7 @@ SHELL_ONLY_PUBLISH = ["Environment", "Lakehouse", "Warehouse", "SQLDatabase"]
 
 # REGEX Constants
 VALID_GUID_REGEX = r"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
-WORKSPACE_ID_REFERENCE_REGEX = r'\"?(default_lakehouse_workspace_id|workspaceId|workspace)\"?\s*[:=]\s*\"(.*?)\"'
+WORKSPACE_ID_REFERENCE_REGEX = r"\"?(default_lakehouse_workspace_id|workspaceId|workspace)\"?\s*[:=]\s*\"(.*?)\""
 DATAFLOW_ID_REFERENCE_REGEX = r'(dataflowId)\s*=\s*"(.*?)"'
 INVALID_FOLDER_CHAR_REGEX = r'[~"#.%&*:<>?/\\{|}]'
 

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -48,7 +48,7 @@ SHELL_ONLY_PUBLISH = ["Environment", "Lakehouse", "Warehouse", "SQLDatabase"]
 
 # REGEX Constants
 VALID_GUID_REGEX = r"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
-WORKSPACE_ID_REFERENCE_REGEX = r"\"?(default_lakehouse_workspace_id|workspaceId|workspace)\"?\s*[:=]\s*\"(.*?)\""
+WORKSPACE_ID_REFERENCE_REGEX = r'\"?(default_lakehouse_workspace_id|workspaceId|workspace)\"?\s*[:=]\s*\"(.*?)\"'
 DATAFLOW_ID_REFERENCE_REGEX = r'(dataflowId)\s*=\s*"(.*?)"'
 INVALID_FOLDER_CHAR_REGEX = r'[~"#.%&*:<>?/\\{|}]'
 


### PR DESCRIPTION
This pull request updates the `fabric-cicd` package to version 0.1.21, introducing a bug fix and an internal optimization. The most important changes include updating the version constant and documenting the new release in the changelog.

### Version update:

* [`src/fabric_cicd/constants.py`](diffhunk://#diff-91c2d32be351f155f090c4bd57ebe3c10e646edbc1b663e2a72b697f956a949cL7-R7): Updated the `VERSION` constant from `"0.1.20"` to `"0.1.21"`.

### Changelog update:

* [`src/fabric_cicd/changelog.md`](diffhunk://#diff-375b3b0713fcf6f8212d7f9bd6eccf4ca9b73db611c469827967823acca6279aR9-R15): Added release notes for version 0.1.21, including a bug fix for workspace ID replacement in JSON files during pipeline deployments and an increase in the maximum retry limit for Warehouses and Dataflows.