### PR TITLE
Resolves #302 - Adds Permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,6 +10,7 @@ permissions:
     contents: read
     pull-requests: write
     issues: write
+    statuses: write
 
 jobs:
     format_ruff:


### PR DESCRIPTION
This pull request updates the permissions in the GitHub Actions workflow configuration file to include write access to statuses, likely to enable the workflow to update commit statuses.

* [`.github/workflows/validate.yml`](diffhunk://#diff-a5c0f08bc43f53a0451cad4a4a2e435ce55ad34183350dfae5e4b2c7dca6360bR13): Added `statuses: write` under the `permissions` section to allow the workflow to write commit statuses.## Description

Briefly describe what this PR does and why.

## Linked Issue (REQUIRED)

<!-- 
REQUIRED: Link to the issue this PR addresses in the Development section or PR title using one of these formats:
- Fixes #123 (for bug fixes)
- Closes #456 (for features)  
- Resolves #789 (for other changes)
-->
