### PR TITLE
Resolves #320 Support an "ALL" environment in parameter.yml

### DIFF
--- a/docs/config/overrides/main.html
+++ b/docs/config/overrides/main.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
 
 {% block announce %}
-    <p style="text-align: center;">⚠️ This library is in Public Preview.  Please raise issues & feature requests as they arise.</p> 
+    <p style="text-align: center;">ℹ️ This library is open source. Please raise issues & feature requests as they arise.</p> 
 {% endblock %}

--- a/docs/how_to/parameterization.md
+++ b/docs/how_to/parameterization.md
@@ -222,9 +222,9 @@ spark_pool:
       item_name: <item-name-filter-value>
 ```
 
-### ALL Environment
+### All Environment
 
-Setting the environment key to `ALL` in `replace_value` is supported for any parameter input (`find_replace`, `key_value_replace`, `spark_pool`). The `ALL` environment key cannot be used alongside other environment keys.
+Setting the environment key to `ALL` or `all` (case-insensitive) in `replace_value` is supported for any parameter input (`find_replace`, `key_value_replace`, `spark_pool`). The `ALL` environment key cannot be used alongside other environment keys.
 
 Use case: when the replace value applies to any target environment (particularly valuable in dynamic replacement scenarios).
 
@@ -233,7 +233,7 @@ find_replace:
     # Lakehouse GUID
     - find_value: "db52be81-c2b2-4261-84fa-840c67f4bbd0"
       replace_value:
-          ALL: "$items.Lakehouse.Example_LH.id"
+          <ALL|all|All>: "$items.Lakehouse.Example_LH.id"
 ```
 
 ## Optional Fields

--- a/docs/how_to/parameterization.md
+++ b/docs/how_to/parameterization.md
@@ -222,6 +222,20 @@ spark_pool:
       item_name: <item-name-filter-value>
 ```
 
+### ALL Environment
+
+Setting the environment key to `ALL` in `replace_value` is supported for any parameter input (`find_replace`, `key_value_replace`, `spark_pool`). The `ALL` environment key cannot be used alongside other environment keys.
+
+Use case: when the replace value applies to any target environment (particularly valuable in dynamic replacement scenarios).
+
+```yaml
+find_replace:
+    # Lakehouse GUID
+    - find_value: "db52be81-c2b2-4261-84fa-840c67f4bbd0"
+      replace_value:
+          ALL: "$items.Lakehouse.Example_LH.id"
+```
+
 ## Optional Fields
 
 When optional fields are omitted or left empty, only basic parameterization functionality will be available. To enable advanced features, you must add the specific optional field(s) (if applicable) and set appropriately.
@@ -305,8 +319,7 @@ find_replace:
     # lakehouse workspace ID to be replaced (using regex pattern)
     - find_value: \#\s*META\s+"default_lakehouse_workspace_id":\s*"([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
       replace_value:
-          PPE: "$workspace.id" # PPE workspace ID (dynamic)
-          PROD: "$workspace.id" # PROD workspace ID (dynamic)
+          ALL: "$workspace.id" # workspace ID of the target environment (dynamic)
       is_regex: "true" # enable regex pattern matching
       item_name: # filter on specific notebook files
           - "Hello World"
@@ -616,7 +629,7 @@ runtime_version: 1.3
 
 Dataflows can have different kinds of Fabric sources and destinations that need to be parameterized, depending on the scenario.
 
-#### Parameterization Overview:
+#### Parameterization Overview
 
 Take a Lakehouse source/destination as an example, the Lakehouse is connected to a Dataflow in the following ways:
 
@@ -627,7 +640,7 @@ Take a Lakehouse source/destination as an example, the Lakehouse is connected to
 
 **\*\*Note:** A Dataflow that sources from another Dataflow introduces a dependency that may require a specific order of deploying (source first then dependent). A Dataflow is referenced by the item ID in the workspace and the actual workspace ID, this makes re-pointing more complex (see parameterization guidance below).
 
-#### Parameterization Guidance:
+#### Parameterization Guidance
 
 Connections must be parameterized in addition to item references.
 

--- a/docs/how_to/parameterization.md
+++ b/docs/how_to/parameterization.md
@@ -222,18 +222,19 @@ spark_pool:
       item_name: <item-name-filter-value>
 ```
 
-### All Environment
+### \_ALL\_ Environment Key in `replace_value`
 
-Setting the environment key to `ALL` or `all` (case-insensitive) in `replace_value` is supported for any parameter input (`find_replace`, `key_value_replace`, `spark_pool`). The `ALL` environment key cannot be used alongside other environment keys.
+The `_ALL_` environment key (case-insensitive) in `replace_value` is supported for all parameter types (`find_replace`, `key_value_replace`, `spark_pool`) and applies the replacement to any target environment. When `_ALL_` is used, it must be the only environment key in the `replace_value` dictionary. Using `ALL` without underscores will be treated as a regular environment key.
 
