### PR TITLE
Resolves #309 Copilot Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/6-copilot.yml
+++ b/.github/ISSUE_TEMPLATE/6-copilot.yml
@@ -1,0 +1,37 @@
+name: GitHub Copilot Assignment
+description: Issue template for tasks assigned to GitHub Copilot Agent
+title: "Copilot"
+labels: ["copilot"]
+body:
+    - type: markdown
+      attributes:
+          value: Used internally to raise issues specifically for GitHub Copilot agent assistance. All fields are optional to allow quick task assignment with focused context.
+
+    - type: textarea
+      id: problem-description
+      attributes:
+          label: What is the problem?
+          description: Describe what needs to be done and why.
+      validations:
+          required: true
+
+    - type: textarea
+      id: solution-description
+      attributes:
+          label: Is there an ideal solution?
+          description: Describe the ideal solution if there is one. Provide specific technical details.
+      validations:
+          required: false
+
+    - type: textarea
+      id: success-criteria
+      attributes:
+          label: Success Criteria
+          description: |
+              Define how to know when the task is complete:
+              - Specific functionality that should work
+              - Tests that should pass
+              - Documentation that should be updated
+              - Performance or quality requirements
+      validations:
+          required: false

--- a/.github/ISSUE_TEMPLATE/6-copilot.yml
+++ b/.github/ISSUE_TEMPLATE/6-copilot.yml
@@ -11,7 +11,7 @@ body:
       id: problem-description
       attributes:
           label: What is the problem?
-          description: Describe what needs to be done and why.
+          description: Describe the issue, highlight specific error messages observed, specify why this is happening or what the likely cause is.
       validations:
           required: true
 


### PR DESCRIPTION
This pull request introduces a new issue template specifically for tasks assigned to the GitHub Copilot Agent. The template is designed to streamline task creation and provide focused context for Copilot-related issues.

New GitHub Copilot issue template:

* [`.github/ISSUE_TEMPLATE/6-copilot.yml`](diffhunk://#diff-425cd01e8cadf1e038cc8a3f5a4b6844969748a8c0654571a23058c2849e2c62R1-R37): Added a new issue template named "GitHub Copilot Assignment" with fields for problem description, solution description, and success criteria. This template is tailored for tasks requiring GitHub Copilot assistance, with optional fields to allow quick assignment.## Description
