### PR TITLE
v0.1.27

### DIFF
--- a/src/fabric_cicd/changelog.md
+++ b/src/fabric_cicd/changelog.md
@@ -6,6 +6,12 @@ The following contains all major, minor, and patch version release notes.
 -   📝 Documentation Update
 -   ⚡ Internal Optimization
 
+## Version 0.1.27
+
+<span class="md-h2-subheader">Release Date: 2025-09-05</span>
+
+-   🔧 Fix traliing comma in report schema ([#534](https://github.com/microsoft/fabric-cicd/issues/534))
+
 ## Version 0.1.26
 
 <span class="md-h2-subheader">Release Date: 2025-09-05</span>

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -4,7 +4,7 @@
 """Constants for the fabric-cicd package."""
 
 # General
-VERSION = "0.1.26"
+VERSION = "0.1.27"
 DEFAULT_WORKSPACE_ID = "00000000-0000-0000-0000-000000000000"
 DEFAULT_API_ROOT_URL = "https://api.powerbi.com"
 FABRIC_API_ROOT_URL = "https://api.fabric.microsoft.com"


### PR DESCRIPTION
This pull request includes a patch release update for the package, addressing a minor bug and updating versioning information.

Release and versioning:

* Updated the package version to `0.1.27` in `constants.py` to reflect the new release.
* Added release notes for version `0.1.27` in `changelog.md`, including a fix for a trailing comma in the report schema.