### PR TITLE
Resolves #302 - Circular Reference

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -64,6 +64,13 @@ jobs:
                     exit 1
                   fi
 
+    validate-version-bump:
+        name: Proper Version Bump
+        uses: ./.github/workflows/validate-version-bump.yml
+        with:
+            pr_title: ${{ github.event.pull_request.title }}
+            pr_head_sha: ${{ github.event.pull_request.head.sha }}
+
     validate-linked-issue:
         name: Issue Linked
         runs-on: ubuntu-latest
@@ -208,9 +215,3 @@ jobs:
                       }
 
                       console.log('✅ Pull request is properly linked to an issue.');
-    validate-version-bump:
-        name: Proper Version Bump
-        uses: ./.github/workflows/validate-version-bump.yml
-        with:
-            pr_title: ${{ github.event.pull_request.title }}
-            pr_head_sha: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
This pull request modifies the `.github/workflows/validate.yml` file to reorganize and streamline the validation workflow by relocating the `validate-version-bump` job.

Workflow restructuring:

* Added the `validate-version-bump` job earlier in the workflow to ensure proper version bump validation is performed promptly. (`[.github/workflows/validate.ymlR67-R73](diffhunk://#diff-a5c0f08bc43f53a0451cad4a4a2e435ce55ad34183350dfae5e4b2c7dca6360bR67-R73)`)
* Removed the `validate-version-bump` job from its previous position later in the workflow to avoid redundancy. (`[.github/workflows/validate.ymlL211-L216](diffhunk://#diff-a5c0f08bc43f53a0451cad4a4a2e435ce55ad34183350dfae5e4b2c7dca6360bL211-L216)`)