-Use case: when the replace value applies to any target environment (particularly valuable in dynamic replacement scenarios).
+Use case: when the same replacement value applies to all target environments (particularly valuable in dynamic replacement scenarios).
 
 ```yaml
 find_replace:
     # Lakehouse GUID
     - find_value: "db52be81-c2b2-4261-84fa-840c67f4bbd0"
       replace_value:
-          <ALL|all|All>: "$items.Lakehouse.Example_LH.id"
+          # use _ALL_ or _all_ or _All_
+          _ALL_: "$items.Lakehouse.Example_LH.id"
 ```
 
 ## Optional Fields
@@ -319,7 +320,7 @@ find_replace:
     # lakehouse workspace ID to be replaced (using regex pattern)
     - find_value: \#\s*META\s+"default_lakehouse_workspace_id":\s*"([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
       replace_value:
-          ALL: "$workspace.id" # workspace ID of the target environment (dynamic)
+          _ALL_: "$workspace.id" # workspace ID of the target environment (dynamic)
       is_regex: "true" # enable regex pattern matching
       item_name: # filter on specific notebook files
           - "Hello World"

--- a/src/fabric_cicd/_items/_environment.py
+++ b/src/fabric_cicd/_items/_environment.py
@@ -145,6 +145,8 @@ def _update_compute_settings(
         item_guid: The GUID of the environment item.
         item_name: Name of the environment item.
     """
+    from fabric_cicd._parameter._utils import process_environment_key
+
     # Read compute settings from YAML file
     with Path.open(Path(item_path, "Setting", "Sparkcompute.yml"), "r+", encoding="utf-8") as f:
         yaml_body = yaml.safe_load(f)
@@ -156,7 +158,7 @@ def _update_compute_settings(
                 parameter_dict = fabric_workspace_obj.environment_parameter["spark_pool"]
                 for key in parameter_dict:
                     instance_pool_id = key["instance_pool_id"]
-                    replace_value = key["replace_value"]
+                    replace_value = process_environment_key(fabric_workspace_obj, key["replace_value"])
                     input_name = key.get("item_name")
                     if instance_pool_id == pool_id and (input_name == item_name or not input_name):
                         # replace any found references with specified environment value

--- a/src/fabric_cicd/_parameter/_parameter.py
+++ b/src/fabric_cicd/_parameter/_parameter.py
@@ -233,7 +233,7 @@ class Parameter:
                 logger.debug(constants.PARAMETER_MSGS["passed"].format(msg))
 
             # Check if replacement will be skipped for a given find value
-            is_valid_env = self._validate_environment(parameter_dict["replace_value"])
+            is_valid_env, case = self._validate_environment(parameter_dict["replace_value"])
             is_valid_optional_val, msg = self._validate_optional_values(param_name, parameter_dict, check_match=True)
             log_func = logger.debug if param_name == "key_value_replace" else logger.warning
 
@@ -244,8 +244,12 @@ class Parameter:
                 else "find value"
             )
 
-            # Replacement skipped if target environment is not present
             if self.environment != "N/A" and not is_valid_env:
+                # Return validation error for invalid ALL case (ALL used with other envs)
+                if case == "all":
+                    return False, constants.PARAMETER_MSGS["other target env"].format(parameter_dict["replace_value"])
+
+                # Otherwise, replacement skipped if target environment is not present
                 skip_msg = constants.PARAMETER_MSGS["no target env"].format(self.environment, param_name)
                 log_func(
                     constants.PARAMETER_MSGS["skip"].format(
@@ -255,7 +259,7 @@ class Parameter:
                 continue
 
             # Log if ALL environment is present in replace_value
-            if "ALL" in parameter_dict["replace_value"]:
+            if case == "all":
                 logger.warning(
                     constants.PARAMETER_MSGS["all target env"].format(parameter_dict["replace_value"]["ALL"])
                 )
@@ -450,9 +454,17 @@ class Parameter:
 
         return True, "Data type is valid"
 
-    def _validate_environment(self, replace_value: dict) -> bool:
-        """Check the target environment exists as a key in the replace_value dictionary."""
-        return self.environment in replace_value or "ALL" in replace_value
+    def _validate_environment(self, replace_value: dict) -> tuple[bool, str]:
+        """
+        Check the target environment exists as a key in the replace_value dictionary.
+        If "ALL" is present, it must be the only key.
+        """
+        if "ALL" in replace_value:
+            # If ALL is present, it must be the only key
+            return len(replace_value) == 1, "all"
+
+        # If ALL is not present, check if target environment is present
+        return self.environment in replace_value, "env"
 
     def _validate_item_type(self, input_type: str) -> tuple[bool, str]:
         """Validate the item type is in scope."""

--- a/src/fabric_cicd/_parameter/_parameter.py
+++ b/src/fabric_cicd/_parameter/_parameter.py
@@ -254,6 +254,12 @@ class Parameter:
                 )
                 continue
 
+            # Log if ALL environment is present in replace_value
+            if "ALL" in parameter_dict["replace_value"]:
+                logger.warning(
+                    constants.PARAMETER_MSGS["all target env"].format(parameter_dict["replace_value"]["ALL"])
+                )
+
             # Replacement skipped if optional filter values don't match
             if msg == "no match" and not is_valid_optional_val:
                 skip_msg = constants.PARAMETER_MSGS["no filter match"]
@@ -446,7 +452,7 @@ class Parameter:
 
     def _validate_environment(self, replace_value: dict) -> bool:
         """Check the target environment exists as a key in the replace_value dictionary."""
-        return self.environment in replace_value
+        return self.environment in replace_value or "ALL" in replace_value
 
     def _validate_item_type(self, input_type: str) -> tuple[bool, str]:
         """Validate the item type is in scope."""

--- a/src/fabric_cicd/_parameter/_parameter.py
+++ b/src/fabric_cicd/_parameter/_parameter.py
@@ -245,8 +245,8 @@ class Parameter:
             )
 
             if self.environment != "N/A" and not is_valid_env:
-                # Return validation error for invalid ALL case (ALL used with other envs)
-                if env_type.lower() == "all":
+                # Return validation error for invalid _ALL_ case (_ALL_ used with other envs)
+                if env_type.lower() == "_all_":
                     return False, constants.PARAMETER_MSGS["other target env"].format(
                         env_type, parameter_dict["replace_value"]
                     )
@@ -260,12 +260,10 @@ class Parameter:
                 )
                 continue
 
-            # Log if all environment is present in replace_value
-            if env_type.lower() == "all":
+            # Log if _ALL_ environment is present in replace_value
+            if env_type.lower() == "_all_":
                 logger.warning(
-                    constants.PARAMETER_MSGS["all target env"].format(
-                        env_type, parameter_dict["replace_value"][env_type]
-                    )
+                    constants.PARAMETER_MSGS["all target env"].format(parameter_dict["replace_value"][env_type])
                 )
 
             # Replacement skipped if optional filter values don't match
@@ -461,19 +459,20 @@ class Parameter:
     def _validate_environment(self, replace_value: dict) -> tuple[bool, str]:
         """
         Check the target environment exists as a key in the replace_value dictionary.
-        If "ALL" (case insensitive) is present, it must be the only key.
+        If "_ALL_" (case insensitive) is present, it must be the only key.
         """
-        # Check for "ALL" in any case variation
+        # Check for _ALL_ in any case variation
         all_key = None
         for key in replace_value:
-            if key.lower() == "all":
+            if key.lower() == "_all_":
+                logger.warning(f"Found the reserved environment key '{key}'")
                 all_key = key
                 break
         if all_key:
-            # If ALL is present, it must be the only key
+            # If _ALL_ is present, it must be the only key
             return len(replace_value) == 1, all_key
 
-        # If ALL is not present, check if target environment is present
+        # If _ALL_ is not present, check if target environment is present
         return self.environment in replace_value, "env"
 
     def _validate_item_type(self, input_type: str) -> tuple[bool, str]:

--- a/src/fabric_cicd/_parameter/_utils.py
+++ b/src/fabric_cicd/_parameter/_utils.py
@@ -185,13 +185,22 @@ def extract_parameter_filters(workspace_obj: FabricWorkspace, param_dict: dict) 
     return item_type, item_name, file_path
 
 
+def process_environment_key(workspace_obj: FabricWorkspace, replace_value_dict: dict) -> str:
+    """Processes the replace_value dictionary to replace the 'ALL' environment key with the target environment when present."""
+    if "ALL" in replace_value_dict:
+        replace_value_dict[workspace_obj.environment] = replace_value_dict.pop("ALL")
+
+    return replace_value_dict
+
+
 """Functions to replace key values in JSON"""
 
 
-def replace_key_value(param_dict: dict, json_content: str, env: str) -> Union[dict]:
+def replace_key_value(workspace_obj: FabricWorkspace, param_dict: dict, json_content: str, env: str) -> Union[dict]:
     """A function to replace key values in a JSON using parameterization. It uses jsonpath_ng to find and replace values in the JSON.
 
     Args:
+        workspace_obj: The FabricWorkspace object.
         param_dict: The parameter dictionary.
         json_content: the JSON content to be modified.
         env: The environment variable to be used for replacement.
@@ -204,11 +213,12 @@ def replace_key_value(param_dict: dict, json_content: str, env: str) -> Union[di
 
     # Extract the jsonpath expression from the find_key attribute of the param_dict
     jsonpath_expr = parse(param_dict["find_key"])
+    replace_value = process_environment_key(workspace_obj, param_dict["replace_value"])
     for match in jsonpath_expr.find(data):
         # If the env is present in the replace_value array perform the replacement
-        if env in param_dict["replace_value"]:
+        if env in replace_value:
             try:
-                match.full_path.update(data, param_dict["replace_value"][env])
+                match.full_path.update(data, replace_value[env])
             except Exception as match_e:
                 raise ValueError(match_e) from match_e
 

--- a/src/fabric_cicd/_parameter/_utils.py
+++ b/src/fabric_cicd/_parameter/_utils.py
@@ -186,11 +186,11 @@ def extract_parameter_filters(workspace_obj: FabricWorkspace, param_dict: dict) 
 
 
 def process_environment_key(workspace_obj: FabricWorkspace, replace_value_dict: dict) -> dict:
-    """Processes the replace_value dictionary to replace the 'ALL' environment key with the target environment when present."""
-    # If there's only one key, check if it's "ALL" (case insensitive) and replace it
+    """Processes the replace_value dictionary to replace the '_ALL_' environment key with the target environment when present."""
+    # If there's only one key, check if it's "_ALL_" (case insensitive) and replace it
     if len(replace_value_dict) == 1:
         key = next(iter(replace_value_dict))
-        if key.lower() == "all":
+        if key.lower() == "_all_":
             replace_value_dict[workspace_obj.environment] = replace_value_dict.pop(key)
 
     return replace_value_dict

--- a/src/fabric_cicd/_parameter/_utils.py
+++ b/src/fabric_cicd/_parameter/_utils.py
@@ -185,7 +185,7 @@ def extract_parameter_filters(workspace_obj: FabricWorkspace, param_dict: dict) 
     return item_type, item_name, file_path
 
 
-def process_environment_key(workspace_obj: FabricWorkspace, replace_value_dict: dict) -> str:
+def process_environment_key(workspace_obj: FabricWorkspace, replace_value_dict: dict) -> dict:
     """Processes the replace_value dictionary to replace the 'ALL' environment key with the target environment when present."""
     if "ALL" in replace_value_dict:
         replace_value_dict[workspace_obj.environment] = replace_value_dict.pop("ALL")

--- a/src/fabric_cicd/_parameter/_utils.py
+++ b/src/fabric_cicd/_parameter/_utils.py
@@ -187,8 +187,11 @@ def extract_parameter_filters(workspace_obj: FabricWorkspace, param_dict: dict) 
 
 def process_environment_key(workspace_obj: FabricWorkspace, replace_value_dict: dict) -> dict:
     """Processes the replace_value dictionary to replace the 'ALL' environment key with the target environment when present."""
-    if "ALL" in replace_value_dict:
-        replace_value_dict[workspace_obj.environment] = replace_value_dict.pop("ALL")
+    # If there's only one key, check if it's "ALL" (case insensitive) and replace it
+    if len(replace_value_dict) == 1:
+        key = next(iter(replace_value_dict))
+        if key.lower() == "all":
+            replace_value_dict[workspace_obj.environment] = replace_value_dict.pop(key)
 
     return replace_value_dict
 

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -102,7 +102,7 @@ PARAMETER_MSGS = {
     "valid parameter": "{} parameter is valid",
     "skip": "The {} '{}' replacement will be skipped due to {} in parameter {}",
     "no target env": "target environment '{}' not found",
-    "all target env": "'{}' environment key found. The replace value: '{}' will be applied for any target environment",
+    "all target env": "The replace value: '{}' will be applied for any target environment",
     "other target env": "The '{}' environment key can only be used alone. Other environment keys found in replace_value: '{}'",
     "no filter match": "unmatched optional filters",
 }

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -103,6 +103,7 @@ PARAMETER_MSGS = {
     "skip": "The {} '{}' replacement will be skipped due to {} in parameter {}",
     "no target env": "target environment '{}' not found",
     "all target env": "'ALL' environment key found. The replace value: '{}' will be applied for any target environment",
+    "other target env": "The 'ALL' environment key can only be used alone. Other environment keys found in replace_value: '{}'",
     "no filter match": "unmatched optional filters",
 }
 

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -102,6 +102,7 @@ PARAMETER_MSGS = {
     "valid parameter": "{} parameter is valid",
     "skip": "The {} '{}' replacement will be skipped due to {} in parameter {}",
     "no target env": "target environment '{}' not found",
+    "all target env": "'ALL' environment key found. The replace value: '{}' will be applied for any target environment",
     "no filter match": "unmatched optional filters",
 }
 

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -102,8 +102,8 @@ PARAMETER_MSGS = {
     "valid parameter": "{} parameter is valid",
     "skip": "The {} '{}' replacement will be skipped due to {} in parameter {}",
     "no target env": "target environment '{}' not found",
-    "all target env": "'ALL' environment key found. The replace value: '{}' will be applied for any target environment",
-    "other target env": "The 'ALL' environment key can only be used alone. Other environment keys found in replace_value: '{}'",
+    "all target env": "'{}' environment key found. The replace value: '{}' will be applied for any target environment",
+    "other target env": "The '{}' environment key can only be used alone. Other environment keys found in replace_value: '{}'",
     "no filter match": "unmatched optional filters",
 }
 

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -350,6 +350,7 @@ class FabricWorkspace:
             extract_find_value,
             extract_parameter_filters,
             extract_replace_value,
+            process_environment_key,
             replace_key_value,
         )
 
@@ -367,7 +368,7 @@ class FabricWorkspace:
 
                 # Perform replacement if condition is met
                 if filter_match and ".json" in file_path.suffix:
-                    raw_file = replace_key_value(parameter_dict, raw_file, self.environment)
+                    raw_file = replace_key_value(self, parameter_dict, raw_file, self.environment)
 
         if "find_replace" in self.environment_parameter:
             for parameter_dict in self.environment_parameter.get("find_replace"):
@@ -377,7 +378,7 @@ class FabricWorkspace:
 
                 # Extract the find_value and replace_value_dict
                 find_value = extract_find_value(parameter_dict, raw_file, filter_match)
-                replace_value_dict = parameter_dict.get("replace_value", {})
+                replace_value_dict = process_environment_key(self, parameter_dict.get("replace_value", {}))
 
                 # Replace any found references with specified environment value if conditions are met
                 if find_value in raw_file and self.environment in replace_value_dict and filter_match:

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -863,11 +863,11 @@ find_replace:
 key_value_replace:
     - find_key: $.test
       replace_value:
-        ALL: "universal-key-value"
+        All: "universal-key-value"
 spark_pool:
     - instance_pool_id: "test-pool-id"
       replace_value:
-        ALL:
+        all:
           type: "Capacity"
           name: "UniversalPool"
 """)
@@ -900,12 +900,12 @@ spark_pool:
         # Overall parameter file should be valid
         assert param_obj._validate_parameter_file() == True
 
-        # Test that the ALL environment key is properly recognized
+        # Test that the ALL environment key is properly recognized (case-insensitive)
         for param_dict in param_obj.environment_parameter.get("find_replace"):
-            assert param_obj._validate_environment(param_dict["replace_value"]) == (True, "all")
+            assert param_obj._validate_environment(param_dict["replace_value"]) == (True, "ALL")
 
         for param_dict in param_obj.environment_parameter.get("key_value_replace"):
-            assert param_obj._validate_environment(param_dict["replace_value"]) == (True, "all")
+            assert param_obj._validate_environment(param_dict["replace_value"]) == (True, "All")
 
         for param_dict in param_obj.environment_parameter.get("spark_pool"):
             assert param_obj._validate_environment(param_dict["replace_value"]) == (True, "all")
@@ -943,7 +943,7 @@ spark_pool:
         PROD:
           type: "Capacity"
           name: "ProdPool"
-        ALL:
+        all:
           type: "Capacity"
           name: "UniversalPool"
 """)
