### PR TITLE
Resolves #302 - Fix Bump Dependency

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -74,7 +74,7 @@ jobs:
 
     bump-version:
         name: Bump Version and Publish Docs
-        needs: [get-pr-details, validate-version-bump]
+        needs: [validate-version-bump]
         if: |
             (github.event_name == 'workflow_dispatch') ||
             (github.event_name == 'pull_request' && github.event.pull_request.merged == true && needs.validate-version-bump.outputs.is_version_bump == 'true')


### PR DESCRIPTION
This pull request makes a minor change to the workflow dependencies in `.github/workflows/bump.yml`, removing the requirement for the `get-pr-details` job before running the `bump-version` job.

* Workflow update: The `bump-version` job now only depends on `validate-version-bump`, simplifying the workflow and potentially reducing execution time.