### PR TITLE
Fixes #685 Incorrect publish order for Eventhouse and Notebook dependencies

### DIFF
--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -204,12 +204,12 @@ def publish_all_items(
     if _should_publish_item_type("UserDataFunction"):
         print_header("Publishing User Data Functions")
         items.publish_userdatafunctions(fabric_workspace_obj)
-    if _should_publish_item_type("Notebook"):
-        print_header("Publishing Notebooks")
-        items.publish_notebooks(fabric_workspace_obj)
     if _should_publish_item_type("Eventhouse"):
         print_header("Publishing Eventhouses")
         items.publish_eventhouses(fabric_workspace_obj)
+    if _should_publish_item_type("Notebook"):
+        print_header("Publishing Notebooks")
+        items.publish_notebooks(fabric_workspace_obj)
     if _should_publish_item_type("SemanticModel"):
         print_header("Publishing Semantic Models")
         items.publish_semanticmodels(fabric_workspace_obj)
@@ -366,21 +366,21 @@ def unpublish_all_orphan_items(
         "GraphQLApi",
         "DataPipeline",
         "Dataflow",
+        "KQLDashboard",
         "Eventstream",
         "Reflex",
-        "KQLDashboard",
         "KQLQueryset",
         "KQLDatabase",
         "CopyJob",
         "Report",
         "SemanticModel",
-        "Eventhouse",
         "Notebook",
+        "Eventhouse",
         "UserDataFunction",
         "Environment",
-        "MirroredDatabase",
         "SQLDatabase",
         "Lakehouse",
+        "MirroredDatabase",
         "Warehouse",
         "VariableLibrary",
     ]:


### PR DESCRIPTION
- Fixes #685

This pull request refactors the publishing logic in `src/fabric_cicd/publish.py` by reordering some of the publish and unpublish operations to improve consistency and maintain the intended sequence of item handling. The main changes involve moving the publishing of Notebooks to a different position and reordering several item types in the `unpublish_all_orphan_items` list.

Ordering and logic consistency improvements:

* Moved the publishing of Notebooks to occur after Eventhouses, aligning the order with other publishing operations.
* Reordered item types in the `unpublish_all_orphan_items` function to ensure that `KQLDashboard`, `Eventhouse`, and `MirroredDatabase` are processed in a consistent and logical order.