### PR TITLE
Resolved #701 Setup demo - create minor bugs

### DIFF
--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -595,10 +595,9 @@ class FabricWorkspace:
                 return
 
         item_guid = item.guid
-        item_description = item.description
         item_files = item.item_files
 
-        metadata_body = {"displayName": item_name, "type": item_type, "description": item_description}
+        metadata_body = {"displayName": item_name, "type": item_type}
 
         # Only shell deployment, no definition support (item_type can be overridden via kwargs)
         shell_only_publish = kwargs.get("shell_only_publish", item_type in constants.SHELL_ONLY_PUBLISH)

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -240,9 +240,6 @@ def publish_all_items(
     if _should_publish_item_type("Eventhouse"):
         print_header("Publishing Eventhouses")
         items.publish_eventhouses(fabric_workspace_obj)
-    if _should_publish_item_type("Notebook"):
-        print_header("Publishing Notebooks")
-        items.publish_notebooks(fabric_workspace_obj)
     if _should_publish_item_type("SemanticModel"):
         print_header("Publishing Semantic Models")
         items.publish_semanticmodels(fabric_workspace_obj)
@@ -276,6 +273,9 @@ def publish_all_items(
     if _should_publish_item_type("GraphQLApi"):
         print_header("Publishing GraphQL APIs")
         items.publish_graphqlapis(fabric_workspace_obj)
+    if _should_publish_item_type("Notebook"):
+        print_header("Publishing Notebooks")
+        items.publish_notebooks(fabric_workspace_obj)
     if _should_publish_item_type("ApacheAirflowJob"):
         print_header("Publishing Apache Airflow Jobs")
         items.publish_apacheairflowjobs(fabric_workspace_obj)
@@ -396,6 +396,7 @@ def unpublish_all_orphan_items(
         "OrgApp",
         "MountedDataFactory",
         "ApacheAirflowJob",
+        "Notebook",
         "GraphQLApi",
         "DataPipeline",
         "Dataflow",
@@ -407,7 +408,6 @@ def unpublish_all_orphan_items(
         "CopyJob",
         "Report",
         "SemanticModel",
-        "Notebook",
         "Eventhouse",
         "UserDataFunction",
         "Environment",


### PR DESCRIPTION

This pull request reorganizes and refines how Notebooks are published and unpublished in the Fabric workspace publishing pipeline. The main changes involve moving the publishing logic for Notebooks to a later stage in the process and updating metadata handling. Below are the most important changes:

**Publishing Pipeline Reordering:**

* Moved the publishing of Notebooks to occur after GraphQL APIs and before Apache Airflow Jobs in the publishing pipeline, ensuring a more logical and consistent order. [[1]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704L243-L245) [[2]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R276-R278)

**Unpublishing Logic Updates:**

* Updated the list of item types in `unpublish_all_orphan_items` so that Notebooks are now unpublished together with items like Apache Airflow Jobs and GraphQL APIs, rather than with Semantic Models and Reports. [[1]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R399) [[2]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704L410)

**Metadata Handling:**

* Removed the `description` field from the metadata body when publishing items, simplifying the metadata sent for each item.
