### PR TITLE
Resolves #412 Fix failure related to updating referenced non-default guids in specific pipeline activities

### DIFF
--- a/docs/how_to/optional_feature.md
+++ b/docs/how_to/optional_feature.md
@@ -6,13 +6,16 @@ fabric-cicd has an expected default flow; however, there will always be cases wh
 
 For scenarios that aren't supported by default, fabric-cicd offers `feature-flags`. Below is an exhaustive list of currently supported features.
 
-| Flag Name                                 | Description                                          |
-| ----------------------------------------- | ---------------------------------------------------- |
-| `enable_lakehouse_unpublish`              | Set to enable the deletion of Lakehouses             |
-| `disable_print_identity`                  | Set to disable printing the executing identity name  |
-| `enable_shortcut_publish`                 | Set to enable deploying shortcuts with the lakehouse |
-| `enable_environment_variable_replacement` | Set to enable the use of pipeline variables          |
-| `disable_workspace_folder_publish`        | Set to disable deploying workspace sub folders       |
+| Flag Name                                 | Description                                                          |
+| ----------------------------------------- | -------------------------------------------------------------------- |
+| `enable_lakehouse_unpublish`              | Set to enable the deletion of Lakehouses                             |
+| `disable_print_identity`                  | Set to disable printing the executing identity name                  |
+| `enable_shortcut_publish`                 | Set to enable deploying shortcuts with the lakehouse                 |
+| `enable_environment_variable_replacement` | Set to enable the use of pipeline variables                          |
+| `enable_item_reference_replacement`\*     | Set to enable replacing referenced item GUIDs in pipeline activities |
+| `disable_workspace_folder_publish`        | Set to disable deploying workspace sub folders                       |
+
+\* The `enable_item_reference_replacement` flag enables replacement of referenced items in pipeline activities that use workspace-specific GUIDs (versus workspace- agnostic GUIDs). Currently, this works for Dataflow refresh and Semantic Model refresh activities (please raise a GitHub issue to request for other activities). This functionality provides an alternative to parameterizing GUIDs found in pipeline activities by automatically resolving the correct GUIDs across environments. Note that this functionality only works when the same workspace access permissions are granted across all environments.
 
 <span class="md-h3-nonanchor">Example</span>
 

--- a/src/fabric_cicd/_common/_exceptions.py
+++ b/src/fabric_cicd/_common/_exceptions.py
@@ -52,3 +52,7 @@ class ParameterFileError(BaseCustomError):
 
 class FailedPublishedItemStatusError(BaseCustomError):
     pass
+
+
+class ItemNotFoundError(BaseCustomError):
+    pass

--- a/src/fabric_cicd/_items/_datapipeline.py
+++ b/src/fabric_cicd/_items/_datapipeline.py
@@ -91,6 +91,10 @@ def update_activity_references(fabric_workspace_obj: FabricWorkspace, file_obj: 
         fabric_workspace_obj: The FabricWorkspace object.
         file_obj: The file object.
     """
+    # If the feature flag is not enabled, return the file contents as is
+    if "enable_item_reference_replacement" not in constants.FEATURE_FLAG:
+        return file_obj.contents
+
     # Create a dictionary from the raw file
     item_content_dict = json.loads(file_obj.contents)
     guid_pattern = re.compile(constants.VALID_GUID_REGEX)


### PR DESCRIPTION
This pull request introduces a new feature flag, `enable_item_reference_replacement`, to enhance pipeline activity management by automatically resolving workspace-specific GUIDs. Additionally, it includes error-handling improvements and updates to the codebase to support this new functionality.

### New Feature: `enable_item_reference_replacement`

* **Documentation update**: Added the `enable_item_reference_replacement` flag to the list of supported feature flags in `docs/how_to/optional_feature.md`. This flag enables automatic replacement of workspace-specific GUIDs in pipeline activities, such as Dataflow and Semantic Model refresh activities. Detailed explanation and usage notes were provided.

* **Feature flag check**: Updated the `update_activity_references` function in `src/fabric_cicd/_items/_datapipeline.py` to return file contents unchanged if the `enable_item_reference_replacement` flag is not enabled.

### Error Handling Enhancements

* **New exception class**: Added the `ItemNotFoundError` exception to `src/fabric_cicd/_common/_exceptions.py` to handle cases where a referenced item cannot be found.

* **Error handling in item lookup**: Updated the `lookup_referenced_item` function in `src/fabric_cicd/_items/_manage_dependencies.py` to raise an `ItemNotFoundError` when an item lookup fails, improving error reporting and debugging.

### Codebase Updates

* **Imports update**: Updated imports in `src/fabric_cicd/_items/_manage_dependencies.py` to include the new `ItemNotFoundError` exception.