### PR TITLE
Resolves #566 Eventhouses published after Semantic Models causing parameter replacement error

### DIFF
--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -205,6 +205,9 @@ def publish_all_items(
     if _should_publish_item_type("Notebook"):
         print_header("Publishing Notebooks")
         items.publish_notebooks(fabric_workspace_obj)
+    if _should_publish_item_type("Eventhouse"):
+        print_header("Publishing Eventhouses")
+        items.publish_eventhouses(fabric_workspace_obj)
     if _should_publish_item_type("SemanticModel"):
         print_header("Publishing Semantic Models")
         items.publish_semanticmodels(fabric_workspace_obj)
@@ -214,9 +217,6 @@ def publish_all_items(
     if _should_publish_item_type("CopyJob"):
         print_header("Publishing Copy Jobs")
         items.publish_copyjobs(fabric_workspace_obj)
-    if _should_publish_item_type("Eventhouse"):
-        print_header("Publishing Eventhouses")
-        items.publish_eventhouses(fabric_workspace_obj)
     if _should_publish_item_type("KQLDatabase"):
         print_header("Publishing KQL Databases")
         items.publish_kqldatabases(fabric_workspace_obj)
@@ -347,10 +347,10 @@ def unpublish_all_orphan_items(
         "KQLDashboard",
         "KQLQueryset",
         "KQLDatabase",
-        "Eventhouse",
         "CopyJob",
         "Report",
         "SemanticModel",
+        "Eventhouse",
         "Notebook",
         "Environment",
         "MirroredDatabase",


### PR DESCRIPTION
This pull request reorganizes the publishing order of item types in the `src/fabric_cicd/publish.py` file to ensure that "Eventhouse" items are published after "Notebook" and before "SemanticModel" items. Additionally, it updates the order of item types handled by the `unpublish_all_orphan_items` function to match this new sequence. No new functionality has been added or removed—only the order of operations has been adjusted for consistency.

Order adjustments to publishing and unpublishing logic:

* Moved the publishing of "Eventhouse" items to occur after "Notebook" and before "SemanticModel" in the main publishing sequence. [[1]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R208-R210) [[2]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704L217-L219)
* Updated the order of "Eventhouse" in the list of item types within `unpublish_all_orphan_items` to match the new publishing order.
