### PR TITLE
Resolves #406 Support Mounted Data Factory item

### DIFF
--- a/docs/how_to/item_types.md
+++ b/docs/how_to/item_types.md
@@ -17,6 +17,13 @@
 -   Changes made to the original API query are not source controlled. You will need to manually update the query in the GraphQL item's query editor within the target workspace.
 -   Only user authentication is currently supported for GraphQL items that source data from the SQL Analytics Endpoint.
 
+## Azure Data Factory
+
+-   **Parameterization:**
+    -   The `find_replace` section in the `parameter.yml` file is not applied.
+-   Deploys a **mounted** Azure Data Factory to a Fabric Workspace.
+-   Before deployment, ensure the Azure Data Factory resource exists with proper permissions.
+
 ## Copy Jobs
 
 -   **Parameterization:**

--- a/src/fabric_cicd/_items/__init__.py
+++ b/src/fabric_cicd/_items/__init__.py
@@ -15,6 +15,7 @@ from fabric_cicd._items._kqlqueryset import publish_kqlquerysets
 from fabric_cicd._items._lakehouse import publish_lakehouses
 from fabric_cicd._items._manage_dependencies import set_unpublish_order
 from fabric_cicd._items._mirroreddatabase import publish_mirroreddatabase
+from fabric_cicd._items._mounteddatafactory import publish_mounteddatafactories
 from fabric_cicd._items._notebook import publish_notebooks
 from fabric_cicd._items._report import publish_reports
 from fabric_cicd._items._semanticmodel import publish_semanticmodels
@@ -38,6 +39,7 @@ __all__ = [
     "publish_kqlquerysets",
     "publish_lakehouses",
     "publish_mirroreddatabase",
+    "publish_mounteddatafactories",
     "publish_notebooks",
     "publish_reports",
     "publish_semanticmodels",

--- a/src/fabric_cicd/_items/_mounteddatafactory.py
+++ b/src/fabric_cicd/_items/_mounteddatafactory.py
@@ -1,0 +1,23 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Functions to process and deploy Mounted Data Factory item."""
+
+import logging
+
+from fabric_cicd import FabricWorkspace
+
+logger = logging.getLogger(__name__)
+
+
+def publish_mounteddatafactories(fabric_workspace_obj: FabricWorkspace) -> None:
+    """
+    Publishes all mounted data factory items from the repository.
+
+    Args:
+        fabric_workspace_obj: The FabricWorkspace object containing the items to be published.
+    """
+    item_type = "MountedDataFactory"
+
+    for item_name in fabric_workspace_obj.repository_items.get(item_type, {}):
+        fabric_workspace_obj._publish_item(item_name=item_name, item_type=item_type)

--- a/src/fabric_cicd/changelog.md
+++ b/src/fabric_cicd/changelog.md
@@ -6,6 +6,18 @@ The following contains all major, minor, and patch version release notes.
 -   📝 Documentation Update
 -   ⚡ Internal Optimization
 
+## Version 0.1.26
+
+<span class="md-h2-subheader">Release Date: 2025-09-05</span>
+
+-   💥 Deprecate Base API URL kwarg in Fabric Workspace ([#529](https://github.com/microsoft/fabric-cicd/issues/529))
+-   ✨ Support Schedules parameterization ([#508](https://github.com/microsoft/fabric-cicd/issues/508))
+-   ✨ Support YAML configuration file-based deployment ([#470](https://github.com/microsoft/fabric-cicd/issues/470))
+-   📝 Add dynamically generated Python version requirements to documentation ([#520](https://github.com/microsoft/fabric-cicd/issues/520))
+-   ⚡ Enhance pytest output to limit console verbosity ([#514](https://github.com/microsoft/fabric-cicd/issues/514))
+-   🔧 Fix Report item schema handling ([#518](https://github.com/microsoft/fabric-cicd/issues/518))
+-   🔧 Fix deployment order to publish Mirrored Database before Lakehouse ([#482](https://github.com/microsoft/fabric-cicd/issues/482))
+
 ## Version 0.1.25
 
 <span class="md-h2-subheader">Release Date: 2025-08-19</span>

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -32,6 +32,7 @@ ACCEPTED_ITEM_TYPES = (
     "KQLDashboard",
     "Dataflow",
     "GraphQLApi",
+    "MountedDataFactory",
 )
 
 # Publish

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -4,7 +4,7 @@
 """Constants for the fabric-cicd package."""
 
 # General
-VERSION = "0.1.25"
+VERSION = "0.1.26"
 DEFAULT_WORKSPACE_ID = "00000000-0000-0000-0000-000000000000"
 DEFAULT_API_ROOT_URL = "https://api.powerbi.com"
 FABRIC_API_ROOT_URL = "https://api.fabric.microsoft.com"

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -187,6 +187,9 @@ def publish_all_items(
     if _should_publish_item_type("GraphQLApi"):
         print_header("Publishing GraphQL APIs")
         items.publish_graphqlapis(fabric_workspace_obj)
+    if _should_publish_item_type("MountedDataFactory"):
+        print_header("Publishing Mounted Data Factories")
+        items.publish_mounteddatafactories(fabric_workspace_obj)
 
     # Check Environment Publish
     if _should_publish_item_type("Environment"):
@@ -276,6 +279,7 @@ def unpublish_all_orphan_items(
     # Define order to unpublish items
     unpublish_order = []
     for item_type in [
+        "MountedDataFactory",
         "GraphQLApi",
         "DataPipeline",
         "Dataflow",


### PR DESCRIPTION
This pull request adds support for publishing and managing "Mounted Data Factory" items in the deployment workflow. It introduces a new function to handle these items, updates the documentation to explain their deployment requirements, and integrates the new item type into the publishing and unpublishing processes.

**Support for Mounted Data Factory items:**

* Added a new function `publish_mounteddatafactories` in `src/fabric_cicd/_items/_mounteddatafactory.py` to process and deploy all mounted data factory items from the repository.
* Updated the `src/fabric_cicd/_items/__init__.py` to import and expose `publish_mounteddatafactories` in the module's public API. [[1]](diffhunk://#diff-94d858110d4e75a68135b9975f58e289c7db48793b5bf7bc56c08efad59f3e34R18) [[2]](diffhunk://#diff-94d858110d4e75a68135b9975f58e289c7db48793b5bf7bc56c08efad59f3e34R42)
* Added "MountedDataFactory" to the list of recognized item types in `src/fabric_cicd/constants.py`.

**Integration into deployment workflow:**

* Modified `src/fabric_cicd/publish.py` to call `publish_mounteddatafactories` during the publishing process and to include "MountedDataFactory" in the unpublishing order. [[1]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R190-R192) [[2]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R282)

**Documentation updates:**

* Updated `docs/how_to/item_types.md` with details on deploying Azure Data Factory as a mounted item, including notes about parameterization and deployment prerequisites.