### PR TITLE
v0.1.32

### DIFF
--- a/src/fabric_cicd/changelog.md
+++ b/src/fabric_cicd/changelog.md
@@ -6,6 +6,12 @@ The following contains all major, minor, and patch version release notes.
 -   📝 Documentation Update
 -   ⚡ Internal Optimization
 
+## Version 0.1.32
+
+<span class="md-h2-subheader">Release Date: 2025-12-03</span>
+
+-   🔧 Fix publish bug for Environment items that contain only spark settings ([#664](https://github.com/microsoft/fabric-cicd/issues/664))
+
 ## Version 0.1.31
 
 <span class="md-h2-subheader">Release Date: 2025-12-01</span>

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -4,7 +4,7 @@
 """Constants for the fabric-cicd package."""
 
 # General
-VERSION = "0.1.31"
+VERSION = "0.1.32"
 DEFAULT_GUID = "00000000-0000-0000-0000-000000000000"
 DEFAULT_API_ROOT_URL = "https://api.powerbi.com"
 FABRIC_API_ROOT_URL = "https://api.fabric.microsoft.com"


### PR DESCRIPTION
This pull request updates the package version to 0.1.32 and adds release notes for this new version. The main change in this release is a bug fix related to publishing Environment items with only spark settings.

Version update and release notes:

* Updated the `VERSION` constant in `constants.py` from "0.1.31" to "0.1.32" to reflect the new release.
* Added release notes for version 0.1.32 in `changelog.md`, highlighting a bug fix for publishing Environment items that contain only spark settings.