### PR TITLE
Resolves #287 Support for GraphQL API Item

### DIFF
--- a/docs/how_to/item_types.md
+++ b/docs/how_to/item_types.md
@@ -10,8 +10,10 @@
 ## API for GraphQL
 
 -   **Parameterization:**
-    -   The source will always point to the original source unless parameterized in the `find_replace` section of the `parameter.yml` file.
+    -   The source will always point to the source in the original workspace unless parameterized in the `find_replace` section of the `parameter.yml` file.
     -   It is recommended to use the supported variables in `find_replace` for dynamic replacement of the source workspace and item IDs.
+    -   If you are using a connection and expect it to change between different environments, then it needs to be parameterized in the `parameter.yml` file.
+-   When using the **Saved Credential** method to connect to data sources, developers must have access to the Saved Credential information in order to successfully deploy GraphQL item.
 
 ## Copy Jobs
 
@@ -35,7 +37,7 @@
     -   Activities connected to items that exist in a different workspace will always point to the original item unless parameterized in the `find_replace` section of the `parameter.yml` file.
     -   Activities connected to items within the same workspace are re-pointed to the new item in the target workspace.
 -   **Connections** are not source controlled and must be created manually.
--   If you are using connections and expect them to change between different environments, then those need to be parameterized in the parameter.yml file.
+-   If you are using connections and expect them to change between different environments, then those need to be parameterized in the `parameter.yml` file.
 -   The **executing identity** of the deployment must have access to the connections, or the deployment will fail.
 
 ## Environments

--- a/docs/how_to/item_types.md
+++ b/docs/how_to/item_types.md
@@ -15,6 +15,7 @@
     -   If you are using a connection and expect it to change between different environments, then it needs to be parameterized in the `parameter.yml` file.
 -   When using the **Saved Credential** method to connect to data sources, developers must have access to the Saved Credential information in order to successfully deploy GraphQL item.
 -   Changes made to the original API query are not source controlled. You will need to manually update the query in the GraphQL item's query editor within the target workspace.
+-   Only user authentication is currently supported for GraphQL items that source data from the SQL Analytics Endpoint.
 
 ## Copy Jobs
 

--- a/docs/how_to/item_types.md
+++ b/docs/how_to/item_types.md
@@ -14,6 +14,7 @@
     -   It is recommended to use the supported variables in `find_replace` for dynamic replacement of the source workspace and item IDs.
     -   If you are using a connection and expect it to change between different environments, then it needs to be parameterized in the `parameter.yml` file.
 -   When using the **Saved Credential** method to connect to data sources, developers must have access to the Saved Credential information in order to successfully deploy GraphQL item.
+-   Changes made to the original API query are not source controlled. You will need to manually update the query in the GraphQL item's query editor within the target workspace.
 
 ## Copy Jobs
 

--- a/docs/how_to/item_types.md
+++ b/docs/how_to/item_types.md
@@ -7,6 +7,11 @@
 -   **Initial deployment** may not reflect streaming data immediately.
 -   **Reflex** is the item name in source control. Source control may not support all activators/reflexes, as not all sources are compatible.
 
+## API for GraphQL
+
+-   **Parameterization:**
+    -   The source will always point to the original source unless parameterized in the `find_replace` section of the `parameter.yml` file.
+
 ## Copy Jobs
 
 -   **Parameterization:**

--- a/docs/how_to/item_types.md
+++ b/docs/how_to/item_types.md
@@ -11,6 +11,7 @@
 
 -   **Parameterization:**
     -   The source will always point to the original source unless parameterized in the `find_replace` section of the `parameter.yml` file.
+    -   It is recommended to use the supported variables in `find_replace` for dynamic replacement of the source workspace and item IDs.
 
 ## Copy Jobs
 

--- a/sample/workspace/Sample.GraphQLApi/.platform
+++ b/sample/workspace/Sample.GraphQLApi/.platform
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/gitIntegration/platformProperties/2.0.0/schema.json",
+  "metadata": {
+    "type": "GraphQLApi",
+    "displayName": "Sample"
+  },
+  "config": {
+    "version": "2.0",
+    "logicalId": "c1e7dc70-264e-928d-43fa-a371558f47e4"
+  }
+}

