### PR TITLE
v0.1.29

### DIFF
--- a/src/fabric_cicd/changelog.md
+++ b/src/fabric_cicd/changelog.md
@@ -6,6 +6,18 @@ The following contains all major, minor, and patch version release notes.
 -   📝 Documentation Update
 -   ⚡ Internal Optimization
 
+## Version 0.1.26
+
+<span class="md-h2-subheader">Release Date: 2025-09-05</span>
+
+-   💥 Deprecate Base API URL kwarg in Fabric Workspace ([#529](https://github.com/microsoft/fabric-cicd/issues/529))
+-   ✨ Support Schedules parameterization ([#508](https://github.com/microsoft/fabric-cicd/issues/508))
+-   ✨ Support YAML configuration file-based deployment ([#470](https://github.com/microsoft/fabric-cicd/issues/470))
+-   📝 Add dynamically generated Python version requirements to documentation ([#520](https://github.com/microsoft/fabric-cicd/issues/520))
+-   ⚡ Enhance pytest output to limit console verbosity ([#514](https://github.com/microsoft/fabric-cicd/issues/514))
+-   🔧 Fix Report item schema handling ([#518](https://github.com/microsoft/fabric-cicd/issues/518))
+-   🔧 Fix deployment order to publish Mirrored Database before Lakehouse ([#482](https://github.com/microsoft/fabric-cicd/issues/482))
+
 ## Version 0.1.25
 
 <span class="md-h2-subheader">Release Date: 2025-08-19</span>

--- a/src/fabric_cicd/changelog.md
+++ b/src/fabric_cicd/changelog.md
@@ -6,6 +6,16 @@ The following contains all major, minor, and patch version release notes.
 -   📝 Documentation Update
 -   ⚡ Internal Optimization
 
+## Version 0.1.29
+
+<span class="md-h2-subheader">Release Date: 2025-10-01</span>
+
+-   ✨ Onboard Apache Airflow Job item type ([#565](https://github.com/microsoft/fabric-cicd/issues/565))
+-   ✨ Onboard Mounted Data Factory item type ([#406](https://github.com/microsoft/fabric-cicd/issues/406))
+-   ✨ Support dynamic replacement for cross-workspace item IDs ([#558](https://github.com/microsoft/fabric-cicd/issues/558))
+-   ✨ Add option to return API response for publish operations in publish_all_items ([#497](https://github.com/microsoft/fabric-cicd/issues/497))
+-   🔧 Fix publish order of Eventhouses and Semantic Models ([#566](https://github.com/microsoft/fabric-cicd/issues/545))
+
 ## Version 0.1.28
 
 <span class="md-h2-subheader">Release Date: 2025-09-15</span>

--- a/src/fabric_cicd/changelog.md
+++ b/src/fabric_cicd/changelog.md
@@ -14,7 +14,7 @@ The following contains all major, minor, and patch version release notes.
 -   ✨ Onboard Mounted Data Factory item type ([#406](https://github.com/microsoft/fabric-cicd/issues/406))
 -   ✨ Support dynamic replacement for cross-workspace item IDs ([#558](https://github.com/microsoft/fabric-cicd/issues/558))
 -   ✨ Add option to return API response for publish operations in publish_all_items ([#497](https://github.com/microsoft/fabric-cicd/issues/497))
--   🔧 Fix publish order of Eventhouses and Semantic Models ([#566](https://github.com/microsoft/fabric-cicd/issues/545))
+-   🔧 Fix publish order of Eventhouses and Semantic Models ([#566](https://github.com/microsoft/fabric-cicd/issues/566))
 
 ## Version 0.1.28
 

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -4,7 +4,7 @@
 """Constants for the fabric-cicd package."""
 
 # General
-VERSION = "0.1.28"
+VERSION = "0.1.29"
 DEFAULT_WORKSPACE_ID = "00000000-0000-0000-0000-000000000000"
 DEFAULT_API_ROOT_URL = "https://api.powerbi.com"
 FABRIC_API_ROOT_URL = "https://api.fabric.microsoft.com"

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -4,7 +4,7 @@
 """Constants for the fabric-cicd package."""
 
 # General
-VERSION = "0.1.25"
+VERSION = "0.1.26"
 DEFAULT_WORKSPACE_ID = "00000000-0000-0000-0000-000000000000"
 DEFAULT_API_ROOT_URL = "https://api.powerbi.com"
 FABRIC_API_ROOT_URL = "https://api.fabric.microsoft.com"


### PR DESCRIPTION
This pull request updates the package to version 0.1.29 and adds several new features and fixes. The most notable changes include support for new item types, improvements for cross-workspace deployments, enhancements to API response handling, and a fix for publish ordering.

**Release Version Update:**

* Bumped the package version from `0.1.28` to `0.1.29` in `constants.py` and added corresponding release notes. [[1]](diffhunk://#diff-91c2d32be351f155f090c4bd57ebe3c10e646edbc1b663e2a72b697f956a949cL7-R7) [[2]](diffhunk://#diff-375b3b0713fcf6f8212d7f9bd6eccf4ca9b73db611c469827967823acca6279aR9-R18)

**New Features:**

* Added support for onboarding the Apache Airflow Job item type.
* Added support for onboarding the Mounted Data Factory item type.
* Added dynamic replacement for cross-workspace item IDs to improve deployment flexibility.
* Added an option to return the API response for publish operations in the `publish_all_items` function.

**Bug Fixes:**

* Fixed the publish order of Eventhouses and Semantic Models to ensure correct deployment sequencing.