### PR TITLE
Update _fabric_endpoint.py to handle JSONDecodeErrors from the response handler

### DIFF
--- a/src/fabric_cicd/_common/_fabric_endpoint.py
+++ b/src/fabric_cicd/_common/_fabric_endpoint.py
@@ -180,7 +180,9 @@ def _handle_response(
     # Handle long-running operations
     # https://learn.microsoft.com/en-us/rest/api/fabric/core/long-running-operations/get-operation-result
     if (response.status_code == 200 and long_running) or response.status_code == 202:
+        print(response.headers)
         url = response.headers.get("Location")
+        print(url)
         method = "GET"
         body = "{}"
         response_json = response.json() if "application/json" in response.headers.get("Content-Type") else {}

--- a/src/fabric_cicd/_common/_fabric_endpoint.py
+++ b/src/fabric_cicd/_common/_fabric_endpoint.py
@@ -183,7 +183,7 @@ def _handle_response(
         url = response.headers.get("Location")
         method = "GET"
         body = "{}"
-        response_json = response.json()
+        response_json = response.json() if "application/json" in response.headers.get("Content-Type") else {}
 
         if long_running:
             status = response_json.get("status")


### PR DESCRIPTION
## Description

This response handler would error if you tried to execute a run notebook job as response.json() gives a JSONDecodeError. I have only updated the response_json = response.json() to mimic that of the return statement of the invoke method.

## Linked Issue (REQUIRED)
https://github.com/microsoft/fabric-cicd/issues/452
<!-- 
REQUIRED: Link to the issue this PR addresses in the Development section or PR title using one of these formats:
- Fixes #452
-->
