### PR TITLE
Allow _handle_response method to handle more long running events

### DIFF
--- a/src/fabric_cicd/_common/_fabric_endpoint.py
+++ b/src/fabric_cicd/_common/_fabric_endpoint.py
@@ -190,7 +190,7 @@ def _handle_response(
             if status in ["Succeeded", "Completed"]:
                 long_running = False
                 # If location not included in operation success call, no body is expected to be returned
-                exit_loop = url is None
+                exit_loop = location is None
 
             elif status == "Failed":
                 response_error = response_json["error"]


### PR DESCRIPTION
## Description
Allows _handle_responses method in _fabric_endpoint.py to handle jobs/instance post calls (wont error on response_json = response.json() and checks for the "Completed" status.

## Linked Issue (REQUIRED)
https://github.com/microsoft/fabric-cicd/issues/452
<!-- 
REQUIRED: Link to the issue this PR addresses in the Development section or PR title using one of these formats:
- Fixes #452 (for bug fixes)
-->

