### PR TITLE
Resolves #565 Support Apache Airflow Job Item Type

### DIFF
--- a/docs/how_to/item_types.md
+++ b/docs/how_to/item_types.md
@@ -7,6 +7,13 @@
 -   **Initial deployment** may not reflect streaming data immediately.
 -   **Reflex** is the item name in source control. Source control may not support all activators/reflexes, as not all sources are compatible.
 
+## Apache Airflow Jobs
+
+-   **Parameterization:**
+    -   The referenced items in DAG files will always point to the original item unless parameterized in the `find_replace` section of the `parameter.yml` file.
+-   **Connections** are not source controlled and must be created manually.
+-   See known CI/CD limitations [here](https://learn.microsoft.com/en-us/fabric/data-factory/cicd-apache-airflow-jobs#known-limitations).
+
 ## API for GraphQL
 
 -   **Parameterization:**

--- a/sample/workspace/sample apache airflow job.ApacheAirflowJob/.platform
+++ b/sample/workspace/sample apache airflow job.ApacheAirflowJob/.platform
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/gitIntegration/platformProperties/2.0.0/schema.json",
+  "metadata": {
+    "type": "ApacheAirflowJob",
+    "displayName": "sample apache airflow job"
+  },
+  "config": {
+    "version": "2.0",
+    "logicalId": "f31cd938-c3ab-b977-4dd4-3e4a56d7c124"
+  }
+}

--- a/sample/workspace/sample apache airflow job.ApacheAirflowJob/apacheairflowjob-content.json
+++ b/sample/workspace/sample apache airflow job.ApacheAirflowJob/apacheairflowjob-content.json
@@ -1,0 +1,25 @@
+{
+  "properties": {
+    "type": "Airflow",
+    "typeProperties": {
+      "airflowProperties": {
+        "airflowConfigurationOverrides": {},
+        "airflowEnvironment": "FabricAirflowJob-1.0.0",
+        "airflowRequirements": [],
+        "airflowVersion": "2.10.5",
+        "enableAADIntegration": true,
+        "enableTriggerers": false,
+        "environmentVariables": {},
+        "packageProviderPath": "plugins",
+        "pythonVersion": "3.12"
+      },
+      "computeProperties": {
+        "computePool": "StarterPool",
+        "computeSize": "Small",
+        "enableAutoscale": false,
+        "enableAvailabilityZones": false,
+        "extraNodes": 0
+      }
+    }
+  }
+}

--- a/sample/workspace/sample apache airflow job.ApacheAirflowJob/dags/dag1.py
+++ b/sample/workspace/sample apache airflow job.ApacheAirflowJob/dags/dag1.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+
+# Define the default arguments for the DAG
+default_args = {
+    'owner': 'airflow',
+    'depends_on_past': False,
+    'start_date': datetime(2023, 5, 1),
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'retries': 1
+}
+
+# Instantiate the DAG object
+with DAG(
+    'dags-dag1.py',
+    default_args=default_args,
+    description='A simple Hello World DAG',
+    schedule_interval=None,
+    catchup=False
+) as dag:
+
+    # Define the tasks
+    hello_task = BashOperator(
+        task_id='hello_world_task',
+        bash_command='echo "Hello, World!"'
+    )
+
+    # Set the task dependencies
+    hello_task

--- a/src/fabric_cicd/_items/__init__.py
+++ b/src/fabric_cicd/_items/__init__.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 from fabric_cicd._items._activator import publish_activators
+from fabric_cicd._items._apacheairflowjob import publish_apacheairflowjobs
 from fabric_cicd._items._copyjob import publish_copyjobs
 from fabric_cicd._items._dataflowgen2 import publish_dataflows
 from fabric_cicd._items._datapipeline import find_referenced_datapipelines, publish_datapipelines
