### PR TITLE
Resolves #514 Limit pytest stdout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ on:
     pull_request:
         branches: ["main"]
         types: [opened, edited, synchronize, ready_for_review]
+    push:
+        branches: ["main"]
 
 jobs:
     unit_test:
@@ -24,4 +26,4 @@ jobs:
                   python -m pip install --upgrade pip
                   pip install uv
                   uv sync --dev
-                  uv run pytest -v -s || exit 1  # Fail the job if any tests fail
+                  uv run pytest -v || exit 1  # Fail the job if any tests fail


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to improve CI coverage and slightly adjust the test execution command. The most important changes are:

**Workflow trigger improvements:**

* Added a `push` trigger on the `main` branch in `.github/workflows/test.yml`, so tests now run on both pull requests and direct pushes to `main`.

**Test command adjustment:**

* Removed the `-s` flag from the `pytest` command in the unit test job, which disables capturing of output during tests.
