### PR TITLE
Allowing for jobs/instances endpoint calls

### DIFF
--- a/src/fabric_cicd/_common/_fabric_endpoint.py
+++ b/src/fabric_cicd/_common/_fabric_endpoint.py
@@ -181,16 +181,23 @@ def _handle_response(
     # https://learn.microsoft.com/en-us/rest/api/fabric/core/long-running-operations/get-operation-result
     if (response.status_code == 200 and long_running) or response.status_code == 202:
         location = response.headers.get("Location")
+        print("+"*60)
+        print("headers: ", response.headers)
+        print("url: ", url)
+        print("location: ", location)
+        print("long_running: ", long_running)
         method = "GET"
         body = "{}"
         response_json = response.json() if "application/json" in response.headers.get("Content-Type") else {}
 
         if long_running:
             status = response_json.get("status")
+            print("status: ", status)
             if status == "Succeeded":
                 long_running = False
                 # If location not included in operation success call, no body is expected to be returned
                 exit_loop = location is None
+                print("exit_loop: ", exit_loop)
 
             elif status == "Failed":
                 response_error = response_json["error"]
@@ -212,6 +219,7 @@ def _handle_response(
         else:
             # Only proceed with long-running operation if Location header exists
             if location:
+                print("Location Updated")
                 url = location
                 time.sleep(1)
                 long_running = True

--- a/src/fabric_cicd/_common/_fabric_endpoint.py
+++ b/src/fabric_cicd/_common/_fabric_endpoint.py
@@ -190,7 +190,7 @@ def _handle_response(
             if status == "Succeeded":
                 long_running = False
                 # If location not included in operation success call, no body is expected to be returned
-                exit_loop = url is None
+                exit_loop = location is None
 
             elif status == "Failed":
                 response_error = response_json["error"]

--- a/src/fabric_cicd/_common/_fabric_endpoint.py
+++ b/src/fabric_cicd/_common/_fabric_endpoint.py
@@ -181,23 +181,16 @@ def _handle_response(
     # https://learn.microsoft.com/en-us/rest/api/fabric/core/long-running-operations/get-operation-result
     if (response.status_code == 200 and long_running) or response.status_code == 202:
         location = response.headers.get("Location")
-        print("+"*60)
-        print("headers: ", response.headers)
-        print("url: ", url)
-        print("location: ", location)
-        print("long_running: ", long_running)
         method = "GET"
         body = "{}"
         response_json = response.json() if "application/json" in response.headers.get("Content-Type") else {}
 
         if long_running:
             status = response_json.get("status")
-            print("status: ", status)
-            if status == "Succeeded":
+            if status in ["Succeeded", "Completed"]:
                 long_running = False
                 # If location not included in operation success call, no body is expected to be returned
                 exit_loop = location is None
-                print("exit_loop: ", exit_loop)
 
             elif status == "Failed":
                 response_error = response_json["error"]
@@ -219,7 +212,6 @@ def _handle_response(
         else:
             # Only proceed with long-running operation if Location header exists
             if location:
-                print("Location Updated")
                 url = location
                 time.sleep(1)
                 long_running = True

--- a/src/fabric_cicd/_common/_fabric_endpoint.py
+++ b/src/fabric_cicd/_common/_fabric_endpoint.py
@@ -180,7 +180,9 @@ def _handle_response(
     # Handle long-running operations
     # https://learn.microsoft.com/en-us/rest/api/fabric/core/long-running-operations/get-operation-result
     if (response.status_code == 200 and long_running) or response.status_code == 202:
+        print(response.headers)
         url = response.headers.get("Location")
+        print(url)
         method = "GET"
         body = "{}"
         response_json = response.json() if "application/json" in response.headers.get("Content-Type") else {}

--- a/src/fabric_cicd/_common/_fabric_endpoint.py
+++ b/src/fabric_cicd/_common/_fabric_endpoint.py
@@ -183,7 +183,7 @@ def _handle_response(
         url = response.headers.get("Location")
         method = "GET"
         body = "{}"
-        response_json = response.json()
+        response_json = response.json() if "application/json" in response.headers.get("Content-Type") else {}
 
         if long_running:
             status = response_json.get("status")

--- a/src/fabric_cicd/_common/_fabric_endpoint.py
+++ b/src/fabric_cicd/_common/_fabric_endpoint.py
@@ -180,9 +180,7 @@ def _handle_response(
     # Handle long-running operations
     # https://learn.microsoft.com/en-us/rest/api/fabric/core/long-running-operations/get-operation-result
     if (response.status_code == 200 and long_running) or response.status_code == 202:
-        print(response.headers)
-        url = response.headers.get("Location")
-        print(url)
+        location = response.headers.get("Location")
         method = "GET"
         body = "{}"
         response_json = response.json() if "application/json" in response.headers.get("Content-Type") else {}
@@ -212,8 +210,14 @@ def _handle_response(
                     prepend_message=f"{constants.INDENT}Operation in progress.",
                 )
         else:
-            time.sleep(1)
-            long_running = True
+            # Only proceed with long-running operation if Location header exists
+            if location:
+                url = location
+                time.sleep(1)
+                long_running = True
+            else:
+                # If no Location header, treat as regular success
+                exit_loop = True
 
     # Handle successful responses
     elif response.status_code in {200, 201} or (


### PR DESCRIPTION
## Description
Allows _handle_responses method in _fabric_endpoint.py to handle jobs/instance post calls (wont error on response_json = response.json() and checks for the "Completed" status.

## Linked Issue (REQUIRED)
https://github.com/microsoft/fabric-cicd/issues/452
<!-- 
REQUIRED: Link to the issue this PR addresses in the Development section or PR title using one of these formats:
- Fixes #452 (for bug fixes)
-->
