### PR TITLE
Fixes #593 - Fixes capacity requirement check to work regardless of item type order

### DIFF
--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -41,7 +41,7 @@ ACCEPTED_ITEM_TYPES = (
 SHELL_ONLY_PUBLISH = ["Environment", "Lakehouse", "Warehouse", "SQLDatabase"]
 
 # Items that do not require assigned capacity
-NO_ASSIGNED_CAPACITY_REQUIRED = [["SemanticModel", "Report"], ["SemanticModel"], ["Report"]]
+NO_ASSIGNED_CAPACITY_REQUIRED = ["SemanticModel", "Report"]
 
 # REGEX Constants
 VALID_GUID_REGEX = r"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -133,7 +133,7 @@ def publish_all_items(
 
     if (
         not has_assigned_capacity
-        and fabric_workspace_obj.item_type_in_scope not in constants.NO_ASSIGNED_CAPACITY_REQUIRED
+        and not set(fabric_workspace_obj.item_type_in_scope).issubset(set(constants.NO_ASSIGNED_CAPACITY_REQUIRED))
     ):
         msg = f"Workspace {fabric_workspace_obj.workspace_id} does not have an assigned capacity. Please assign a capacity before publishing items."
         raise FailedPublishedItemStatusError(msg, logger)


### PR DESCRIPTION
## Description

This fixes how the code validates whether a Fabric capacity is needed or not. The original code required the "item types in scope" to be written in a specific order, this changes the validation to work regardless of item type order.

## Linked Issue (REQUIRED)

- Fixes #593 
