### PR TITLE
Fixes #583 - Workspace Name Not Extracted When Using Non-ID Attribute

### DIFF
--- a/src/fabric_cicd/_parameter/_utils.py
+++ b/src/fabric_cicd/_parameter/_utils.py
@@ -107,7 +107,9 @@ def _extract_workspace_id(workspace_obj: FabricWorkspace, replace_value: str) ->
         var_string = replace_value.removeprefix("$workspace.")
 
         # Check for pattern: $workspace.name.$items.type.name.$id
-        if "$items." in var_string and var_string.endswith(".$id"):
+        if "$items." in var_string and var_string.endswith(
+            tuple(f"{prefix}{suffix}" for suffix in constants.ITEM_ATTR_LOOKUP for prefix in [".$", "."])
+        ):
             # Split on the $items prefix to get workspace name
             workspace_part, items_part = var_string.split(".$items.", 1)
             workspace_name = workspace_part.strip()
@@ -117,12 +119,12 @@ def _extract_workspace_id(workspace_obj: FabricWorkspace, replace_value: str) ->
             workspace_id = workspace_obj._resolve_workspace_id(workspace_name)
 
             # Remove the trailing .$id to get the item info
-            items_info = items_part.removesuffix(".$id")
+            items_info = items_part.rsplit(".", 1)[0]
 
             # Find the last period to separate item type from item name
             last_period_pos = items_info.rfind(".")
             if last_period_pos == -1:
-                msg = f"Invalid $workspace variable syntax: {replace_value}. Expected format: $workspace.name.$items.type.name.$id"
+                msg = f"Invalid $workspace variable syntax: {replace_value}. Expected format: $workspace.name.$items.type.name.$attribute"
                 raise ParsingError(msg, logger)
 
             # Extract item_type and item_name

--- a/tests/test_parameter_utils.py
+++ b/tests/test_parameter_utils.py
@@ -364,6 +364,25 @@ class TestParameterUtilities:
         mock_workspace._resolve_workspace_id.assert_called_once_with("test_workspace")
         mock_workspace._lookup_item_id.assert_called_once_with("resolved-workspace-id", "Notebook", "Test Notebook")
 
+    def test_extract_workspace_id_with_item_attribute_lookup(self, mock_workspace):
+        """Tests _extract_workspace_id with item lookup in another workspace."""
+        from fabric_cicd._parameter._utils import _extract_workspace_id
+
+        # Mock the _resolve_workspace_id method
+        mock_workspace._resolve_workspace_id.return_value = "resolved-workspace-id"
+
+        # Mock the _lookup_item_id method
+        mock_workspace._lookup_item_id = mock.MagicMock(return_value="item-123-id")
+
+        # Test with $workspace.<name>.$items.<item_type>.<item_name>.$attribute format
+        result = _extract_workspace_id(
+            mock_workspace, "$workspace.test_workspace.$items.Notebook.Test Notebook.$sqlendpoint"
+        )
+
+        assert result == "item-123-id"
+        mock_workspace._resolve_workspace_id.assert_called_once_with("test_workspace")
+        mock_workspace._lookup_item_id.assert_called_once_with("resolved-workspace-id", "Notebook", "Test Notebook")
+
     def test_extract_workspace_id_with_item_lookup_not_found(self, mock_workspace):
         """Tests _extract_workspace_id when item lookup fails."""
         from fabric_cicd._parameter._utils import _extract_workspace_id


### PR DESCRIPTION
This pull request adds a test that fails in version v0.1.29 when testing that the workspace name is correctly extracted when looking up a non-`id` attribute (such as `sqlendpoint`) for an item in a different workspace.

The fix was to reference the `ITEM_ATTR_LOOKUP` constant when deciding which format algorithm to use for workspace name extraction.