@@ -26,6 +27,7 @@ __all__ = [
     "check_environment_publish_state",
     "find_referenced_datapipelines",
     "publish_activators",
+    "publish_apacheairflowjobs",
     "publish_copyjobs",
     "publish_dataflows",
     "publish_datapipelines",

--- a/src/fabric_cicd/_items/_apacheairflowjob.py
+++ b/src/fabric_cicd/_items/_apacheairflowjob.py
@@ -1,0 +1,23 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Functions to process and deploy Apache Airflow Job item."""
+
+import logging
+
+from fabric_cicd import FabricWorkspace
+
+logger = logging.getLogger(__name__)
+
+
+def publish_apacheairflowjobs(fabric_workspace_obj: FabricWorkspace) -> None:
+    """
+    Publishes all Apache Airflow job items from the repository.
+
+    Args:
+        fabric_workspace_obj: The FabricWorkspace object containing the items to be published.
+    """
+    item_type = "ApacheAirflowJob"
+
+    for item_name in fabric_workspace_obj.repository_items.get(item_type, {}):
+        fabric_workspace_obj._publish_item(item_name=item_name, item_type=item_type)

--- a/src/fabric_cicd/changelog.md
+++ b/src/fabric_cicd/changelog.md
@@ -6,6 +6,18 @@ The following contains all major, minor, and patch version release notes.
 -   📝 Documentation Update
 -   ⚡ Internal Optimization
 
+## Version 0.1.26
+
+<span class="md-h2-subheader">Release Date: 2025-09-05</span>
+
+-   💥 Deprecate Base API URL kwarg in Fabric Workspace ([#529](https://github.com/microsoft/fabric-cicd/issues/529))
+-   ✨ Support Schedules parameterization ([#508](https://github.com/microsoft/fabric-cicd/issues/508))
+-   ✨ Support YAML configuration file-based deployment ([#470](https://github.com/microsoft/fabric-cicd/issues/470))
+-   📝 Add dynamically generated Python version requirements to documentation ([#520](https://github.com/microsoft/fabric-cicd/issues/520))
+-   ⚡ Enhance pytest output to limit console verbosity ([#514](https://github.com/microsoft/fabric-cicd/issues/514))
+-   🔧 Fix Report item schema handling ([#518](https://github.com/microsoft/fabric-cicd/issues/518))
+-   🔧 Fix deployment order to publish Mirrored Database before Lakehouse ([#482](https://github.com/microsoft/fabric-cicd/issues/482))
+
 ## Version 0.1.25
 
 <span class="md-h2-subheader">Release Date: 2025-08-19</span>

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -32,6 +32,7 @@ ACCEPTED_ITEM_TYPES = (
     "KQLDashboard",
     "Dataflow",
     "GraphQLApi",
+    "ApacheAirflowJob",
 )
 
 # Publish

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -4,7 +4,7 @@
 """Constants for the fabric-cicd package."""
 
 # General
-VERSION = "0.1.25"
+VERSION = "0.1.26"
 DEFAULT_WORKSPACE_ID = "00000000-0000-0000-0000-000000000000"
 DEFAULT_API_ROOT_URL = "https://api.powerbi.com"
 FABRIC_API_ROOT_URL = "https://api.fabric.microsoft.com"

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -241,6 +241,9 @@ def publish_all_items(
     if _should_publish_item_type("GraphQLApi"):
         print_header("Publishing GraphQL APIs")
         items.publish_graphqlapis(fabric_workspace_obj)
+    if _should_publish_item_type("ApacheAirflowJob"):
+        print_header("Publishing Apache Airflow Jobs")
+        items.publish_apacheairflowjobs(fabric_workspace_obj)
 
     # Check Environment Publish
     if _should_publish_item_type("Environment"):
@@ -339,6 +342,7 @@ def unpublish_all_orphan_items(
     # Define order to unpublish items
     unpublish_order = []
     for item_type in [
+        "ApacheAirflowJob",
         "GraphQLApi",
         "DataPipeline",
         "Dataflow",


### PR DESCRIPTION
This pull request introduces support for Apache Airflow Jobs in the codebase, enabling these jobs to be managed and published as part of the CI/CD workflow. The changes include documentation updates, new sample files for an Airflow job, and corresponding updates to the code to recognize and publish this new item type.

**Apache Airflow Job support:**

* Added a new function `publish_apacheairflowjobs` in `src/fabric_cicd/_items/_apacheairflowjob.py` to handle publishing of Apache Airflow Job items.
* Registered the new publish function in the `src/fabric_cicd/_items/__init__.py` module and included it in the public API. [[1]](diffhunk://#diff-94d858110d4e75a68135b9975f58e289c7db48793b5bf7bc56c08efad59f3e34R5) [[2]](diffhunk://#diff-94d858110d4e75a68135b9975f58e289c7db48793b5bf7bc56c08efad59f3e34R30)
* Updated the item type constants in `src/fabric_cicd/constants.py` to include `"ApacheAirflowJob"`.
* Modified the publishing logic in `src/fabric_cicd/publish.py` to publish and unpublish Apache Airflow Jobs in the correct order. [[1]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R244-R246) [[2]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R345)

**Documentation and sample files:**

* Added documentation for Apache Airflow Jobs, including parameterization notes and CI/CD limitations, to `docs/how_to/item_types.md`.
* Added a sample Apache Airflow Job, including configuration (`.platform`), content (`apacheairflowjob-content.json`), and a sample DAG (`dags/dag1.py`). [[1]](diffhunk://#diff-67e4fb2983c28eadc9ad9ac1f312de16f6ec0ab11eda396b4950b9125337dbbbR1-R11) [[2]](diffhunk://#diff-0c3b6f2e7dbd377c20ebe318892bea7df5a827338c1353fd576a13e8f94654d8R1-R25) [[3]](diffhunk://#diff-9cc98f9b53de6352c9e93ee5f7d0e03f74e04e4640a6ce1e3a13e6719d6cb4bbR1-R31)
