### PR TITLE
Resolves #364 add structured logs output to publish and unpublish functions

### DIFF
--- a/docs/how_to/optional_feature.md
+++ b/docs/how_to/optional_feature.md
@@ -14,6 +14,7 @@ For scenarios that aren't supported by default, fabric-cicd offers `feature-flag
 | `enable_eventhouse_unpublish`             | Set to enable the deletion of Eventhouses                          |              |
 | `disable_print_identity`                  | Set to disable printing the executing identity name                |              |
 | `enable_shortcut_publish`                 | Set to enable deploying shortcuts with the lakehouse               |              |
+| `continue_on_shortcut_failure`            | Set to enable deploying when shortcuts fail to publish             |              |
 | `enable_environment_variable_replacement` | Set to enable the use of pipeline variables                        |              |
 | `disable_workspace_folder_publish`        | Set to disable deploying workspace sub folders                     |              |
 | `enable_experimental_features`            | Set to enable experimental features, such as selective deployments |              |

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,3 +40,88 @@ unpublish_all_orphan_items(target_workspace)
 ```
 
 > **Note**: The `environment` parameter is required for parameter replacement to work properly. It must match one of the environment keys defined in your `parameter.yml` file (e.g., "PPE", "PROD", "DEV"). If you don't need parameter replacement, you can omit this parameter.
+
+## Structured Logging
+
+Both `publish_all_items()` and `unpublish_all_orphan_items()` return detailed deployment logs that can be used for monitoring, reporting, and debugging:
+
+```python
+from fabric_cicd import FabricWorkspace, publish_all_items, unpublish_all_orphan_items
+
+target_workspace = FabricWorkspace(
+    workspace_id="your-workspace-id",
+    environment="DEV",
+    repository_directory="./workspace-items",
+    item_type_in_scope=["Notebook", "DataPipeline", "Environment"],
+)
+
+# Get structured logs for publish operations
+publish_logs = publish_all_items(target_workspace)
+
+# Get structured logs for unpublish operations
+unpublish_logs = unpublish_all_orphan_items(target_workspace)
+
+# Process the logs
+for log_entry in publish_logs:
+    status = "✅ Success" if log_entry.success else "❌ Failed"
+    print(f"{status} - {log_entry.item_type}: {log_entry.name}")
+    print(f"   Duration: {log_entry.duration_seconds:.2f}s")
+
+    if not log_entry.success:
+        print(f"   Error: {log_entry.error}")
+        print(f"   Item ID: {log_entry.guid}")
+```
+
+### Log Entry Properties
+
+Each log entry contains:
+
+-   `name`: Item display name
+-   `item_type`: Type of Fabric item (Notebook, DataPipeline, etc.)
+-   `operation_type`: Either "publish" or "unpublish"
+-   `success`: Boolean indicating if operation succeeded
+-   `start_time`: When the operation started (datetime)
+-   `end_time`: When the operation completed (datetime)
+-   `duration_seconds`: Operation duration in seconds (float)
+-   `guid`: Fabric item ID (available after successful publish)
+-   `error`: Error details (only present when success=False)
+
+### Use Cases for Structured Logs
+
+**CI/CD Pipeline Reporting:**
+
+```python
+# Count successful vs failed operations
+successful = [log for log in publish_logs if log.success]
+failed = [log for log in publish_logs if not log.success]
+
+print(f"Published: {len(successful)} items successfully")
+print(f"Failed: {len(failed)} items")
+
+# Fail the pipeline if any items failed
+if failed:
+    for entry in failed:
+        print(f"FAILED: {entry.item_type} '{entry.name}' - {entry.error}")
+    exit(1)
+```
+
+**Performance Monitoring:**
+
+```python
+# Track deployment performance
+slow_operations = [log for log in publish_logs if log.duration_seconds > 30]
+total_time = sum(log.duration_seconds for log in publish_logs)
+
+print(f"Total deployment time: {total_time:.2f} seconds")
+if slow_operations:
+    print(f"Slow operations detected: {len(slow_operations)}")
+```
+
+**Custom Notifications:**
+
+```python
+# Send alerts for specific failures
+for entry in publish_logs:
+    if not entry.success and "timeout" in entry.error.lower():
+        send_alert(f"Timeout deploying {entry.item_type}: {entry.name}")
+```

--- a/src/fabric_cicd/_common/_deployment_log_entry.py
+++ b/src/fabric_cicd/_common/_deployment_log_entry.py
@@ -3,9 +3,15 @@
 
 """Module for structured publish/unpublish logging."""
 
+from collections.abc import Generator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
+
+# This allows type hints without circular imports (fabric_workspace imports this module)
+if TYPE_CHECKING:
+    from fabric_cicd.fabric_workspace import FabricWorkspace
 
 
 @dataclass
@@ -26,7 +32,7 @@ class DeploymentLogEntry:
         """Calculate the duration of the operation in seconds."""
         return (self.end_time - self.start_time).total_seconds()
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, str | bool | float | None]:
         """Convert the log entry to a dictionary for serialization."""
         return {
             "name": self.name,
@@ -39,3 +45,64 @@ class DeploymentLogEntry:
             "guid": self.guid,
             "operation_type": self.operation_type,
         }
+
+
+@contextmanager
+def log_operation(
+    workspace_obj: "FabricWorkspace",
+    operation_type: str,
+    item_name: str,
+    item_type: str,
+    item_guid: Optional[str] = None,
+) -> Generator[dict[str, str | bool | None], None, None]:
+    """
+    Context manager for structured operation logging.
+
+    Args:
+        workspace_obj: The FabricWorkspace object
+        operation_type: "publish" or "unpublish"
+        item_name: Name of the item
+        item_type: Type of the item
+        item_guid: Optional GUID of the item
+
+    Yields:
+        dict: Context dictionary with operation state
+    """
+    if operation_type not in ("publish", "unpublish"):
+        msg = f"Unsupported operation_type: {operation_type}. Must be 'publish' or 'unpublish'"
+        raise ValueError(msg)
+
+    # Initialize operation state
+    start_time = datetime.now()
+    context: dict[str, str | bool | None] = {
+        "success": True,
+        "error_msg": None,
+        "item_guid": item_guid,
+    }
+    try:
+        yield context
+    except Exception as e:
+        # Mark operation as failed and capture error details
+        context["success"] = False
+        context["error_msg"] = str(e)
+        raise  # Re-raise the exception (allows exception to propagate)
+    finally:
+        end_time = datetime.now()
+
+        # Create log entry
+        log_entry = DeploymentLogEntry(
+            name=item_name,
+            item_type=item_type,
+            success=bool(context["success"]),
+            error=context["error_msg"] if isinstance(context["error_msg"], str) else None,
+            start_time=start_time,
+            end_time=end_time,
+            guid=context["item_guid"] if isinstance(context["item_guid"], str) else None,
+            operation_type=operation_type,
+        )
+
+        # Append to appropriate log list
+        if operation_type == "publish":
+            workspace_obj.publish_log_entries.append(log_entry)
+        elif operation_type == "unpublish":
+            workspace_obj.unpublish_log_entries.append(log_entry)

--- a/src/fabric_cicd/_common/_deployment_log_entry.py
+++ b/src/fabric_cicd/_common/_deployment_log_entry.py
@@ -1,0 +1,41 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Module for structured publish/unpublish logging."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass
+class DeploymentLogEntry:
+    """Represents a structured log entry for publish/unpublish operations."""
+
+    name: str
+    item_type: str
+    success: bool
+    error: Optional[str]
+    start_time: datetime
+    end_time: datetime
+    guid: Optional[str] = None
+    operation_type: str = "publish"  # or "unpublish"
+
+    @property
+    def duration_seconds(self) -> float:
+        """Calculate the duration of the operation in seconds."""
+        return (self.end_time - self.start_time).total_seconds()
+
+    def to_dict(self) -> dict:
+        """Convert the log entry to a dictionary for serialization."""
+        return {
+            "name": self.name,
+            "item_type": self.item_type,
+            "success": self.success,
+            "error": self.error,
+            "start_time": self.start_time.isoformat(),
+            "end_time": self.end_time.isoformat(),
+            "duration_seconds": self.duration_seconds,
+            "guid": self.guid,
+            "operation_type": self.operation_type,
+        }

--- a/src/fabric_cicd/_common/_exceptions.py
+++ b/src/fabric_cicd/_common/_exceptions.py
@@ -52,3 +52,7 @@ class ParameterFileError(BaseCustomError):
 
 class FailedPublishedItemStatusError(BaseCustomError):
     pass
+
+
+class DeploymentError(BaseCustomError):
+    pass

--- a/src/fabric_cicd/_items/_lakehouse.py
+++ b/src/fabric_cicd/_items/_lakehouse.py
@@ -5,12 +5,11 @@
 
 import json
 import logging
-from datetime import datetime
 
 import dpath
 
 from fabric_cicd import FabricWorkspace, constants
-from fabric_cicd._common._deployment_log_entry import DeploymentLogEntry
+from fabric_cicd._common._deployment_log_entry import log_operation
 from fabric_cicd._common._exceptions import FailedPublishedItemStatusError
 from fabric_cicd._common._fabric_endpoint import handle_retry
 from fabric_cicd._common._item import Item
@@ -142,49 +141,35 @@ def publish_shortcuts(fabric_workspace_obj: FabricWorkspace, item_obj: Item, sho
         shortcut_dict: The dict of shortcuts to publish
     """
     for shortcut in shortcut_dict.values():
-        # Capture the start time for structured logging
-        start_time = datetime.now()
-        error_msg = None
-        success = True
-
-        try:
-            # https://learn.microsoft.com/en-us/rest/api/fabric/core/onelake-shortcuts/create-shortcut
-            fabric_workspace_obj.endpoint.invoke(
-                method="POST",
-                url=f"{fabric_workspace_obj.base_api_url}/items/{item_obj.guid}/shortcuts?shortcutConflictPolicy=CreateOrOverwrite",
-                body=shortcut,
-            )
-            logger.info(f"{constants.INDENT}{shortcut['name']} Shortcut Published")
-
-        except Exception as e:
-            success = False
-            error_msg = str(e)
-
-            if "continue_on_shortcut_failure" in constants.FEATURE_FLAG:
-                logger.warning(
-                    f"Failed to publish '{shortcut['name']}'. This usually happens when the lakehouse containing the source for this shortcut is published as a shell and has no data yet."
+        with log_operation(
+            fabric_workspace_obj,
+            "publish",
+            f"{item_obj.name}/{shortcut['name']}",
+            "Shortcut",
+            f"{item_obj.guid}/shortcut/{shortcut['name']}",
+        ) as context:
+            try:
+                # https://learn.microsoft.com/en-us/rest/api/fabric/core/onelake-shortcuts/create-shortcut
+                fabric_workspace_obj.endpoint.invoke(
+                    method="POST",
+                    url=f"{fabric_workspace_obj.base_api_url}/items/{item_obj.guid}/shortcuts?shortcutConflictPolicy=CreateOrOverwrite",
+                    body=shortcut,
                 )
-                logger.info("The publish process will continue with the other items.")
-                continue
+                logger.info(f"{constants.INDENT}{shortcut['name']} Shortcut Published")
 
-            msg = f"Failed to publish '{shortcut['name']}' for lakehouse {item_obj.name}"
-            raise FailedPublishedItemStatusError(msg, logger) from e
+            except Exception as e:
+                if "continue_on_shortcut_failure" in constants.FEATURE_FLAG:
+                    context["success"] = False
+                    context["error_msg"] = str(e)
 
-        finally:
-            end_time = datetime.now()
+                    logger.warning(
+                        f"Failed to publish '{shortcut['name']}'. This usually happens when the lakehouse containing the source for this shortcut is published as a shell and has no data yet."
+                    )
+                    logger.info("The publish process will continue with the other items.")
+                    continue
 
-            # Add log entry for publish attempt
-            fabric_workspace_obj.publish_log_entries.append(
-                DeploymentLogEntry(
-                    name=f"{item_obj.name}/{shortcut['name']}",
-                    item_type="Shortcut",
-                    success=success,
-                    error=error_msg,
-                    start_time=start_time,
-                    end_time=end_time,
-                    guid=f"{item_obj.guid}/shortcut/{shortcut['name']}",
-                )
-            )
+                msg = f"Failed to publish '{shortcut['name']}' for lakehouse {item_obj.name}"
+                raise FailedPublishedItemStatusError(msg, logger) from e
 
 
 def unpublish_shortcuts(fabric_workspace_obj: FabricWorkspace, item_obj: Item, shortcut_paths: list) -> None:

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -473,34 +473,34 @@ class FabricWorkspace:
         """
         item = self.repository_items[item_type][item_name]
 
+        # Skip publishing if the item is excluded by the regex
+        if self.publish_item_name_exclude_regex:
+            regex_pattern = check_regex(self.publish_item_name_exclude_regex)
+            if regex_pattern.match(item_name):
+                item.skip_publish = True
+                logger.info(f"Skipping publishing of {item_type} '{item_name}' due to exclusion regex.")
+                return
+
+        # Skip publishing if the item is not in the include list
+        if self.items_to_include:
+            current_item = f"{item_name}.{item_type}"
+
+            # Normalize include list to a lowercase set for efficient lookups
+            normalized_include_set = {include_item.lower() for include_item in self.items_to_include}
+
+            # Check for exact match or case-insensitive match
+            match_found = current_item in self.items_to_include or current_item.lower() in normalized_include_set
+            if not match_found:
+                item.skip_publish = True
+                logger.info(f"Skipping publishing of {item_type} '{item_name}' as it is not in the include list.")
+                return
+
         # Capture the start time for structured logging
         start_time = datetime.now()
         error_msg = None
         success = True
 
         try:
-            # Skip publishing if the item is excluded by the regex
-            if self.publish_item_name_exclude_regex:
-                regex_pattern = check_regex(self.publish_item_name_exclude_regex)
-                if regex_pattern.match(item_name):
-                    item.skip_publish = True
-                    logger.info(f"Skipping publishing of {item_type} '{item_name}' due to exclusion regex.")
-                    return
-
-            # Skip publishing if the item is not in the include list
-            if self.items_to_include:
-                current_item = f"{item_name}.{item_type}"
-
-                # Normalize include list to a lowercase set for efficient lookups
-                normalized_include_set = {include_item.lower() for include_item in self.items_to_include}
-
-                # Check for exact match or case-insensitive match
-                match_found = current_item in self.items_to_include or current_item.lower() in normalized_include_set
-                if not match_found:
-                    item.skip_publish = True
-                    logger.info(f"Skipping publishing of {item_type} '{item_name}' as it is not in the include list.")
-                    return
-
             item_guid = item.guid
             item_files = item.item_files
 
@@ -616,25 +616,25 @@ class FabricWorkspace:
         """
         item_guid = self.deployed_items[item_type][item_name].guid
 
+        # Skip unpublishing if the item is not in the include list
+        if self.items_to_include:
+            current_item = f"{item_name}.{item_type}"
+
+            # Normalize include list to a lowercase set for efficient lookups
+            normalized_include_set = {include_item.lower() for include_item in self.items_to_include}
+
+            # Check for exact match or case-insensitive match
+            match_found = current_item in self.items_to_include or current_item.lower() in normalized_include_set
+            if not match_found:
+                logger.info(f"Skipping unpublishing of {item_type} '{item_name}' as it is not in the include list.")
+                return
+
         # Capture the start time for structured logging
         start_time = datetime.now()
         error_msg = None
         success = True
 
         try:
-            # Skip unpublishing if the item is not in the include list
-            if self.items_to_include:
-                current_item = f"{item_name}.{item_type}"
-
-                # Normalize include list to a lowercase set for efficient lookups
-                normalized_include_set = {include_item.lower() for include_item in self.items_to_include}
-
-                # Check for exact match or case-insensitive match
-                match_found = current_item in self.items_to_include or current_item.lower() in normalized_include_set
-                if not match_found:
-                    logger.info(f"Skipping unpublishing of {item_type} '{item_name}' as it is not in the include list.")
-                    return
-
             logger.info(f"Unpublishing {item_type} '{item_name}'")
 
             # Delete the item from the workspace

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -472,6 +472,8 @@ class FabricWorkspace:
             **kwargs: Additional keyword arguments.
         """
         item = self.repository_items[item_type][item_name]
+        item_guid = item.guid
+        item_files = item.item_files
 
         # Skip publishing if the item is excluded by the regex
         if self.publish_item_name_exclude_regex:
@@ -501,9 +503,6 @@ class FabricWorkspace:
         success = True
 
         try:
-            item_guid = item.guid
-            item_files = item.item_files
-
             metadata_body = {"displayName": item_name, "type": item_type}
 
             # Only shell deployment, no definition support

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -639,11 +639,8 @@ class FabricWorkspace:
 
             # Delete the item from the workspace
             # https://learn.microsoft.com/en-us/rest/api/fabric/core/items/delete-item
-            try:
-                self.endpoint.invoke(method="DELETE", url=f"{self.base_api_url}/items/{item_guid}")
-                logger.info(f"{constants.INDENT}Unpublished")
-            except Exception as e:
-                logger.warning(f"Failed to unpublish {item_type} '{item_name}'.  Raw exception: {e}")
+            self.endpoint.invoke(method="DELETE", url=f"{self.base_api_url}/items/{item_guid}")
+            logger.info(f"{constants.INDENT}Unpublished")
 
         except Exception as e:
             success = False

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -12,7 +12,7 @@ import fabric_cicd._items as items
 from fabric_cicd import constants
 from fabric_cicd._common._check_utils import check_regex
 from fabric_cicd._common._deployment_log_entry import DeploymentLogEntry
-from fabric_cicd._common._exceptions import FailedPublishedItemStatusError, InputError
+from fabric_cicd._common._exceptions import DeploymentError, FailedPublishedItemStatusError, InputError
 from fabric_cicd._common._logging import print_header
 from fabric_cicd._common._validate_input import (
     validate_fabric_workspace_obj,
@@ -146,73 +146,68 @@ def publish_all_items(
             item_type in fabric_workspace_obj.item_type_in_scope and item_type in fabric_workspace_obj.repository_items
         )
 
-    try:
-        if _should_publish_item_type("VariableLibrary"):
-            print_header("Publishing Variable Libraries")
-            items.publish_variablelibraries(fabric_workspace_obj)
-        if _should_publish_item_type("Warehouse"):
-            print_header("Publishing Warehouses")
-            items.publish_warehouses(fabric_workspace_obj)
-        if _should_publish_item_type("Lakehouse"):
-            print_header("Publishing Lakehouses")
-            items.publish_lakehouses(fabric_workspace_obj)
-        if _should_publish_item_type("SQLDatabase"):
-            print_header("Publishing SQL Databases")
-            items.publish_sqldatabases(fabric_workspace_obj)
-        if _should_publish_item_type("MirroredDatabase"):
-            print_header("Publishing Mirrored Databases")
-            items.publish_mirroreddatabase(fabric_workspace_obj)
-        if _should_publish_item_type("Environment"):
-            print_header("Publishing Environments")
-            items.publish_environments(fabric_workspace_obj)
-        if _should_publish_item_type("Notebook"):
-            print_header("Publishing Notebooks")
-            items.publish_notebooks(fabric_workspace_obj)
-        if _should_publish_item_type("SemanticModel"):
-            print_header("Publishing Semantic Models")
-            items.publish_semanticmodels(fabric_workspace_obj)
-        if _should_publish_item_type("Report"):
-            print_header("Publishing Reports")
-            items.publish_reports(fabric_workspace_obj)
-        if _should_publish_item_type("CopyJob"):
-            print_header("Publishing Copy Jobs")
-            items.publish_copyjobs(fabric_workspace_obj)
-        if _should_publish_item_type("Eventhouse"):
-            print_header("Publishing Eventhouses")
-            items.publish_eventhouses(fabric_workspace_obj)
-        if _should_publish_item_type("KQLDatabase"):
-            print_header("Publishing KQL Databases")
-            items.publish_kqldatabases(fabric_workspace_obj)
-        if _should_publish_item_type("KQLQueryset"):
-            print_header("Publishing KQL Querysets")
-            items.publish_kqlquerysets(fabric_workspace_obj)
-        if _should_publish_item_type("Reflex"):
-            print_header("Publishing Activators")
-            items.publish_activators(fabric_workspace_obj)
-        if _should_publish_item_type("Eventstream"):
-            print_header("Publishing Eventstreams")
-            items.publish_eventstreams(fabric_workspace_obj)
-        if _should_publish_item_type("KQLDashboard"):
-            print_header("Publishing KQL Dashboards")
-            items.publish_kqldashboard(fabric_workspace_obj)
-        if _should_publish_item_type("Dataflow"):
-            print_header("Publishing Dataflows")
-            items.publish_dataflows(fabric_workspace_obj)
-        if _should_publish_item_type("DataPipeline"):
-            print_header("Publishing Data Pipelines")
-            items.publish_datapipelines(fabric_workspace_obj)
-        if _should_publish_item_type("GraphQLApi"):
-            print_header("Publishing GraphQL APIs")
-            items.publish_graphqlapis(fabric_workspace_obj)
+    if _should_publish_item_type("VariableLibrary"):
+        print_header("Publishing Variable Libraries")
+        items.publish_variablelibraries(fabric_workspace_obj)
+    if _should_publish_item_type("Warehouse"):
+        print_header("Publishing Warehouses")
+        items.publish_warehouses(fabric_workspace_obj)
+    if _should_publish_item_type("Lakehouse"):
+        print_header("Publishing Lakehouses")
+        items.publish_lakehouses(fabric_workspace_obj)
+    if _should_publish_item_type("SQLDatabase"):
+        print_header("Publishing SQL Databases")
+        items.publish_sqldatabases(fabric_workspace_obj)
+    if _should_publish_item_type("MirroredDatabase"):
+        print_header("Publishing Mirrored Databases")
+        items.publish_mirroreddatabase(fabric_workspace_obj)
+    if _should_publish_item_type("Environment"):
+        print_header("Publishing Environments")
+        items.publish_environments(fabric_workspace_obj)
+    if _should_publish_item_type("Notebook"):
+        print_header("Publishing Notebooks")
+        items.publish_notebooks(fabric_workspace_obj)
+    if _should_publish_item_type("SemanticModel"):
+        print_header("Publishing Semantic Models")
+        items.publish_semanticmodels(fabric_workspace_obj)
+    if _should_publish_item_type("Report"):
+        print_header("Publishing Reports")
+        items.publish_reports(fabric_workspace_obj)
+    if _should_publish_item_type("CopyJob"):
+        print_header("Publishing Copy Jobs")
+        items.publish_copyjobs(fabric_workspace_obj)
+    if _should_publish_item_type("Eventhouse"):
+        print_header("Publishing Eventhouses")
+        items.publish_eventhouses(fabric_workspace_obj)
+    if _should_publish_item_type("KQLDatabase"):
+        print_header("Publishing KQL Databases")
+        items.publish_kqldatabases(fabric_workspace_obj)
+    if _should_publish_item_type("KQLQueryset"):
+        print_header("Publishing KQL Querysets")
+        items.publish_kqlquerysets(fabric_workspace_obj)
+    if _should_publish_item_type("Reflex"):
+        print_header("Publishing Activators")
+        items.publish_activators(fabric_workspace_obj)
+    if _should_publish_item_type("Eventstream"):
+        print_header("Publishing Eventstreams")
+        items.publish_eventstreams(fabric_workspace_obj)
+    if _should_publish_item_type("KQLDashboard"):
+        print_header("Publishing KQL Dashboards")
+        items.publish_kqldashboard(fabric_workspace_obj)
+    if _should_publish_item_type("Dataflow"):
+        print_header("Publishing Dataflows")
+        items.publish_dataflows(fabric_workspace_obj)
+    if _should_publish_item_type("DataPipeline"):
+        print_header("Publishing Data Pipelines")
+        items.publish_datapipelines(fabric_workspace_obj)
+    if _should_publish_item_type("GraphQLApi"):
+        print_header("Publishing GraphQL APIs")
+        items.publish_graphqlapis(fabric_workspace_obj)
 
-        # Check Environment Publish
-        if _should_publish_item_type("Environment"):
-            print_header("Checking Environment Publish State")
-            items.check_environment_publish_state(fabric_workspace_obj)
-
-    except Exception as e:
-        logger.error(f"An error occurred during publishing: {e}", exc_info=True)
-        return fabric_workspace_obj.publish_log_entries
+    # Check Environment Publish
+    if _should_publish_item_type("Environment"):
+        print_header("Checking Environment Publish State")
+        items.check_environment_publish_state(fabric_workspace_obj)
 
     return fabric_workspace_obj.publish_log_entries
 
@@ -380,7 +375,7 @@ def unpublish_all_orphan_items(
             fabric_workspace_obj._unpublish_folders()
 
     except Exception as e:
-        logger.error(f"An error occurred during unpublishing: {e}", exc_info=True)
-        return fabric_workspace_obj.unpublish_log_entries
+        msg = f"An error occurred during unpublishing: {e}"
+        raise DeploymentError(msg, logger) from e
 
     return fabric_workspace_obj.unpublish_log_entries

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -341,8 +341,8 @@ def test_unpublish_with_feature_flags_enabled(mock_endpoint, caplog):
             # Restore original feature flags
             constants.FEATURE_FLAG.clear()
             constants.FEATURE_FLAG.update(original_flags)
-           
-          
+
+
 def test_publish_all_items_deployment_log_entries(mock_endpoint):
     """Test that publish_all_items returns list of DeploymentLogEntry objects."""
 
@@ -509,4 +509,4 @@ def test_unpublish_all_orphan_items_returns_empty_list(mock_endpoint):
 
             # Verify return type
             assert isinstance(result, list)
-            assert len(result) == 0   
+            assert len(result) == 0


### PR DESCRIPTION
This pull request introduces structured logging for publish and unpublish operations in the deployment workflow. It adds a new `DeploymentLogEntry` dataclass to capture detailed metadata about each operation, updates the main publishing and unpublishing flows to record these logs, and changes the `publish_all_items` and `unpublish_all_orphan_items` APIs to return lists of these structured log entries. Additionally, the documentation and usage examples are updated to reflect these changes.

**Structured Logging Enhancements:**

* Added a new `DeploymentLogEntry` dataclass in `_common/_deployment_log_entry.py` to represent structured log entries for publish/unpublish operations, including fields for timing, success, error details, and operation type.
* Updated the `FabricWorkspace` class to maintain lists of publish and unpublish log entries, and record a `DeploymentLogEntry` for each item published or unpublished, capturing timing and error information. [[1]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0R141-R145) [[2]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0R476-R481) [[3]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0R584-R606) [[4]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0R619-R624)
* Modified shortcut publishing in `_lakehouse.py` to log each shortcut publish attempt using `DeploymentLogEntry`.

**API and Usage Changes:**

* Changed the signatures of `publish_all_items` and `unpublish_all_orphan_items` to return lists of `DeploymentLogEntry` objects, and updated their docstrings and examples to demonstrate structured logging usage. [[1]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704L28-R29) [[2]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R38-R39) [[3]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R56-R70) [[4]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704L61-R81) [[5]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704L71-R100) [[6]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R240-R242) [[7]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704L217-R267) [[8]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704L228-R280) [[9]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704L239-R299)
* Both functions now clear previous log entries at the start of execution to ensure logs only reflect the current operation. [[1]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704L71-R100) [[2]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704L239-R299)

**Error Handling Improvements:**

* Wrapped the main publish and unpublish loops in try/except blocks to ensure that errors are logged and the structured log entries are returned even if an exception occurs. [[1]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R149) [[2]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R216-R227) [[3]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R355)

These changes improve traceability and debugging for deployment operations by providing detailed, structured logs for each publish and unpublish action.