@@ -961,14 +961,14 @@ spark_pool:
         assert param_obj._validate_parameter("find_replace") == (
             False,
             constants.PARAMETER_MSGS["other target env"].format(
-                param_obj.environment_parameter["find_replace"][0]["replace_value"]
+                "ALL", param_obj.environment_parameter["find_replace"][0]["replace_value"]
             ),
         )
 
         assert param_obj._validate_parameter("spark_pool") == (
             False,
             constants.PARAMETER_MSGS["other target env"].format(
-                param_obj.environment_parameter["spark_pool"][0]["replace_value"]
+                "all", param_obj.environment_parameter["spark_pool"][0]["replace_value"]
             ),
         )
 
@@ -977,7 +977,7 @@ spark_pool:
 
         # Test that mixed environment combinations are invalid
         for param_dict in param_obj.environment_parameter.get("find_replace"):
-            assert param_obj._validate_environment(param_dict["replace_value"]) == (False, "all")
+            assert param_obj._validate_environment(param_dict["replace_value"]) == (False, "ALL")
 
         for param_dict in param_obj.environment_parameter.get("spark_pool"):
             assert param_obj._validate_environment(param_dict["replace_value"]) == (False, "all")
@@ -1001,7 +1001,7 @@ find_replace:
 spark_pool:
     - instance_pool_id: "test-pool-id"
       replace_value:
