### PR TITLE
Resolves #302 - Bump Authentication

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -80,11 +80,18 @@ jobs:
             (github.event_name == 'pull_request' && github.event.pull_request.merged == true && needs.validate-version-bump.outputs.is_version_bump == 'true')
         runs-on: ubuntu-latest
         steps:
+            - name: Generate GitHub App Token
+              id: app-token
+              uses: actions/create-github-app-token@v1
+              with:
+                  app-id: ${{ secrets.APP_ID }}
+                  private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
             - name: Checkout repository
               uses: actions/checkout@v4
               with:
                   fetch-depth: 0
-                  token: ${{ secrets.GITHUB_TOKEN }}
+                  token: ${{ steps.app-token.outputs.token }}
 
             - name: Extract version
               id: version-check
@@ -131,8 +138,8 @@ jobs:
                     echo "✅ Tag $TAG_NAME does not exist, creating new tag"
                     
                     # Configure git
-                    git config user.name "github-actions[bot]"
-                    git config user.email "github-actions[bot]@users.noreply.github.com"
+                    git config user.name "fabric-cicd-release[bot]"
+                    git config user.email "fabric-cicd-release[bot]@users.noreply.github.com"
 
                     # Create and push the tag
                     git tag "$TAG_NAME"
@@ -145,7 +152,7 @@ jobs:
               if: needs.validate-version-bump.outputs.is_version_bump == 'true'
               uses: actions/github-script@v7
               with:
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  github-token: ${{ steps.app-token.outputs.token }}
                   script: |
                       const tagName = '${{ steps.version-check.outputs.version_tag }}';
 
@@ -238,10 +245,10 @@ jobs:
 
             - name: Deploy GitHub Pages
               env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
               run: |
-                  git config user.name github-actions[bot]
-                  git config user.email github-actions[bot]@users.noreply.github.com
+                  git config user.name "fabric-cicd-release[bot]"
+                  git config user.email "fabric-cicd-release[bot]@users.noreply.github.com"
                   git fetch --no-tags --prune --depth=1 origin +refs/heads/gh-pages:refs/remotes/origin/gh-pages
                   uv sync
 


### PR DESCRIPTION
This pull request updates the `.github/workflows/bump.yml` workflow to improve security and clarify bot identity by switching from a personal access token to a GitHub App token, and by updating the bot user details. These changes ensure actions are performed with the correct permissions and attribution.

Authentication and permissions:

* Replaced usage of `${{ secrets.GITHUB_TOKEN }}` with a dynamically generated GitHub App token via the `actions/create-github-app-token@v1` step, and updated all subsequent steps to use this token for authentication. [[1]](diffhunk://#diff-5f52eaedfd785b5c9a77a6b1ad06a20e0e854e3ac2db7f63bd0946062df8b855R83-R94) [[2]](diffhunk://#diff-5f52eaedfd785b5c9a77a6b1ad06a20e0e854e3ac2db7f63bd0946062df8b855L148-R155) [[3]](diffhunk://#diff-5f52eaedfd785b5c9a77a6b1ad06a20e0e854e3ac2db7f63bd0946062df8b855L241-R251)

Bot identity and attribution:

* Changed the configured git user name and email from `github-actions[bot]` to `fabric-cicd-release[bot]` in steps that create tags and deploy GitHub Pages, ensuring correct attribution for automated commits and tags. [[1]](diffhunk://#diff-5f52eaedfd785b5c9a77a6b1ad06a20e0e854e3ac2db7f63bd0946062df8b855L134-R142) [[2]](diffhunk://#diff-5f52eaedfd785b5c9a77a6b1ad06a20e0e854e3ac2db7f63bd0946062df8b855L241-R251)