--- a/sample/workspace/Sample.GraphQLApi/graphql-definition.json
+++ b/sample/workspace/Sample.GraphQLApi/graphql-definition.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/graphqlApi/definition/1.0.0/schema.json",
+  "datasources": []
+}

--- a/src/fabric_cicd/_items/__init__.py
+++ b/src/fabric_cicd/_items/__init__.py
@@ -8,6 +8,7 @@ from fabric_cicd._items._datapipeline import find_referenced_datapipelines, publ
 from fabric_cicd._items._environment import check_environment_publish_state, publish_environments
 from fabric_cicd._items._eventhouse import publish_eventhouses
 from fabric_cicd._items._eventstream import publish_eventstreams
+from fabric_cicd._items._graphqlapi import publish_graphqlapis
 from fabric_cicd._items._kqldashboard import publish_kqldashboard
 from fabric_cicd._items._kqldatabase import publish_kqldatabases
 from fabric_cicd._items._kqlqueryset import publish_kqlquerysets
@@ -32,6 +33,7 @@ __all__ = [
     "publish_environments",
     "publish_eventhouses",
     "publish_eventstreams",
+    "publish_graphqlapis",
     "publish_kqldashboard",
     "publish_kqldatabases",
     "publish_kqlquerysets",

--- a/src/fabric_cicd/_items/_graphqlapi.py
+++ b/src/fabric_cicd/_items/_graphqlapi.py
@@ -1,0 +1,23 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Functions to process and deploy API for GraphQL item."""
+
+import logging
+
+from fabric_cicd import FabricWorkspace
+
+logger = logging.getLogger(__name__)
+
+
+def publish_graphqlapis(fabric_workspace_obj: FabricWorkspace) -> None:
+    """
+    Publishes all graphqlapi items from the repository.
+
+    Args:
+        fabric_workspace_obj: The FabricWorkspace object containing the items to be published.
+    """
+    item_type = "GraphQLApi"
+
+    for item_name in fabric_workspace_obj.repository_items.get(item_type, {}):
+        fabric_workspace_obj._publish_item(item_name=item_name, item_type=item_type)

--- a/src/fabric_cicd/changelog.md
+++ b/src/fabric_cicd/changelog.md
@@ -6,6 +6,13 @@ The following contains all major, minor, and patch version release notes.
 -   📝 Documentation Update
 -   ⚡ Internal Optimization
 
+## Version 0.1.21
+
+<span class="md-h2-subheader">Release Date: 2025-06-18</span>
+
+-   🔧 Fix bug with workspace ID replacement in JSON files for pipeline deployments ([#345](https://github.com/microsoft/fabric-cicd/issues/345))
+-   ⚡ Increased max retry for Warehouses and Dataflows
+
 ## Version 0.1.20
 
 <span class="md-h2-subheader">Release Date: 2025-06-12</span>

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -4,7 +4,7 @@
 """Constants for the fabric-cicd package."""
 
 # General
-VERSION = "0.1.20"
+VERSION = "0.1.21"
 DEFAULT_WORKSPACE_ID = "00000000-0000-0000-0000-000000000000"
 DEFAULT_API_ROOT_URL = "https://api.powerbi.com"
 FEATURE_FLAG = set()

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -30,6 +30,7 @@ ACCEPTED_ITEM_TYPES_UPN = (
     "SQLDatabase",
     "KQLDashboard",
     "Dataflow",
+    "GraphQLApi",
 )
 ACCEPTED_ITEM_TYPES_NON_UPN = ACCEPTED_ITEM_TYPES_UPN
 
@@ -43,12 +44,13 @@ MAX_RETRY_OVERRIDE = {
     "Warehouse": 10,
     "Dataflow": 10,
     "VariableLibrary": 7,
+    "GraphQLApi": 7,
 }
 SHELL_ONLY_PUBLISH = ["Environment", "Lakehouse", "Warehouse", "SQLDatabase"]
 
 # REGEX Constants
 VALID_GUID_REGEX = r"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
-WORKSPACE_ID_REFERENCE_REGEX = r'\"?(default_lakehouse_workspace_id|workspaceId|workspace)\"?\s*[:=]\s*\"(.*?)\"'
+WORKSPACE_ID_REFERENCE_REGEX = r"\"?(default_lakehouse_workspace_id|workspaceId|workspace)\"?\s*[:=]\s*\"(.*?)\""
 DATAFLOW_ID_REFERENCE_REGEX = r'(dataflowId)\s*=\s*"(.*?)"'
 INVALID_FOLDER_CHAR_REGEX = r'[~"#.%&*:<>?/\\{|}]'
 

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -119,6 +119,9 @@ def publish_all_items(fabric_workspace_obj: FabricWorkspace, item_name_exclude_r
         items.publish_datapipelines(fabric_workspace_obj)
     if "GraphQLApi" in fabric_workspace_obj.item_type_in_scope:
         print_header("Publishing GraphQL APIs")
+        logger.warning(
+            "Only user authentication is supported for GraphQL API items sourced from SQL Analytics Endpoint"
+        )
         items.publish_graphqlapis(fabric_workspace_obj)
 
     # Check Environment Publish

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -117,6 +117,9 @@ def publish_all_items(fabric_workspace_obj: FabricWorkspace, item_name_exclude_r
     if "DataPipeline" in fabric_workspace_obj.item_type_in_scope:
         print_header("Publishing DataPipelines")
         items.publish_datapipelines(fabric_workspace_obj)
+    if "GraphQLApi" in fabric_workspace_obj.item_type_in_scope:
+        print_header("Publishing GraphQLApi")
+        items.publish_graphqlapis(fabric_workspace_obj)
 
     # Check Environment Publish
     if "Environment" in fabric_workspace_obj.item_type_in_scope:
@@ -172,6 +175,7 @@ def unpublish_all_orphan_items(fabric_workspace_obj: FabricWorkspace, item_name_
     # Define order to unpublish items
     unpublish_order = []
     for item_type in [
+        "GraphQLApi",
         "DataPipeline",
         "Dataflow",
         "Eventstream",

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -76,7 +76,7 @@ def publish_all_items(fabric_workspace_obj: FabricWorkspace, item_name_exclude_r
         print_header("Publishing SQL Databases")
         items.publish_sqldatabases(fabric_workspace_obj)
     if "MirroredDatabase" in fabric_workspace_obj.item_type_in_scope:
-        print_header("Publishing MirroredDatabase")
+        print_header("Publishing Mirrored Databases")
         items.publish_mirroreddatabase(fabric_workspace_obj)
     if "Environment" in fabric_workspace_obj.item_type_in_scope:
         print_header("Publishing Environments")
@@ -85,13 +85,13 @@ def publish_all_items(fabric_workspace_obj: FabricWorkspace, item_name_exclude_r
         print_header("Publishing Notebooks")
         items.publish_notebooks(fabric_workspace_obj)
     if "SemanticModel" in fabric_workspace_obj.item_type_in_scope:
-        print_header("Publishing SemanticModels")
+        print_header("Publishing Semantic Models")
         items.publish_semanticmodels(fabric_workspace_obj)
     if "Report" in fabric_workspace_obj.item_type_in_scope:
         print_header("Publishing Reports")
         items.publish_reports(fabric_workspace_obj)
     if "CopyJob" in fabric_workspace_obj.item_type_in_scope:
-        print_header("Publishing CopyJobs")
+        print_header("Publishing Copy Jobs")
         items.publish_copyjobs(fabric_workspace_obj)
     if "Eventhouse" in fabric_workspace_obj.item_type_in_scope:
         print_header("Publishing Eventhouses")
@@ -109,16 +109,16 @@ def publish_all_items(fabric_workspace_obj: FabricWorkspace, item_name_exclude_r
         print_header("Publishing Eventstreams")
         items.publish_eventstreams(fabric_workspace_obj)
     if "KQLDashboard" in fabric_workspace_obj.item_type_in_scope:
-        print_header("Publishing KQLDashboard")
+        print_header("Publishing KQL Dashboards")
         items.publish_kqldashboard(fabric_workspace_obj)
     if "Dataflow" in fabric_workspace_obj.item_type_in_scope:
         print_header("Publishing Dataflows")
         items.publish_dataflows(fabric_workspace_obj)
     if "DataPipeline" in fabric_workspace_obj.item_type_in_scope:
-        print_header("Publishing DataPipelines")
+        print_header("Publishing Data Pipelines")
         items.publish_datapipelines(fabric_workspace_obj)
     if "GraphQLApi" in fabric_workspace_obj.item_type_in_scope:
-        print_header("Publishing GraphQLApi")
+        print_header("Publishing GraphQL APIs")
         items.publish_graphqlapis(fabric_workspace_obj)
 
     # Check Environment Publish


### PR DESCRIPTION
This pull request introduces support for a new `GraphQLApi` item type in the project. The changes include updates to documentation, configuration files, and the codebase to enable publishing and managing `GraphQLApi` items.

### Documentation Updates:
* Added a new section in `docs/how_to/item_types.md` explaining how to parameterize and deploy `GraphQLApi` items, including guidelines for using saved credentials and handling API query updates. [[1]](diffhunk://#diff-2b5373cf38b50a290bee3f403778f7dff7cdc942ddbb39026b291da113dc6025R10-R18) [[2]](diffhunk://#diff-2b5373cf38b50a290bee3f403778f7dff7cdc942ddbb39026b291da113dc6025L32-R41)

### Configuration Updates:
* Added a `.platform` file in `sample/workspace/Sample.GraphQLApi` to define metadata and configuration for the `GraphQLApi` item type.
* Added a `graphql-definition.json` file in `sample/workspace/Sample.GraphQLApi` to define the schema for `GraphQLApi` items.

### Codebase Enhancements:
* Introduced a new `publish_graphqlapis` function in `src/fabric_cicd/_items/_graphqlapi.py` to handle publishing of `GraphQLApi` items.
* Updated `src/fabric_cicd/_items/__init__.py` to include `publish_graphqlapis` in the module imports and exports. [[1]](diffhunk://#diff-94d858110d4e75a68135b9975f58e289c7db48793b5bf7bc56c08efad59f3e34R11) [[2]](diffhunk://#diff-94d858110d4e75a68135b9975f58e289c7db48793b5bf7bc56c08efad59f3e34R36)
* Added `GraphQLApi` as a valid item type in `src/fabric_cicd/constants.py` and specified its priority for publishing. [[1]](diffhunk://#diff-91c2d32be351f155f090c4bd57ebe3c10e646edbc1b663e2a72b697f956a949cR34) [[2]](diffhunk://#diff-91c2d32be351f155f090c4bd57ebe3c10e646edbc1b663e2a72b697f956a949cR48)
* Updated `src/fabric_cicd/publish.py` to include `GraphQLApi` in the publishing and unpublishing workflows. [[1]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R120-R122) [[2]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R178)This pull request introduces support for a new item type, `GraphQLApi`, within the Fabric CICD framework. The changes include adding functionality to publish and unpublish `GraphQLApi` items, updating constants to include the new type, and documenting its parameterization in the API. Below is a breakdown of the most important changes:

### Support for `GraphQLApi` item type:

* Added a new module, `src/fabric_cicd/_items/_graphqlapi.py`, with the `publish_graphqlapis` function to handle publishing `GraphQLApi` items.
* Updated `src/fabric_cicd/_items/__init__.py` to include `publish_graphqlapis` in imports and the `__all__` list for module exports. [[1]](diffhunk://#diff-94d858110d4e75a68135b9975f58e289c7db48793b5bf7bc56c08efad59f3e34R11) [[2]](diffhunk://#diff-94d858110d4e75a68135b9975f58e289c7db48793b5bf7bc56c08efad59f3e34R36)
* Modified `src/fabric_cicd/constants.py` to add `GraphQLApi` to the `ACCEPTED_ITEM_TYPES_UPN` list and define its priority in `ITEM_TYPE_PRIORITY`. [[1]](diffhunk://#diff-91c2d32be351f155f090c4bd57ebe3c10e646edbc1b663e2a72b697f956a949cR33) [[2]](diffhunk://#diff-91c2d32be351f155f090c4bd57ebe3c10e646edbc1b663e2a72b697f956a949cR47-R53)

### Integration into publishing workflows:

* Updated `src/fabric_cicd/publish.py` to include `GraphQLApi` in the `publish_all_items` and `unpublish_all_orphan_items` functions, ensuring it is handled in both publishing and unpublishing workflows. [[1]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R120-R122) [[2]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R178)

### Documentation updates:

* Added a new section in `docs/how_to/item_types.md` to document the parameterization of `GraphQLApi` items, specifying how the source is managed via the `parameter.yml` file.