### PR TITLE
Resolves #628 Publish semantic model should be done before publish of Data agent

### DIFF
--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -131,9 +131,8 @@ def publish_all_items(
 
     has_assigned_capacity = dpath.get(response_state, "body/capacityId", default=None)
 
-    if (
-        not has_assigned_capacity
-        and not set(fabric_workspace_obj.item_type_in_scope).issubset(set(constants.NO_ASSIGNED_CAPACITY_REQUIRED))
+    if not has_assigned_capacity and not set(fabric_workspace_obj.item_type_in_scope).issubset(
+        set(constants.NO_ASSIGNED_CAPACITY_REQUIRED)
     ):
         msg = f"Workspace {fabric_workspace_obj.workspace_id} does not have an assigned capacity. Please assign a capacity before publishing items."
         raise FailedPublishedItemStatusError(msg, logger)
@@ -202,9 +201,6 @@ def publish_all_items(
     if _should_publish_item_type("Environment"):
         print_header("Publishing Environments")
         items.publish_environments(fabric_workspace_obj)
-    if _should_publish_item_type("DataAgent"):
-        print_header("Publishing Data Agents")
-        items.publish_dataagents(fabric_workspace_obj)
     if _should_publish_item_type("UserDataFunction"):
         print_header("Publishing User Data Functions")
         items.publish_userdatafunctions(fabric_workspace_obj)
@@ -256,6 +252,9 @@ def publish_all_items(
     if _should_publish_item_type("OrgApp"):
         print_header("Publishing Org Apps")
         items.publish_orgapps(fabric_workspace_obj)
+    if _should_publish_item_type("DataAgent"):
+        print_header("Publishing Data Agents")
+        items.publish_dataagents(fabric_workspace_obj)
 
     # Check Environment Publish
     if _should_publish_item_type("Environment"):


### PR DESCRIPTION
This pull request updates the publishing logic in `src/fabric_cicd/publish.py` to improve the order and conditional checks for publishing different item types. The main changes involve refactoring the checks for assigned capacity and adjusting the sequence for publishing `DataAgent` items.

Publishing logic improvements:

* Refactored the assigned capacity check in `publish_all_items` to simplify the conditional and improve readability.

Order of publishing item types:

* Moved the publishing of `DataAgent` items to occur after `OrgApp` items instead of before `UserDataFunction` items, ensuring a more logical sequence in the publishing workflow. [[1]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704L205-L207) [[2]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R255-R257)