-        ALL:
+        all:
           type: "Capacity"
           name: "UniversalPool"
 """)
@@ -1016,35 +1016,35 @@ spark_pool:
         )
 
         # Test environment validation specifically for ALL key
-        replace_value_with_all = {"ALL": "universal-value"}
+        replace_value_with_all = {"all": "universal-value"}
         assert param_obj._validate_environment(replace_value_with_all) == (True, "all")
 
         # Test spark_pool with ALL environment key
         spark_pool_replace_value_with_all = {"ALL": {"type": "Capacity", "name": "UniversalPool"}}
-        assert param_obj._validate_environment(spark_pool_replace_value_with_all) == (True, "all")
+        assert param_obj._validate_environment(spark_pool_replace_value_with_all) == (True, "ALL")
 
         # Test environment validation with both target env and ALL key (should fail)
         replace_value_mixed = {"TEST": "test-value", "ALL": "universal-value"}
-        assert param_obj._validate_environment(replace_value_mixed) == (False, "all")
+        assert param_obj._validate_environment(replace_value_mixed) == (False, "ALL")
 
         # Test spark_pool with mixed environment keys (should fail)
         spark_pool_mixed = {
             "TEST": {"type": "Workspace", "name": "TestPool"},
             "ALL": {"type": "Capacity", "name": "UniversalPool"},
         }
-        assert param_obj._validate_environment(spark_pool_mixed) == (False, "all")
+        assert param_obj._validate_environment(spark_pool_mixed) == (False, "ALL")
 
         # Test environment validation with multiple environment keys including PROD (should fail)
         replace_value_multiple_envs = {"TEST": "test-value", "PROD": "prod-value", "ALL": "universal-value"}
-        assert param_obj._validate_environment(replace_value_multiple_envs) == (False, "all")
+        assert param_obj._validate_environment(replace_value_multiple_envs) == (False, "ALL")
 
         # Test spark_pool with multiple environment keys including PROD (should fail)
         spark_pool_multiple_envs = {
             "TEST": {"type": "Workspace", "name": "TestPool"},
             "PROD": {"type": "Workspace", "name": "ProdPool"},
-            "ALL": {"type": "Capacity", "name": "UniversalPool"},
+            "All": {"type": "Capacity", "name": "UniversalPool"},
         }
-        assert param_obj._validate_environment(spark_pool_multiple_envs) == (False, "all")
+        assert param_obj._validate_environment(spark_pool_multiple_envs) == (False, "All")
 
         # Test environment validation with only target env (no ALL key)
         replace_value_target_only = {"TEST": "test-value"}

--- a/tests/test_parameter_utils.py
+++ b/tests/test_parameter_utils.py
@@ -561,12 +561,8 @@ class TestParameterUtilities:
 
     def test_process_environment_key(self, mock_workspace):
         """Test process_environment_key function with ALL environment key replacement."""
-        # Test with ALL key present - should replace with target environment
-        replace_value_dict = {
-            "ALL": "universal-value",
-            "DEV": "dev-value",
-            "PROD": "prod-value",
-        }
+        # Test with ALL key only - should replace with target environment
+        replace_value_dict = {"ALL": "universal-value"}
 
         # Mock the workspace environment
         mock_workspace.environment = "TEST"
@@ -578,12 +574,8 @@ class TestParameterUtilities:
         assert "ALL" not in result
         assert "TEST" in result
         assert result["TEST"] == "universal-value"
-        # Other keys should remain unchanged
-        assert result["DEV"] == "dev-value"
-        assert result["PROD"] == "prod-value"
+        assert result == {"TEST": "universal-value"}
 
-    def test_process_environment_key_no_all_key(self, mock_workspace):
-        """Test process_environment_key function when ALL key is not present."""
         # Test without ALL key - should return unchanged dictionary
         replace_value_dict = {
             "DEV": "dev-value",
@@ -600,39 +592,6 @@ class TestParameterUtilities:
         assert result == replace_value_dict
         assert "ALL" not in result
         assert "TEST" not in result
-
-    def test_process_environment_key_all_key_only(self, mock_workspace):
-        """Test process_environment_key function with only ALL key present."""
-        # Test with only ALL key present
-        replace_value_dict = {"ALL": "universal-value"}
-
-        # Mock the workspace environment
-        mock_workspace.environment = "PPE"
-
-        # Call the function
-        result = process_environment_key(mock_workspace, replace_value_dict)
-
-        # ALL key should be replaced with PPE key
-        assert "ALL" not in result
-        assert result == {"PPE": "universal-value"}
-
-    def test_process_environment_key_overwrite_existing(self, mock_workspace):
-        """Test process_environment_key function when ALL key overwrites existing environment key."""
-        # Test with ALL key that should overwrite an existing environment key
-        replace_value_dict = {
-            "ALL": "universal-value",
-            "PROD": "original-prod-value",
-        }
-
-        # Mock the workspace environment to match existing key
-        mock_workspace.environment = "PROD"
-
-        # Call the function
-        result = process_environment_key(mock_workspace, replace_value_dict)
-
-        # ALL key should replace the existing PROD value
-        assert "ALL" not in result
-        assert result["PROD"] == "universal-value"
 
 
 class TestPathUtilities:

--- a/tests/test_parameter_utils.py
+++ b/tests/test_parameter_utils.py
@@ -562,22 +562,45 @@ class TestParameterUtilities:
     def test_process_environment_key(self, mock_workspace):
         """Test process_environment_key function with ALL environment key replacement."""
         # Test with ALL key only - should replace with target environment
-        replace_value_dict = {"ALL": "universal-value"}
+        replace_value_dict_1 = {"_ALL_": "universal-value"}
+        replace_value_dict_2 = {"_all_": "universal-value"}
+        replace_value_dict_3 = {"_All_": "universal-value"}
+        replace_value_dict_4 = {"ALL": "universal-value"}
 
         # Mock the workspace environment
         mock_workspace.environment = "TEST"
 
         # Call the function
-        result = process_environment_key(mock_workspace, replace_value_dict)
+        result_1 = process_environment_key(mock_workspace, replace_value_dict_1)
+        result_2 = process_environment_key(mock_workspace, replace_value_dict_2)
+        result_3 = process_environment_key(mock_workspace, replace_value_dict_3)
+        result_4 = process_environment_key(mock_workspace, replace_value_dict_4)
+
+        # Verify _ALL_ key is replaced with the target environment
+        assert "_ALL_" not in result_1
+        assert "TEST" in result_1
+        assert result_1["TEST"] == "universal-value"
+
+        # Verify _all_ key is replaced with the target environment
+        assert "_all_" not in result_2
+        assert "TEST" in result_2
+        assert result_2["TEST"] == "universal-value"
+
+        # Verify _All_ key is replaced with the target environment
+        assert "_All_" not in result_3
+        assert "TEST" in result_3
+        assert result_3["TEST"] == "universal-value"
 
         # Verify ALL key is replaced with the target environment
-        assert "ALL" not in result
-        assert "TEST" in result
-        assert result["TEST"] == "universal-value"
-        assert result == {"TEST": "universal-value"}
+        assert "ALL" in result_4
+        assert "TEST" not in result_4
+        assert result_4["ALL"] == "universal-value"
+
+        assert result_1 == {"TEST": "universal-value"}
+        assert result_1 == result_2 == result_3 != result_4
 
         # Test without ALL key - should return unchanged dictionary
-        replace_value_dict = {
+        replace_value_dict_5 = {
             "DEV": "dev-value",
             "PROD": "prod-value",
         }
@@ -586,11 +609,10 @@ class TestParameterUtilities:
         mock_workspace.environment = "TEST"
 
         # Call the function
-        result = process_environment_key(mock_workspace, replace_value_dict)
+        result = process_environment_key(mock_workspace, replace_value_dict_5)
 
         # Dictionary should remain unchanged
-        assert result == replace_value_dict
-        assert "ALL" not in result
+        assert result == replace_value_dict_5
         assert "TEST" not in result
 
 

--- a/tests/test_parameter_utils.py
+++ b/tests/test_parameter_utils.py
@@ -404,7 +404,7 @@ class TestParameterUtilities:
         assert check_replacement("type1", "name2", [file_path], "type1", "name1", file_path) is False
         assert check_replacement("type1", "name1", [Path("other.txt")], "type1", "name1", file_path) is False
 
-    def test_replace_key_value_valid_json(self):
+    def test_replace_key_value_valid_json(self, mock_workspace):
         """Tests replace_key_value with valid JSON content and environment."""
         # Test JSON with server host configuration
         test_json = '{"server": {"host": "localhost", "port": 8080}}'
@@ -414,17 +414,17 @@ class TestParameterUtilities:
         }
 
         # Test successful replacement for dev environment
-        result = replace_key_value(param_dict, test_json, "dev")
+        result = replace_key_value(mock_workspace, param_dict, test_json, "dev")
         result_data = json.loads(result)
         assert result_data["server"]["host"] == "dev-server.example.com"
         assert result_data["server"]["port"] == 8080  # Verify other values unchanged
 
         # Test successful replacement for prod environment
-        result = replace_key_value(param_dict, test_json, "prod")
+        result = replace_key_value(mock_workspace, param_dict, test_json, "prod")
         result_data = json.loads(result)
         assert result_data["server"]["host"] == "prod-server.example.com"
 
-    def test_replace_key_value_environment_not_found(self):
+    def test_replace_key_value_environment_not_found(self, mock_workspace):
         """Tests replace_key_value when environment is not in the replace_value dictionary."""
         test_json = '{"server": {"host": "localhost", "port": 8080}}'
         param_dict = {
@@ -433,20 +433,20 @@ class TestParameterUtilities:
         }
 
         # Test when environment not in replace_value
-        result = replace_key_value(param_dict, test_json, "test")
+        result = replace_key_value(mock_workspace, param_dict, test_json, "test")
         result_data = json.loads(result)
         assert result_data["server"]["host"] == "localhost"  # Original value unchanged
 
-    def test_replace_key_value_invalid_json(self):
+    def test_replace_key_value_invalid_json(self, mock_workspace):
         """Tests replace_key_value with invalid JSON content."""
         invalid_json = "{invalid json content}"
         param_dict = {"find_key": "$.server.host", "replace_value": {"dev": "test-server"}}
 
         # JSONDecodeError will be raised for invalid JSON and wrapped in ValueError
         with pytest.raises(ValueError, match="Expecting property name"):
-            replace_key_value(param_dict, invalid_json, "dev")
+            replace_key_value(mock_workspace, param_dict, invalid_json, "dev")
 
-    def test_replace_key_value(self):
+    def test_replace_key_value(self, mock_workspace):
         """Test replace_key_value function with JSON content."""
         # Create test parameter dictionary and JSON content
         param_dict = {
@@ -456,20 +456,20 @@ class TestParameterUtilities:
         json_content = '{"server": {"host": "localhost", "port": 8080}}'
 
         # Test successful replacement
-        result = replace_key_value(param_dict, json_content, "dev")
+        result = replace_key_value(mock_workspace, param_dict, json_content, "dev")
 
         # Parse the JSON result and check the exact value (avoid substring sanitization issues)
         result_json = json.loads(result)
         assert result_json["server"]["host"] == "dev-server.example.com"
 
         # Test with environment not in replace_value
-        result = replace_key_value(param_dict, json_content, "test")
+        result = replace_key_value(mock_workspace, param_dict, json_content, "test")
         result_json = json.loads(result)
         assert result_json["server"]["host"] == "localhost"
 
         # Test with invalid JSON content
         with pytest.raises(ValueError, match="Expecting property name"):
-            replace_key_value(param_dict, "{invalid json}", "dev")
+            replace_key_value(mock_workspace, param_dict, "{invalid json}", "dev")
 
     def test_replace_variables_in_parameter_file(self, monkeypatch):
         """Test replace_variables_in_parameter_file with feature flag enabled."""


### PR DESCRIPTION
This pull request introduces support for the `_ALL_` environment key in parameterization logic, allowing a single replacement value to be applied across all environments. The changes include documentation updates, logic for processing the `_ALL_` key, validation enhancements, and new tests. This provides a more flexible and user-friendly approach to environment-specific replacements.

**Parameterization enhancements:**

* Added support for the `_ALL_` (case-insensitive) environment key in `replace_value` for all parameter types. If present, it must be the only key and applies the replacement to any environment. Documentation was updated to explain this feature and provide usage examples. [[1]](diffhunk://#diff-9cdd02ee5f5219c5426160beb19ff83c624221fd6db2ac6f8bf923d6ebb6f0ffR225-R239) [[2]](diffhunk://#diff-9cdd02ee5f5219c5426160beb19ff83c624221fd6db2ac6f8bf923d6ebb6f0ffL308-R323)
* Implemented the `process_environment_key` function in `_utils.py` to transform a `_ALL_` key into the current target environment at runtime, ensuring correct replacement logic throughout the codebase. [[1]](diffhunk://#diff-08e7f8767bb7d280f82e88a77521554115ad781c1dceb4ff0a7b450d38a684abR188-R206) [[2]](diffhunk://#diff-08e7f8767bb7d280f82e88a77521554115ad781c1dceb4ff0a7b450d38a684abR219-R224) [[3]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0R357) [[4]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L374-R375) [[5]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L384-R385) [[6]](diffhunk://#diff-d21d8d1ab1b91c6581949c76a61d12d3f838509ef127b4ae5144feb5bc23bd8aR148-R149) [[7]](diffhunk://#diff-d21d8d1ab1b91c6581949c76a61d12d3f838509ef127b4ae5144feb5bc23bd8aL159-R161)

**Validation improvements:**

* Enhanced environment key validation to enforce that `_ALL_` is used alone, returning an error if combined with other keys. Added warning and error messages for misuse, and improved logging for `_ALL_` usage. [[1]](diffhunk://#diff-663a11b92ff45fa9b30ab4086a71af3d0f87fce5a8da7967ff9a1197cc24d501L236-R236) [[2]](diffhunk://#diff-663a11b92ff45fa9b30ab4086a71af3d0f87fce5a8da7967ff9a1197cc24d501L247-R254) [[3]](diffhunk://#diff-663a11b92ff45fa9b30ab4086a71af3d0f87fce5a8da7967ff9a1197cc24d501R263-R268) [[4]](diffhunk://#diff-663a11b92ff45fa9b30ab4086a71af3d0f87fce5a8da7967ff9a1197cc24d501L447-R476) [[5]](diffhunk://#diff-91c2d32be351f155f090c4bd57ebe3c10e646edbc1b663e2a72b697f956a949cR105-R106)

**Testing updates:**

* Added new test data and cases to verify correct handling of the `_ALL_` environment key in parameter files and validation logic. [[1]](diffhunk://#diff-a7580c594391fc5972b18b00a41243fbc7b828c7aa4b9933894be40143cd0f22R214-R232) [[2]](diffhunk://#diff-a7580c594391fc5972b18b00a41243fbc7b828c7aa4b9933894be40143cd0f22R299-R302) [[3]](diffhunk://#diff-a7580c594391fc5972b18b00a41243fbc7b828c7aa4b9933894be40143cd0f22L611-R634)

**Documentation and minor cleanups:**

* Updated parameterization documentation with usage instructions and clarified parameterization guidance. [[1]](diffhunk://#diff-9cdd02ee5f5219c5426160beb19ff83c624221fd6db2ac6f8bf923d6ebb6f0ffL619-R633) [[2]](diffhunk://#diff-9cdd02ee5f5219c5426160beb19ff83c624221fd6db2ac6f8bf923d6ebb6f0ffL630-R644)