### PR TITLE
v0.1.26

### DIFF
--- a/src/fabric_cicd/changelog.md
+++ b/src/fabric_cicd/changelog.md
@@ -6,6 +6,18 @@ The following contains all major, minor, and patch version release notes.
 -   📝 Documentation Update
 -   ⚡ Internal Optimization
 
+## Version 0.1.26
+
+<span class="md-h2-subheader">Release Date: 2025-09-05</span>
+
+-   💥 Deprecate Base API URL kwarg in Fabric Workspace ([#529](https://github.com/microsoft/fabric-cicd/issues/529))
+-   ✨ Support Schedules parameterization ([#508](https://github.com/microsoft/fabric-cicd/issues/508))
+-   ✨ Support YAML configuration file-based deployment ([#470](https://github.com/microsoft/fabric-cicd/issues/470))
+-   📝 Add dynamically generated Python version requirements to documentation ([#520](https://github.com/microsoft/fabric-cicd/issues/520))
+-   ⚡ Enhance pytest output to limit console verbosity ([#514](https://github.com/microsoft/fabric-cicd/issues/514))
+-   🔧 Fix Report item schema handling ([#518](https://github.com/microsoft/fabric-cicd/issues/518))
+-   🔧 Fix deployment order to publish Mirrored Database before Lakehouse ([#482](https://github.com/microsoft/fabric-cicd/issues/482))
+
 ## Version 0.1.25
 
 <span class="md-h2-subheader">Release Date: 2025-08-19</span>

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -4,7 +4,7 @@
 """Constants for the fabric-cicd package."""
 
 # General
-VERSION = "0.1.25"
+VERSION = "0.1.26"
 DEFAULT_WORKSPACE_ID = "00000000-0000-0000-0000-000000000000"
 DEFAULT_API_ROOT_URL = "https://api.powerbi.com"
 FABRIC_API_ROOT_URL = "https://api.fabric.microsoft.com"


### PR DESCRIPTION
This pull request updates the package to version 0.1.26 and introduces several new features, improvements, and bug fixes. The most significant changes include support for YAML configuration file-based deployment, parameterization of schedules, and enhancements to documentation and testing output.

**Release and Feature Updates:**

* Bumped the package version to `0.1.26` in `src/fabric_cicd/constants.py` and added corresponding release notes in `src/fabric_cicd/changelog.md`. [[1]](diffhunk://#diff-91c2d32be351f155f090c4bd57ebe3c10e646edbc1b663e2a72b697f956a949cL7-R7) [[2]](diffhunk://#diff-375b3b0713fcf6f8212d7f9bd6eccf4ca9b73db611c469827967823acca6279aR9-R20)
* Added support for YAML configuration file-based deployment, allowing users to manage deployments through configuration files.
* Introduced parameterization for schedules, enabling more flexible scheduling options.

**Documentation and Testing Improvements:**

* Documentation now includes dynamically generated Python version requirements.
* Enhanced pytest output to limit console verbosity for clearer test results.

**Bug Fixes and Deprecations:**

* Deprecated the Base API URL keyword argument in `Fabric Workspace`.
* Fixed report item schema handling and corrected deployment order to publish Mirrored Database before Lakehouse.
