### PR TITLE
Fixes #703 Correct publish order for Pipelines and Notebooks

### DIFF
--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -240,6 +240,9 @@ def publish_all_items(
     if _should_publish_item_type("Eventhouse"):
         print_header("Publishing Eventhouses")
         items.publish_eventhouses(fabric_workspace_obj)
+    if _should_publish_item_type("Notebook"):
+        print_header("Publishing Notebooks")
+        items.publish_notebooks(fabric_workspace_obj)
     if _should_publish_item_type("SemanticModel"):
         print_header("Publishing Semantic Models")
         items.publish_semanticmodels(fabric_workspace_obj)
@@ -273,9 +276,6 @@ def publish_all_items(
     if _should_publish_item_type("GraphQLApi"):
         print_header("Publishing GraphQL APIs")
         items.publish_graphqlapis(fabric_workspace_obj)
-    if _should_publish_item_type("Notebook"):
-        print_header("Publishing Notebooks")
-        items.publish_notebooks(fabric_workspace_obj)
     if _should_publish_item_type("ApacheAirflowJob"):
         print_header("Publishing Apache Airflow Jobs")
         items.publish_apacheairflowjobs(fabric_workspace_obj)
@@ -396,7 +396,6 @@ def unpublish_all_orphan_items(
         "OrgApp",
         "MountedDataFactory",
         "ApacheAirflowJob",
-        "Notebook",
         "GraphQLApi",
         "DataPipeline",
         "Dataflow",
@@ -408,6 +407,7 @@ def unpublish_all_orphan_items(
         "CopyJob",
         "Report",
         "SemanticModel",
+        "Notebook",
         "Eventhouse",
         "UserDataFunction",
         "Environment",


### PR DESCRIPTION
This pull request updates the publishing and unpublishing logic for Notebooks in the `src/fabric_cicd/publish.py` file. The main change is to adjust the order and grouping of how Notebooks are published and unpublished, ensuring consistency with other item types.

Publishing logic updates:

* Moved the publishing of Notebooks to occur immediately after Eventhouses, instead of after GraphQL APIs, for better logical grouping and consistency. [[1]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R243-R245) [[2]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704L276-L278)

Unpublishing logic updates:

* Updated the list of item types in `unpublish_all_orphan_items` so that Notebooks are now grouped with "SemanticModel", "Report", and similar items, instead of with "ApacheAirflowJob" and "GraphQLApi". [[1]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704L399) [[2]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R410)