### PR TITLE
Resolves #508 - Schedules Parameter Support

### DIFF
--- a/sample/workspace/Run Hello World.DataPipeline/.schedules
+++ b/sample/workspace/Run Hello World.DataPipeline/.schedules
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/gitIntegration/schedules/1.0.0/schema.json",
+  "schedules": [
+    {
+      "enabled": true,
+      "jobType": "Execute",
+      "configuration": {
+        "type": "Cron",
+        "startDateTime": "2025-07-01T12:00:00",
+        "endDateTime": "2029-07-01T12:00:00",
+        "localTimeZoneId": "Pacific Standard Time",
+        "interval": 15
+      }
+    }
+  ]
+}

--- a/sample/workspace/parameter.yml
+++ b/sample/workspace/parameter.yml
@@ -74,6 +74,12 @@ key_value_replace:
       file_path: Vars.VariableLibrary/valueSets/PROD.json
       item_type: "VariableLibrary"
       item_name: "Vars"
+    - find_key: $.schedules[?(@.jobType=="Execute")].enabled
+      replace_value:
+        PPE: false
+        PROD: true
+      item_type: "DataPipeline"
+      file_path: "**/.schedules"
 
 spark_pool:
     # CapacityPool_Large

--- a/sample/workspace/parameter.yml
+++ b/sample/workspace/parameter.yml
@@ -78,7 +78,6 @@ key_value_replace:
       replace_value:
         PPE: false
         PROD: true
-      item_type: "DataPipeline"
       file_path: "**/.schedules"
 
 spark_pool:

--- a/src/fabric_cicd/_common/_check_utils.py
+++ b/src/fabric_cicd/_common/_check_utils.py
@@ -3,6 +3,7 @@
 
 """Utility functions for checking file types and versions."""
 
+import json
 import logging
 import re
 from pathlib import Path
@@ -125,3 +126,35 @@ def check_regex(regex: str) -> re.Pattern:
         msg = f"An error occurred with the regex provided: {e}"
         raise ValueError(msg) from e
     return regex_pattern
+
+
+def check_valid_json(file_path: Path) -> bool:
+    """
+    Check if a file contains valid JSON content.
+
+    Args:
+        file_path: The path to the file to check.
+    """
+    try:
+        with file_path.open(encoding="utf-8") as file:
+            json.load(file)
+        return True
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+        return False
+
+
+def check_valid_json_content(content: str) -> bool:
+    """
+    Check if the given string content is valid JSON.
+
+    Args:
+        content: The string content to validate as JSON.
+
+    Returns:
+        bool: True if the content is valid JSON, False otherwise.
+    """
+    try:
+        json.loads(content)
+        return True
+    except json.JSONDecodeError:
+        return False

--- a/src/fabric_cicd/_common/_check_utils.py
+++ b/src/fabric_cicd/_common/_check_utils.py
@@ -128,21 +128,6 @@ def check_regex(regex: str) -> re.Pattern:
     return regex_pattern
 
 
