### PR TITLE
Resolves #447 check for items not requiring assinged capacity

### DIFF
--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -39,7 +39,7 @@ ACCEPTED_ITEM_TYPES_NON_UPN = ACCEPTED_ITEM_TYPES_UPN
 SHELL_ONLY_PUBLISH = ["Environment", "Lakehouse", "Warehouse", "SQLDatabase"]
 
 # Does not require assigned capacity
-NO_ASSIGNED_CAPACITY_REQUIRED = ["SemanticModel", "Report"]
+NO_ASSIGNED_CAPACITY_REQUIRED = [["SemanticModel", "Report"], ["SemanticModel"], ["Report"]]
 
 # REGEX Constants
 VALID_GUID_REGEX = r"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -61,7 +61,10 @@ def publish_all_items(fabric_workspace_obj: FabricWorkspace, item_name_exclude_r
 
     has_assigned_capacity = dpath.get(response_state, "body/capacityId", default=None)
 
-    if not has_assigned_capacity and fabric_workspace_obj.item_type_in_scope != constants.NO_ASSIGNED_CAPACITY_REQUIRED:
+    if (
+        not has_assigned_capacity
+        and fabric_workspace_obj.item_type_in_scope not in constants.NO_ASSIGNED_CAPACITY_REQUIRED
+    ):
         msg = f"Workspace {fabric_workspace_obj.workspace_id} does not have an assigned capacity. Please assign a capacity before publishing items."
         raise FailedPublishedItemStatusError(msg, logger)
 


### PR DESCRIPTION
This pull request updates the logic for determining whether an item requires assigned capacity by modifying the `NO_ASSIGNED_CAPACITY_REQUIRED` constant and updating its usage in the publishing logic. 
https://github.com/microsoft/fabric-cicd/issues/447
### Changes to constants:

* [`src/fabric_cicd/constants.py`](diffhunk://#diff-91c2d32be351f155f090c4bd57ebe3c10e646edbc1b663e2a72b697f956a949cL42-R42): Updated `NO_ASSIGNED_CAPACITY_REQUIRED` to be a list of lists, instead of a flat list, to allow for more granular checks.

### Changes to publishing logic:

* [`src/fabric_cicd/publish.py`](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704L64-R67): Updated the condition in `publish_all_items` to handle the new structure of `NO_ASSIGNED_CAPACITY_REQUIRED` by checking if `fabric_workspace_obj.item_type_in_scope` is not in the updated list of lists.
