### PR TITLE
Resolves #402 Publishing Warehouse Returns "The feature is not available"

### DIFF
--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -38,6 +38,9 @@ ACCEPTED_ITEM_TYPES_NON_UPN = ACCEPTED_ITEM_TYPES_UPN
 # Publish
 SHELL_ONLY_PUBLISH = ["Environment", "Lakehouse", "Warehouse", "SQLDatabase"]
 
+# Does not require assigned capacity
+NO_ASSIGNED_CAPACITY_REQUIRED = ["SemanticModel", "Report"]
+
 # REGEX Constants
 VALID_GUID_REGEX = r"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
 WORKSPACE_ID_REFERENCE_REGEX = r"\"?(default_lakehouse_workspace_id|workspaceId|workspace)\"?\s*[:=]\s*\"(.*?)\""

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -6,9 +6,12 @@
 import logging
 from typing import Optional
 
+import dpath.util as dpath
+
 import fabric_cicd._items as items
 from fabric_cicd import constants
 from fabric_cicd._common._check_utils import check_regex
+from fabric_cicd._common._exceptions import FailedPublishedItemStatusError
 from fabric_cicd._common._logging import print_header
 from fabric_cicd._common._validate_input import (
     validate_fabric_workspace_obj,
@@ -48,6 +51,19 @@ def publish_all_items(fabric_workspace_obj: FabricWorkspace, item_name_exclude_r
         >>> publish_all_items(workspace, exclude_regex)
     """
     fabric_workspace_obj = validate_fabric_workspace_obj(fabric_workspace_obj)
+
+    # check if workspace has assigned capacity, if not, exit
+    has_assigned_capacity = None
+
+    response_state = fabric_workspace_obj.endpoint.invoke(
+        method="GET", url=f"{constants.DEFAULT_API_ROOT_URL}/v1/workspaces/{fabric_workspace_obj.workspace_id}"
+    )
+
+    has_assigned_capacity = dpath.get(response_state, "body/capacityId", default=None)
+
+    if not has_assigned_capacity:
+        msg = f"Workspace {fabric_workspace_obj.workspace_id} does not have an assigned capacity. Please assign a capacity before publishing items."
+        raise FailedPublishedItemStatusError(msg, logger)
 
     if "disable_workspace_folder_publish" not in constants.FEATURE_FLAG:
         fabric_workspace_obj._refresh_deployed_folders()

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -61,7 +61,7 @@ def publish_all_items(fabric_workspace_obj: FabricWorkspace, item_name_exclude_r
 
     has_assigned_capacity = dpath.get(response_state, "body/capacityId", default=None)
 
-    if not has_assigned_capacity:
+    if not has_assigned_capacity and fabric_workspace_obj.item_type_in_scope != constants.NO_ASSIGNED_CAPACITY_REQUIRED:
         msg = f"Workspace {fabric_workspace_obj.workspace_id} does not have an assigned capacity. Please assign a capacity before publishing items."
         raise FailedPublishedItemStatusError(msg, logger)
 


### PR DESCRIPTION
This pull request introduces a new validation mechanism for publishing items in Fabric CI/CD workflows, ensuring that a workspace has assigned capacity unless the item type is exempt. It also includes updates to constants and imports to support this functionality.

### Validation for assigned capacity:

* [`src/fabric_cicd/constants.py`](diffhunk://#diff-91c2d32be351f155f090c4bd57ebe3c10e646edbc1b663e2a72b697f956a949cR41-R43): Added `NO_ASSIGNED_CAPACITY_REQUIRED` constant, listing item types (`SemanticModel`, `Report`) that do not require assigned capacity.
* [`src/fabric_cicd/publish.py`](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R55-R67): Implemented a check in `publish_all_items` to validate if the workspace has assigned capacity. If not, and the item type is not exempt, an error is raised with a descriptive message.

### Supporting updates:

* [`src/fabric_cicd/publish.py`](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R9-R14): Imported `dpath.util` for JSON path extraction and `FailedPublishedItemStatusError` for error handling.