-def check_valid_json(file_path: Path) -> bool:
-    """
-    Check if a file contains valid JSON content.
-
-    Args:
-        file_path: The path to the file to check.
-    """
-    try:
-        with file_path.open(encoding="utf-8") as file:
-            json.load(file)
-        return True
-    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
-        return False
-
-
 def check_valid_json_content(content: str) -> bool:
     """
     Check if the given string content is valid JSON.

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -15,7 +15,7 @@ from azure.core.credentials import TokenCredential
 from azure.identity import DefaultAzureCredential
 
 from fabric_cicd import constants
-from fabric_cicd._common._check_utils import check_regex
+from fabric_cicd._common._check_utils import check_regex, check_valid_json_content
 from fabric_cicd._common._exceptions import FailedPublishedItemStatusError, InputError, ParameterFileError, ParsingError
 from fabric_cicd._common._fabric_endpoint import FabricEndpoint
 from fabric_cicd._common._item import Item
@@ -371,8 +371,8 @@ class FabricWorkspace:
                 input_type, input_name, input_path = extract_parameter_filters(self, parameter_dict)
                 filter_match = check_replacement(input_type, input_name, input_path, item_type, item_name, file_path)
 
-                # Perform replacement if condition is met
-                if filter_match and ".json" in file_path.suffix:
+                # Perform replacement if condition is met and file contains valid JSON
+                if filter_match and check_valid_json_content(raw_file):
                     raw_file = replace_key_value(self, parameter_dict, raw_file, self.environment)
 
         if "find_replace" in self.environment_parameter:

--- a/tests/test__check_utils.py
+++ b/tests/test__check_utils.py
@@ -143,7 +143,6 @@ def test_real_sample_schedules_file():
     assert "schedules" in data
     assert isinstance(data["schedules"], list)
 
-    print(f"✓ Real sample .schedules file is valid JSON with {len(data['schedules'])} schedules")
 
 
 def test_check_valid_json_content_with_valid_json():

--- a/tests/test__check_utils.py
+++ b/tests/test__check_utils.py
@@ -1,9 +1,11 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+import json
+
 import pytest
 
-from fabric_cicd._common._check_utils import check_file_type
+from fabric_cicd._common._check_utils import check_file_type, check_valid_json, check_valid_json_content
 
 
 @pytest.fixture
@@ -39,3 +41,191 @@ def test_check_file_type_binary(binary_file):
 
 def test_check_file_type_image(image_file):
     assert check_file_type(image_file) == "image"
+
+
+@pytest.fixture
+def json_file(tmp_path):
+    file_path = tmp_path / "test.json"
+    file_path.write_text('{"key": "value", "number": 123}')
+    return file_path
+
+
+@pytest.fixture
+def schedules_like_file(tmp_path):
+    """Create a file like .schedules with JSON content but no .json extension."""
+    file_path = tmp_path / ".schedules"
+    schedules_content = {"schedules": [{"jobType": "Execute", "enabled": True, "cronExpression": "0 0 12 * * ?"}]}
+    file_path.write_text(json.dumps(schedules_content))
+    return file_path
+
+
+@pytest.fixture
+def invalid_json_file(tmp_path):
+    file_path = tmp_path / "invalid.json"
+    file_path.write_text('{"key": "value" invalid json}')
+    return file_path
+
+
+@pytest.fixture
+def text_file_no_json(tmp_path):
+    file_path = tmp_path / "test.py"
+    file_path.write_text('print("Hello World")')
+    return file_path
+
+
+def test_check_valid_json_with_json_file(json_file):
+    """Test check_valid_json with a standard .json file."""
+    assert check_valid_json(json_file) is True
+
+
+def test_check_valid_json_with_schedules_file(schedules_like_file):
+    """Test check_valid_json with .schedules file (JSON content, no .json extension)."""
+    assert check_valid_json(schedules_like_file) is True
+
+
+def test_check_valid_json_with_invalid_json(invalid_json_file):
+    """Test check_valid_json with invalid JSON content."""
+    assert check_valid_json(invalid_json_file) is False
+
+
+def test_check_valid_json_with_non_json_file(text_file_no_json):
+    """Test check_valid_json with non-JSON text file."""
+    assert check_valid_json(text_file_no_json) is False
+
+
+def test_check_valid_json_with_nonexistent_file(tmp_path):
+    """Test check_valid_json with nonexistent file."""
+    nonexistent_file = tmp_path / "nonexistent.json"
+    assert check_valid_json(nonexistent_file) is False
+
+
+@pytest.fixture
+def real_schedules_file(tmp_path):
+    """Create a realistic .schedules file with exact structure like fabric-cicd uses."""
+    # Create a DataPipeline directory structure
+    pipeline_dir = tmp_path / "Test Pipeline.DataPipeline"
+    pipeline_dir.mkdir()
+
+    schedules_file = pipeline_dir / ".schedules"
+    schedules_content = {
+        "schedules": [
+            {
+                "jobType": "Execute",
+                "enabled": True,
+                "cronExpression": "0 0 12 * * ?",
+                "timeZone": "UTC",
+                "description": "Daily execution at noon",
+            },
+            {
+                "jobType": "Refresh",
+                "enabled": False,
+                "cronExpression": "0 0 6 * * ?",
+                "timeZone": "UTC",
+                "description": "Morning refresh",
+            },
+        ]
+    }
+    schedules_file.write_text(json.dumps(schedules_content, indent=2))
+    return schedules_file
+
+
+def test_schedules_file_json_validation_and_structure(real_schedules_file):
+    """Test that .schedules files are properly validated and contain expected structure."""
+    # Test that check_valid_json correctly identifies .schedules as valid JSON
+    assert check_valid_json(real_schedules_file) is True
+
+    # Verify the file has the expected structure for key_value_replace
+    content = real_schedules_file.read_text(encoding="utf-8")
+    data = json.loads(content)
+
+    # Verify the structure matches what the JSONPath expression expects
+    assert "schedules" in data
+    assert isinstance(data["schedules"], list)
+    assert len(data["schedules"]) >= 1
+
+    # Find Execute job and verify it has enabled field
+    execute_jobs = [schedule for schedule in data["schedules"] if schedule.get("jobType") == "Execute"]
+    assert len(execute_jobs) >= 1
+
+    execute_job = execute_jobs[0]
+    assert "enabled" in execute_job
+    assert isinstance(execute_job["enabled"], bool)
+
+    # Verify file path ends with .schedules
+    assert real_schedules_file.name == ".schedules"
+    assert str(real_schedules_file).endswith(".schedules")
+
+
+def test_schedules_file_jsonpath_compatibility(real_schedules_file):
+    """Test that .schedules files work with the specific JSONPath expression used in parameter.yml."""
+    try:
+        from jsonpath_ng.ext import parse
+    except ImportError:
+        pytest.skip("jsonpath_ng not available for testing")
+
+    # Read and parse the .schedules file
+    content = real_schedules_file.read_text(encoding="utf-8")
+    data = json.loads(content)
+
+    # Test the exact JSONPath expression from the parameter.yml
+    jsonpath_expr = parse('$.schedules[?(@.jobType=="Execute")].enabled')
+    matches = [match.value for match in jsonpath_expr.find(data)]
+
+    # Should find at least one enabled field from Execute jobs
+    assert len(matches) >= 1
+    assert all(isinstance(match, bool) for match in matches)
+
+    # Verify we can access the specific value that would be replaced
+    first_match = matches[0]
+    assert first_match is True  # Our test data has enabled=True
+
+    print(f"✓ JSONPath found {len(matches)} enabled values: {matches}")
+    print("✓ .schedules file is compatible with key_value_replace parameter")
+
+
+def test_real_sample_schedules_file():
+    """Test that the actual sample .schedules file works with our function."""
+    from pathlib import Path
+
+    schedules_file = Path("sample/workspace/Run Hello World.DataPipeline/.schedules")
+
+    # Skip if sample file doesn't exist (optional test)
+    if not schedules_file.exists():
+        pytest.skip("Sample .schedules file not found")
+
+    # Test that our function works with the real file
+    assert check_valid_json(schedules_file) is True
+
+    # Verify the structure contains what we expect
+    content = schedules_file.read_text(encoding="utf-8")
+    data = json.loads(content)
+
+    assert "schedules" in data
+    assert isinstance(data["schedules"], list)
+
+    print(f"✓ Real sample .schedules file is valid JSON with {len(data['schedules'])} schedules")
+
+
+def test_check_valid_json_content_with_valid_json():
+    """Test check_valid_json_content with valid JSON string."""
+    valid_json = '{"key": "value", "number": 123, "boolean": true}'
+    assert check_valid_json_content(valid_json) is True
+
+
+def test_check_valid_json_content_with_invalid_json():
+    """Test check_valid_json_content with invalid JSON string."""
+    invalid_json = '{"key": "value" invalid json}'
+    assert check_valid_json_content(invalid_json) is False
+
+
+def test_check_valid_json_content_with_empty_string():
+    """Test check_valid_json_content with empty string."""
+    assert check_valid_json_content("") is False
+
+
+def test_check_valid_json_content_with_schedules_structure():
+    """Test check_valid_json_content with realistic schedules JSON structure."""
+    schedules_json = json.dumps({
+        "schedules": [{"jobType": "Execute", "enabled": True, "cronExpression": "0 0 12 * * ?"}]
+    })
+    assert check_valid_json_content(schedules_json) is True

--- a/tests/test__check_utils.py
+++ b/tests/test__check_utils.py
@@ -123,10 +123,6 @@ def test_schedules_file_jsonpath_compatibility(real_schedules_file):
     first_match = matches[0]
     assert first_match is True  # Our test data has enabled=True
 
-    print(f"✓ JSONPath found {len(matches)} enabled values: {matches}")
-    print("✓ .schedules file is compatible with key_value_replace parameter")
-
-
 def test_real_sample_schedules_file():
     """Test that the actual sample .schedules file works with our function."""
     from pathlib import Path

--- a/tests/test__check_utils.py
+++ b/tests/test__check_utils.py
@@ -5,7 +5,7 @@ import json
 
 import pytest
 
-from fabric_cicd._common._check_utils import check_file_type, check_valid_json, check_valid_json_content
+from fabric_cicd._common._check_utils import check_file_type, check_valid_json_content
 
 
 @pytest.fixture
@@ -44,62 +44,6 @@ def test_check_file_type_image(image_file):
 
 
 @pytest.fixture
-def json_file(tmp_path):
-    file_path = tmp_path / "test.json"
-    file_path.write_text('{"key": "value", "number": 123}')
-    return file_path
-
-
-@pytest.fixture
-def schedules_like_file(tmp_path):
-    """Create a file like .schedules with JSON content but no .json extension."""
-    file_path = tmp_path / ".schedules"
-    schedules_content = {"schedules": [{"jobType": "Execute", "enabled": True, "cronExpression": "0 0 12 * * ?"}]}
-    file_path.write_text(json.dumps(schedules_content))
-    return file_path
-
-
-@pytest.fixture
-def invalid_json_file(tmp_path):
-    file_path = tmp_path / "invalid.json"
-    file_path.write_text('{"key": "value" invalid json}')
-    return file_path
-
-
-@pytest.fixture
-def text_file_no_json(tmp_path):
-    file_path = tmp_path / "test.py"
-    file_path.write_text('print("Hello World")')
-    return file_path
-
-
-def test_check_valid_json_with_json_file(json_file):
-    """Test check_valid_json with a standard .json file."""
-    assert check_valid_json(json_file) is True
-
-
-def test_check_valid_json_with_schedules_file(schedules_like_file):
-    """Test check_valid_json with .schedules file (JSON content, no .json extension)."""
-    assert check_valid_json(schedules_like_file) is True
-
-
-def test_check_valid_json_with_invalid_json(invalid_json_file):
-    """Test check_valid_json with invalid JSON content."""
-    assert check_valid_json(invalid_json_file) is False
-
-
-def test_check_valid_json_with_non_json_file(text_file_no_json):
-    """Test check_valid_json with non-JSON text file."""
-    assert check_valid_json(text_file_no_json) is False
-
-
-def test_check_valid_json_with_nonexistent_file(tmp_path):
-    """Test check_valid_json with nonexistent file."""
-    nonexistent_file = tmp_path / "nonexistent.json"
-    assert check_valid_json(nonexistent_file) is False
-
-
-@pytest.fixture
 def real_schedules_file(tmp_path):
     """Create a realistic .schedules file with exact structure like fabric-cicd uses."""
     # Create a DataPipeline directory structure
@@ -131,11 +75,11 @@ def real_schedules_file(tmp_path):
 
 def test_schedules_file_json_validation_and_structure(real_schedules_file):
     """Test that .schedules files are properly validated and contain expected structure."""
-    # Test that check_valid_json correctly identifies .schedules as valid JSON
-    assert check_valid_json(real_schedules_file) is True
+    # Test that check_valid_json_content correctly identifies .schedules content as valid JSON
+    content = real_schedules_file.read_text(encoding="utf-8")
+    assert check_valid_json_content(content) is True
 
     # Verify the file has the expected structure for key_value_replace
-    content = real_schedules_file.read_text(encoding="utf-8")
     data = json.loads(content)
 
     # Verify the structure matches what the JSONPath expression expects
@@ -193,11 +137,11 @@ def test_real_sample_schedules_file():
     if not schedules_file.exists():
         pytest.skip("Sample .schedules file not found")
 
-    # Test that our function works with the real file
-    assert check_valid_json(schedules_file) is True
+    # Test that our function works with the real file content
+    content = schedules_file.read_text(encoding="utf-8")
+    assert check_valid_json_content(content) is True
 
     # Verify the structure contains what we expect
-    content = schedules_file.read_text(encoding="utf-8")
     data = json.loads(content)
 
     assert "schedules" in data

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -437,6 +437,81 @@ def test_validate_find_replace_replace_value(parameter_object, replace_value, re
 
 
 @pytest.mark.parametrize(
+    ("replace_value", "result", "msg"),
+    [
+        # Valid cases - all values are same type
+        (
+            {"PPE": "string_value", "PROD": "another_string"},
+            True,
+            "valid replace value",
+        ),
+        (
+            {"PPE": True, "PROD": False},
+            True,
+            "valid replace value",
+        ),
+        (
+            {"PPE": 123, "PROD": 456},
+            True,
+            "valid replace value",
+        ),
+        (
+            {"PPE": 1.5, "PROD": 2.7},
+            True,
+            "valid replace value",
+        ),
+        (
+            {"PPE": ["item1", "item2"], "PROD": ["item3", "item4"]},
+            True,
+            "valid replace value",
+        ),
+        (
+            {"PPE": {"key": "value1"}, "PROD": {"key": "value2"}},
+            True,
+            "valid replace value",
+        ),
+        # Invalid cases - missing values
+        (
+            {"PPE": "value", "PROD": None},
+            False,
+            "missing replace value",
+        ),
+        # Invalid cases - mixed types
+        (
+            {"PPE": "string_value", "PROD": 123},
+            False,
+            "mixed types",
+        ),
+        (
+            {"PPE": True, "PROD": "false"},
+            False,
+            "mixed types",
+        ),
+        (
+            {"PPE": 123, "PROD": 45.6},
+            False,
+            "mixed types",
+        ),
+    ],
+)
+def test_validate_key_value_replace_replace_value(parameter_object, replace_value, result, msg):
+    """Test the _validate_key_value_replace_replace_value method."""
+    is_valid, actual_msg = parameter_object._validate_key_value_replace_replace_value(replace_value)
+
+    if msg == "valid replace value":
+        expected_msg = constants.PARAMETER_MSGS[msg].format("key_value_replace")
+        assert (is_valid, actual_msg) == (result, expected_msg)
+    elif msg == "missing replace value":
+        # For missing replace value, check that the message contains the expected format
+        assert is_valid == result
+        assert "key_value_replace is missing a replace value for" in actual_msg
+    elif msg == "mixed types":
+        # For mixed types, check that the message contains the expected content
+        assert is_valid == result
+        assert "Inconsistent data types in key_value_replace replace_value" in actual_msg
+
+
+@pytest.mark.parametrize(
     ("replace_value", "result", "msg", "desc"),
     [
         (


### PR DESCRIPTION
This pull request introduces enhancements and bug fixes to support key-value replacement in non-standard JSON files (such as `.schedules`), improve type safety and validation for parameter replacements, and expand test coverage for these scenarios. The main changes ensure that files with JSON content but non-`.json` extensions are correctly validated and processed, and that `key_value_replace` operations enforce type consistency across environments.

**Key improvements and fixes:**

### Support for key-value replacement in `.schedules` and similar files

* Added a sample `.schedules` file with valid JSON content to demonstrate and test key-value replacement in non-`.json` files.
* Updated `parameter.yml` to include a `key_value_replace` rule targeting the `enabled` field in `.schedules` files for different environments.

### Enhanced JSON validation utilities

* Added `check_valid_json` (for files) and `check_valid_json_content` (for strings) utility functions to robustly detect valid JSON content, regardless of file extension. These are now used to determine if key-value replacement should be performed. [[1]](diffhunk://#diff-ed3713e24dab32c1a8de7fc474ab489877af35d51d709421fe8a708d7dc6221fR6) [[2]](diffhunk://#diff-ed3713e24dab32c1a8de7fc474ab489877af35d51d709421fe8a708d7dc6221fR129-R160) [[3]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L18-R18) [[4]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L374-R375)

### Improved type safety and validation for key_value_replace

* Refactored the parameter validation logic to introduce a dedicated `_validate_key_value_replace_replace_value` method, ensuring all replacement values for `key_value_replace` are present and of the same type across environments. [[1]](diffhunk://#diff-663a11b92ff45fa9b30ab4086a71af3d0f87fce5a8da7967ff9a1197cc24d501L344-R344) [[2]](diffhunk://#diff-663a11b92ff45fa9b30ab4086a71af3d0f87fce5a8da7967ff9a1197cc24d501L355-R355) [[3]](diffhunk://#diff-663a11b92ff45fa9b30ab4086a71af3d0f87fce5a8da7967ff9a1197cc24d501R367-R399)

### Expanded and improved test coverage

* Added comprehensive tests for the new JSON validation utilities, including cases for `.schedules` files, invalid JSON, and compatibility with JSONPath expressions used in `parameter.yml`. [[1]](diffhunk://#diff-85d97c4e2e65328a9a2814e620ad430f2d70b7b28d727e2db5badfcb89506e4cR4-R8) [[2]](diffhunk://#diff-85d97c4e2e65328a9a2814e620ad430f2d70b7b28d727e2db5badfcb89506e4cR44-R231)
* Introduced parameterized tests for the new `key_value_replace` validation logic, covering valid, missing, and mixed-type scenarios.

These changes make it safer and more flexible to perform parameterized replacements in files with JSON content, even when they do not use the `.json` extension, and ensure robust validation and error reporting for configuration management workflows.