### PR TITLE
v0.1.22

### DIFF
--- a/src/fabric_cicd/changelog.md
+++ b/src/fabric_cicd/changelog.md
@@ -6,6 +6,14 @@ The following contains all major, minor, and patch version release notes.
 -   📝 Documentation Update
 -   ⚡ Internal Optimization
 
+## Version 0.1.22
+
+<span class="md-h2-subheader">Release Date: 2025-06-25</span>
+
+-   ✨ Onboard API for GraphQL item type ([#287](https://github.com/microsoft/fabric-cicd/issues/287))
+-   🔧 Fix Fabric API call error during dataflow publish ([#352](https://github.com/microsoft/fabric-cicd/issues/352))
+-   ⚡ Expanded test coverage to handle folder edge cases ([#358](https://github.com/microsoft/fabric-cicd/issues/358))
+
 ## Version 0.1.21
 
 <span class="md-h2-subheader">Release Date: 2025-06-18</span>

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -4,7 +4,7 @@
 """Constants for the fabric-cicd package."""
 
 # General
-VERSION = "0.1.21"
+VERSION = "0.1.22"
 DEFAULT_WORKSPACE_ID = "00000000-0000-0000-0000-000000000000"
 DEFAULT_API_ROOT_URL = "https://api.powerbi.com"
 FABRIC_API_ROOT_URL = "https://api.fabric.microsoft.com"
@@ -51,7 +51,7 @@ SHELL_ONLY_PUBLISH = ["Environment", "Lakehouse", "Warehouse", "SQLDatabase"]
 
 # REGEX Constants
 VALID_GUID_REGEX = r"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
-WORKSPACE_ID_REFERENCE_REGEX = r'\"?(default_lakehouse_workspace_id|workspaceId|workspace)\"?\s*[:=]\s*\"(.*?)\"'
+WORKSPACE_ID_REFERENCE_REGEX = r"\"?(default_lakehouse_workspace_id|workspaceId|workspace)\"?\s*[:=]\s*\"(.*?)\""
 DATAFLOW_ID_REFERENCE_REGEX = r'(dataflowId)\s*=\s*"(.*?)"'
 INVALID_FOLDER_CHAR_REGEX = r'[~"#.%&*:<>?/\\{|}]'
 


### PR DESCRIPTION
This pull request introduces updates for the new version `0.1.22` of the `fabric-cicd` package, including a version bump, changelog additions, and a minor regex formatting change. Below are the most important changes grouped by theme:

### Version Update:

* Updated the `VERSION` constant in `src/fabric_cicd/constants.py` to reflect the new release version `0.1.22`.

### Changelog Additions:

* Added release notes for version `0.1.22` in `src/fabric_cicd/changelog.md`, which include:
  - ✨ Onboarding API for GraphQL item type ([#287](https://github.com/microsoft/fabric-cicd/issues/287)).
  - 🔧 Fix for a Fabric API call error during dataflow publishing ([#352](https://github.com/microsoft/fabric-cicd/issues/352)).
  - ⚡ Expanded test coverage to handle folder edge cases ([#358](https://github.com/microsoft/fabric-cicd/issues/358)).

### Code Formatting:

* Adjusted the `WORKSPACE_ID_REFERENCE_REGEX` in `src/fabric_cicd/constants.py` to use double quotes consistently for string literals.