### PR TITLE
Resolves #414 - Dynamic Replacement Support for Eventhouse query URI

### DIFF
--- a/docs/how_to/parameterization.md
+++ b/docs/how_to/parameterization.md
@@ -57,7 +57,7 @@ The `replace_value` field supports variables that reference workspace or deploye
 -   **`$workspace.id`**: Replace value is the workspace ID of the target environment.
 -   **`$items.type.name.attribute`**: Replace value is an attribute of a deployed item.
 -   **Format**: Item type and name are **case-sensitive**. Enter the item name exactly as it appears, including spaces. For example: `$items.Notebook.Hello World.id`
--   **Supported attributes**: `id` (item ID) and `sqlendpoint`. Attributes should be lowercase.
+-   **Supported attributes**: `id` (item ID), `sqlendpoint`, and `queryserviceuri`. Attributes should be lowercase.
 -   **Important**: If the specified item type or name does not exist in the deployed workspace, or if an invalid attribute is provided, or if the attribute value does not exist, the deployment will fail.
 -   For an in-depth example, see the **advanced notebook example**.
 
@@ -75,6 +75,10 @@ find_replace:
       replace_value:
           PPE: "$items.Lakehouse.Sample_LH.sqlendpoint" # PPE Sample_LH Lakehouse sql endpoint
           PROD: "$items.Lakehouse.Sample_LH.sqlendpoint" # PROD Sample_LH Lakehouse sql endpoint
