### PR TITLE
Resolves #544 Configuration-based deploy fails if unpublish exclude_regex isn't supplied

### DIFF
--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -6,7 +6,7 @@
 import logging
 from typing import Optional
 
-import dpath.util as dpath
+import dpath
 from azure.core.credentials import TokenCredential
 
 import fabric_cicd._items as items
@@ -469,7 +469,7 @@ def deploy_with_config(
     if not unpublish_settings.get("skip", False):
         unpublish_all_orphan_items(
             workspace,
-            item_name_exclude_regex=unpublish_settings.get("exclude_regex"),
+            item_name_exclude_regex=unpublish_settings.get("exclude_regex", "^$"),
             items_to_include=unpublish_settings.get("items_to_include"),
         )
     else:


### PR DESCRIPTION
This pull request includes minor updates to the `src/fabric_cicd/publish.py` file to improve import usage and default configuration handling.

* **Dependency Import Update:** Changed the import statement from `import dpath.util as dpath` to `import dpath` to simplify how the `dpath` library is imported.

* **Configuration Defaulting:** Updated the `item_name_exclude_regex` parameter in the `deploy_with_config` function to use a default value of `"^$"` when not specified, ensuring more predictable behavior when excluding item names.