### PR TITLE
Resolves #529 - Deprecate Base API URL

### DIFF
--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -136,19 +136,22 @@ class FabricWorkspace:
         # Initialize dataflow dependencies dictionary (used in dataflow item processing)
         self.dataflow_dependencies = {}
 
-        # temporarily support base_api_url until deprecated
+        # base_api_url is no longer supported - raise error if provided
         if "base_api_url" in kwargs:
-            logger.warning(
-                """Setting base_api_url will be deprecated in a future version, please use the below moving forward:
-                >>> import fabric_cicd.constants
-                >>> constants.DEFAULT_API_ROOT_URL = '<your_base_api_url>'\n"""
+            msg = (
+                "Setting base_api_url is no longer supported. Please use the following instead:\n"
+                ">>> import fabric_cicd.constants\n"
+                ">>> constants.DEFAULT_API_ROOT_URL = '<your_base_api_url>'"
             )
-            self.base_api_url = f"{kwargs['base_api_url']}/v1/workspaces/{self.workspace_id}"
-        else:
-            self.base_api_url = f"{constants.DEFAULT_API_ROOT_URL}/v1/workspaces/{self.workspace_id}"
+            raise InputError(msg, logger)
 
         # Initialize dictionaries to store repository and deployed items
         self._refresh_parameter_file()
+
+    @property
+    def base_api_url(self) -> str:
+        """Construct the base API URL using constants."""
+        return f"{constants.DEFAULT_API_ROOT_URL}/v1/workspaces/{self.workspace_id}"
 
     def _resolve_workspace_id(self, workspace_name: str) -> str:
         """Resolve workspace ID based on the workspace name given."""


### PR DESCRIPTION
This pull request removes support for the `base_api_url` keyword argument in the `FabricWorkspace` class and enforces the use of `constants.DEFAULT_API_ROOT_URL` for API root configuration. It also introduces a test to ensure that passing `base_api_url` raises an appropriate error.

Deprecation and error handling:

* Removed support for the `base_api_url` keyword argument in `FabricWorkspace.__init__`, now raising an `InputError` if it is provided, and updated the error message to guide users to use `constants.DEFAULT_API_ROOT_URL` instead.

API URL construction:

* Added a `base_api_url` property to `FabricWorkspace` that constructs the base API URL using `constants.DEFAULT_API_ROOT_URL` and the workspace ID.

Testing:

* Added a new test `test_base_api_url_kwarg_raises_error` to verify that passing `base_api_url` as a keyword argument raises an `InputError` with the correct message.