+    - find_value: "https://trd-a1b2c3d4e5f6g7h8i9.z4.kusto.fabric.microsoft.com" # Eventhouse query service URI
+      replace_value:
+          PPE: "$items.Eventhouse.Sample_EH.queryserviceuri" # PPE Sample_EH Eventhouse query service URI
+          PROD: "$items.Eventhouse.Sample_EH.queryserviceuri" # PROD Sample_EH Eventhouse query service URI
 ```
 
 <span class="md-h4-nonanchor">Environment Variable Replacement</span>

--- a/sample/workspace/Example Notebook.Notebook/notebook-content.py
+++ b/sample/workspace/Example Notebook.Notebook/notebook-content.py
@@ -26,6 +26,8 @@
 # Type here in the cell editor to add code!
 print("This notebook is attached to the 'WithoutSchema' lakehouse.")
 print("This its SQL analytics endpoint: sqlserverconnectionstringinoriginlakehouse.com")
+print("This workspace includes 'SampleEventhouse' eventhouse.")
+print("This its eventhouse query URI: https://trd-origineventhouse.z4.kusto.fabric.microsoft.com")
 
 # METADATA ********************
 

--- a/sample/workspace/parameter.yml
+++ b/sample/workspace/parameter.yml
@@ -9,7 +9,7 @@ find_replace:
       item_name: ["Hello World", "Hello World Subfolder"]
       file_path:
        - "/Hello World.Notebook/notebook-content.py"
-       - "\\subfolder\\Hello World Subfolder.Notebook/notebook-content.py"
+       - "/subfolder/Hello World Subfolder.Notebook/notebook-content.py"
     # Lakehouse Connection Guid regex
     - find_value: \#\s*META\s+"default_lakehouse":\s*"([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
       replace_value:
@@ -34,6 +34,14 @@ find_replace:
       # Variable: $items.type.name.attribute (Note: item type and name values are CASE SENSITIVE; sqlendpoint attribute returns the deployed item's sql endpoint)
         PPE: "$items.Lakehouse.WithoutSchema.sqlendpoint"   
         PROD: "$items.Lakehouse.WithoutSchema.sqlendpoint" 
+      # Optional fields:
+      file_path: "/Example Notebook.Notebook/notebook-content.py"
+    # Eventhouse query URI
+    - find_value: "https://trd-origineventhouse.z4.kusto.fabric.microsoft.com"
+      replace_value:
+      # Variable: $items.type.name.attribute (Note: item type and name values are CASE SENSITIVE; queryserviceuri attribute returns the deployed item's query service URI)
+        PPE: "$items.Eventhouse.SampleEventhouse.queryserviceuri"   
+        PROD: "$items.Eventhouse.SampleEventhouse.queryserviceuri" 
       # Optional fields:
       file_path: "/Example Notebook.Notebook/notebook-content.py"
     

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -52,15 +52,16 @@ DATA_PIPELINE_ACTIVITY_TYPES = {
     "PBISemanticModelRefresh": ["groupId", "SemanticModel", "datasetId", "semanticModels"],
 }
 
-# Property path to get SQL Endpoint
+# Property path to get SQL Endpoint or Eventhouse URI
 PROPERTY_PATH_MAPPING = {
     "Lakehouse": "body/properties/sqlEndpointProperties/connectionString",
     "Warehouse": "body/properties/connectionString",
+    "Eventhouse": "body/properties/queryServiceUri",
 }
 
 # Parameter file configs
 PARAMETER_FILE_NAME = "parameter.yml"
-ITEM_ATTR_LOOKUP = ["id", "sqlendpoint"]
+ITEM_ATTR_LOOKUP = ["id", "sqlendpoint", "queryserviceuri"]
 
 # Parameter file validation messages
 INVALID_YAML = {"char": "Invalid characters found", "quote": "Unclosed quote: {}"}

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -266,6 +266,7 @@ class FabricWorkspace:
             item_guid = item["id"]
             item_folder_id = item.get("folderId", "")
             sql_endpoint = ""
+            query_service_uri = ""
 
             # Add an empty dictionary if the item type hasn't been added yet
             if item_type not in self.deployed_items:
@@ -275,14 +276,23 @@ class FabricWorkspace:
                 self.workspace_items[item_type] = {}
 
             # Get additional properties based on item type
-            if item_type in ["Lakehouse", "Warehouse"]:
+            if item_type in ["Lakehouse", "Warehouse", "Eventhouse"]:
                 # Construct the endpoint URL and set the property path based on item type
                 endpoint_url = f"{self.base_api_url}/{item_type.lower()}s/{item_guid}"
                 response = self.endpoint.invoke(method="GET", url=endpoint_url)
                 # Use dpath.get for safe nested property access
-                sql_endpoint = dpath.get(response, constants.PROPERTY_PATH_MAPPING[item_type], default="")
-                if not sql_endpoint:
-                    logger.debug(f"Failed to get SQL endpoint for {item_type} '{item_name}'")
+                property_path = constants.PROPERTY_PATH_MAPPING[item_type]
+                property_value = dpath.get(response, property_path, default="")
+                # Set the appropriate variable based on the last segment of the path
+                if not property_value:
+                    logger.debug(f"Failed to get endpoint for {item_type} '{item_name}'")
+                elif property_path.endswith("connectionString"):
+                    sql_endpoint = property_value
+                elif property_path.endswith("queryServiceUri"):
+                    query_service_uri = property_value
+                # sql_endpoint = dpath.get(response, constants.PROPERTY_PATH_MAPPING[item_type], default="")
+                # if not sql_endpoint:
+                #     logger.debug(f"Failed to get SQL endpoint for {item_type} '{item_name}'")
 
             # Add item details to the deployed_items dictionary
             self.deployed_items[item_type][item_name] = Item(
@@ -294,7 +304,11 @@ class FabricWorkspace:
             )
 
             # Add item details to the workspace_items dictionary required for parameterization (public-facing attributes)
-            self.workspace_items[item_type][item_name] = {"id": item_guid, "sqlendpoint": sql_endpoint}
+            self.workspace_items[item_type][item_name] = {
+                "id": item_guid,
+                "sqlendpoint": sql_endpoint,
+                "queryserviceuri": query_service_uri,
+            }
 
     def _replace_logical_ids(self, raw_file: str) -> str:
         """

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -290,9 +290,6 @@ class FabricWorkspace:
                     sql_endpoint = property_value
                 elif property_path.endswith("queryServiceUri"):
                     query_service_uri = property_value
-                # sql_endpoint = dpath.get(response, constants.PROPERTY_PATH_MAPPING[item_type], default="")
-                # if not sql_endpoint:
-                #     logger.debug(f"Failed to get SQL endpoint for {item_type} '{item_name}'")
 
             # Add item details to the deployed_items dictionary
             self.deployed_items[item_type][item_name] = Item(

--- a/tests/test_parameter_utils.py
+++ b/tests/test_parameter_utils.py
@@ -169,7 +169,7 @@ class TestParameterUtilities:
         # Test with invalid attributes
         # Mock the constants lookup
         original_lookup = constants.ITEM_ATTR_LOOKUP
-        constants.ITEM_ATTR_LOOKUP = ["id", "sqlendpoint"]
+        constants.ITEM_ATTR_LOOKUP = ["id", "sqlendpoint", "queryserviceuri"]
         try:
             with pytest.raises(ParsingError):
                 _extract_item_attribute(mock_workspace, "$items.Notebook.TestNotebook.invalidattr")


### PR DESCRIPTION
## Description

This PR extends the workspace items refresh functionality to support Eventhouse item type attribute `queryserviceuri` alongside the existing Lakehouse and Warehouse support of `sqlendpoint`.

The dynamic replacement for `queryserviceuri` is accessible with similar attribute form of:
`$items.Eventhouse.Sample_EH.queryserviceuri`

## Linked Issue (REQUIRED)

- Resolves #414 

