### PR TITLE
Resolves #384 Experimental Feature Flag to Enable Selective Deployment

### DIFF
--- a/docs/how_to/optional_feature.md
+++ b/docs/how_to/optional_feature.md
@@ -13,6 +13,9 @@ For scenarios that aren't supported by default, fabric-cicd offers `feature-flag
 | `enable_shortcut_publish`                 | Set to enable deploying shortcuts with the lakehouse |
 | `enable_environment_variable_replacement` | Set to enable the use of pipeline variables          |
 | `disable_workspace_folder_publish`        | Set to disable deploying workspace sub folders       |
+| `experimental`                            | Set to enable selective deployment\*                 |
+
+\*`experimental` flag must be used with `publish_all_items(workspace, publish_items_to_include_list)`
 
 <span class="md-h3-nonanchor">Example</span>
 

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -127,6 +127,7 @@ class FabricWorkspace:
             self.item_type_in_scope = validate_item_type_in_scope(item_type_in_scope, upn_auth=self.endpoint.upn_auth)
         self.environment = validate_environment(environment)
         self.publish_item_name_exclude_regex = None
+        self.publish_items_to_include = None
         self.repository_folders = {}
         self.repository_items = {}
         self.deployed_folders = {}
@@ -470,6 +471,22 @@ class FabricWorkspace:
             if regex_pattern.match(item_name):
                 item.skip_publish = True
                 logger.info(f"Skipping publishing of {item_type} '{item_name}' due to exclusion regex.")
+                return
+
+        # Skip publishing if the item is not in the include list
+        if self.publish_items_to_include:
+            current_item = f"{item_name}.{item_type}"
+
+            # Normalize include list to a lowercase set for efficient lookups
+            normalized_include_set = {include_item.lower() for include_item in self.publish_items_to_include}
+
+            # Check for exact match or case-insensitive match
+            match_found = (
+                current_item in self.publish_items_to_include or current_item.lower() in normalized_include_set
+            )
+            if not match_found:
+                item.skip_publish = True
+                logger.info(f"Skipping publishing of {item_type} '{item_name}' as it is not in the include list.")
                 return
 
         item_guid = item.guid

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -21,13 +21,18 @@ from fabric_cicd.fabric_workspace import FabricWorkspace
 logger = logging.getLogger(__name__)
 
 
-def publish_all_items(fabric_workspace_obj: FabricWorkspace, item_name_exclude_regex: Optional[str] = None) -> None:
+def publish_all_items(
+    fabric_workspace_obj: FabricWorkspace,
+    item_name_exclude_regex: Optional[str] = None,
+    items_to_include_list: Optional[list[str]] = None,
+) -> None:
     """
     Publishes all items defined in the `item_type_in_scope` list of the given FabricWorkspace object.
 
     Args:
         fabric_workspace_obj: The FabricWorkspace object containing the items to be published.
         item_name_exclude_regex: Regex pattern to exclude specific items from being published.
+        items_to_include_list: List of items in the format "item_name.item_type" that should be published.
 
 
     Examples:
@@ -49,6 +54,16 @@ def publish_all_items(fabric_workspace_obj: FabricWorkspace, item_name_exclude_r
         ... )
         >>> exclude_regex = ".*_do_not_publish"
         >>> publish_all_items(workspace, exclude_regex)
+
+        With items to include list
+        >>> from fabric_cicd import FabricWorkspace, publish_all_items
+        >>> workspace = FabricWorkspace(
+        ...     workspace_id="your-workspace-id",
+        ...     repository_directory="/path/to/repo",
+        ...     item_type_in_scope=["Environment", "Notebook", "DataPipeline"]
+        ... )
+        >>> items_to_include = ["Hello World.Notebook", "Hello.Environment"]
+        >>> publish_all_items(workspace, items_to_include)
     """
     fabric_workspace_obj = validate_fabric_workspace_obj(fabric_workspace_obj)
 
@@ -81,6 +96,12 @@ def publish_all_items(fabric_workspace_obj: FabricWorkspace, item_name_exclude_r
             "Using item_name_exclude_regex is risky as it can prevent needed dependencies from being deployed.  Use at your own risk."
         )
         fabric_workspace_obj.publish_item_name_exclude_regex = item_name_exclude_regex
+
+    if "experimental" in constants.FEATURE_FLAG and items_to_include_list:
+        logger.warning(
+            "Using items_to_include_list is risky as it can prevent needed dependencies from being deployed.  Use at your own risk."
+        )
+        fabric_workspace_obj.publish_items_to_include = items_to_include_list
 
     def _should_publish_item_type(item_type: str) -> bool:
         """Check if an item type should be published based on scope and repository content."""


### PR DESCRIPTION
This pull request introduces an experimental feature for selective deployment in the `fabric-cicd` package, allowing users to specify a list of items to publish instead of deploying all items by default. The feature is gated behind a new `experimental` feature flag and is intended for advanced scenarios where fine-grained control over deployments is needed. Documentation and code changes ensure the new functionality is clearly described and safely integrated.

**Selective deployment feature:**

* Added support for an `items_to_include_list` parameter to the `publish_all_items` function in `publish.py`, allowing users to specify exactly which items (by `item_name.item_type`) should be published. The function now checks this list and only publishes matching items. [[1]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704L24-R35) [[2]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R57-R66) [[3]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R100-R105)
* Updated the `_publish_item` method in `fabric_workspace.py` to skip publishing items not present in the `publish_items_to_include` list, with case-insensitive matching for flexibility.

**Feature flag and documentation:**

* Introduced a new `experimental` feature flag, which must be enabled to use the selective deployment feature. This is documented in `docs/how_to/optional_feature.md` with usage notes and caveats.
* Added a warning log when the experimental selective deployment feature is used, highlighting the risk that dependencies may not be deployed.

**Internal API changes:**

* Added a new `publish_items_to_include` attribute to the `FabricWorkspace` class to store the list of items to include during publishing.