### PR TITLE
Fixes #522 fabric-cicd workspace-level private links base_api_url fix

### DIFF
--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -136,14 +136,8 @@ class FabricWorkspace:
         # Initialize dataflow dependencies dictionary (used in dataflow item processing)
         self.dataflow_dependencies = {}
 
-        # temporarily support base_api_url until deprecated
+        # Support for dynamic base_api_url value
         if "base_api_url" in kwargs:
-            logger.warning(
-                f"""Constant DEFAULT_API_ROOT_URL will be replaced with:
-                >>> import fabric_cicd.constants
-                >>> constants.DEFAULT_API_ROOT_URL = '<your_base_api_url>'\n
-                >>> using base_api_url = {kwargs['base_api_url']} instead"""
-            )
             self.base_api_url = f"{kwargs['base_api_url']}"
         else:
             self.base_api_url = f"{constants.DEFAULT_API_ROOT_URL}"

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -76,7 +76,7 @@ def publish_all_items(
     has_assigned_capacity = None
 
     response_state = fabric_workspace_obj.endpoint.invoke(
-        method="GET", url=f"{constants.DEFAULT_API_ROOT_URL}/v1/workspaces/{fabric_workspace_obj.workspace_id}"
+        method="GET", url=f"{fabric_workspace_obj.base_api_url}/v1/workspaces/{fabric_workspace_obj.workspace_id}"
     )
 
     has_assigned_capacity = dpath.get(response_state, "body/capacityId", default=None)


### PR DESCRIPTION
## Description
With workspace-level private links (see [setup guide](https://review.learn.microsoft.com/en-us/fabric/security/security-workspace-level-private-links-set-up?branch=main#step-7-access-fabric-privately-from-the-virtual-machine)), the API URL becomes dynamic and must be resolved per workspace, not globally or via a static override.

Blocking Deployment:
If the API URL is not dynamically resolved per workspace, deployments behind private links will fail, as the correct endpoint will not be reachable.
## Linked Issue (REQUIRED)
Fixes #522
https://github.com/microsoft/fabric-cicd/issues/522
<!-- 
REQUIRED: Link to the issue this PR addresses in the Development section or PR title using one of these formats:
- Fixes #123 (for bug fixes)
- Closes #456 (for features)  
- Resolves #789 (for other changes)
-->
