### PR TITLE
v0.1.28

### DIFF
--- a/src/fabric_cicd/changelog.md
+++ b/src/fabric_cicd/changelog.md
@@ -6,6 +6,15 @@ The following contains all major, minor, and patch version release notes.
 -   📝 Documentation Update
 -   ⚡ Internal Optimization
 
+## Version 0.1.28
+
+<span class="md-h2-subheader">Release Date: 2025-09-15</span>
+
+-   ✨ Add folder exclusion feature for publish operations ([#427](https://github.com/microsoft/fabric-cicd/issues/427))
+-   ✨ Expand workspace ID dynamic replacement capabilities in parameterization ([#408](https://github.com/microsoft/fabric-cicd/issues/408))
+-   🔧 Fix unexpected behavior with file_path parameter filter ([#545](https://github.com/microsoft/fabric-cicd/issues/545))
+-   🔧 Fix unpublish exclude_regex bug in configuration file-based deployment ([#544](https://github.com/microsoft/fabric-cicd/issues/544))
+
 ## Version 0.1.27
 
 <span class="md-h2-subheader">Release Date: 2025-09-05</span>

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -4,7 +4,7 @@
 """Constants for the fabric-cicd package."""
 
 # General
-VERSION = "0.1.27"
+VERSION = "0.1.28"
 DEFAULT_WORKSPACE_ID = "00000000-0000-0000-0000-000000000000"
 DEFAULT_API_ROOT_URL = "https://api.powerbi.com"
 FABRIC_API_ROOT_URL = "https://api.fabric.microsoft.com"


### PR DESCRIPTION
This pull request updates the project to version 0.1.28 and introduces several new features and bug fixes related to publish and unpublish operations, as well as parameterization improvements.

### Versioning and Release Notes

* Updated the `VERSION` constant in `constants.py` to `0.1.28` to reflect the new release.
* Added detailed release notes for version 0.1.28 in `changelog.md`, including the release date and a summary of new features and fixes.

### New Features

* Added folder exclusion support for publish operations, allowing users to specify folders to exclude during publishing.
* Enhanced workspace ID dynamic replacement capabilities in parameterization, enabling more flexible workspace management.

### Bug Fixes

* Fixed unexpected behavior with the `file_path` parameter filter to ensure correct filtering during operations.
* Resolved an `exclude_regex` bug in configuration file-based deployment for unpublish operations.