### PR TITLE
Fixes #518 - Report Explicit Schema

### DIFF
--- a/src/fabric_cicd/_items/_report.py
+++ b/src/fabric_cicd/_items/_report.py
@@ -57,6 +57,10 @@ def func_process_file(workspace_obj: FabricWorkspace, item_obj: Item, file_obj: 
                 msg = "Semantic model not found in the repository. Cannot deploy a report with a relative path without deploying the model."
                 raise ItemDependencyError(msg, logger)
 
+            definition_body["$schema"] = (
+                "https://developer.microsoft.com/json-schemas/fabric/item/report/definitionProperties/1.0.0/schema.json",
+            )
+
             definition_body["datasetReference"] = {
                 "byConnection": {
                     "connectionString": None,


### PR DESCRIPTION
This pull request introduces a small but important change to the report deployment process. Specifically, it ensures that the report definition includes a JSON schema reference, which helps validate the structure and content of the report definition.

Enhancement to report definition validation:

* Added a `$schema` property to the `definition_body` in the `func_process_file` function within `src/fabric_cicd/_items/_report.py`, specifying the appropriate JSON schema URL for report definitions.