### PR TITLE
Resolves #460 - Remove Public Preview Header

### DIFF
--- a/docs/config/overrides/main.html
+++ b/docs/config/overrides/main.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
 
 {% block announce %}
-    <p style="text-align: center;">⚠️ This library is in Public Preview.  Please raise issues & feature requests as they arise.</p> 
+    <p style="text-align: center;">ℹ️ This library is open source. Please raise issues & feature requests as they arise.</p> 
 {% endblock %}


### PR DESCRIPTION
This pull request updates the announcement banner in the documentation to clarify the status of the library.

* Documentation banner update: Changed the message in `docs/config/overrides/main.html` to indicate the library is open source, replacing the previous "Public Preview" status.