### PR TITLE
Fixes #730: Update license pyproject configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ authors = [{ name = "Microsoft Corporation" }]
 description = "Microsoft Fabric CI/CD"
 readme = "README.md"
 requires-python = ">=3.9,<3.13"
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 dynamic = ["version"]
 urls.Repository = "https://github.com/microsoft/fabric-cicd.git"
 classifiers = [


### PR DESCRIPTION
## Description

Following PEP best practices - https://peps.python.org/pep-0639/#project-source-metadata.

Table values for the license key in the [project] table, including the `text` and `file` table subkeys, are now deprecated. If the new license-files key is present, build tools MUST raise an error if the license key is defined and has a value other than a single top-level string.

## Linked Issue (REQUIRED)
- Fixes #730 
<!-- 
REQUIRED: This PR must be linked to an issue via the PR title format.
PR Title MUST follow this exact format: "Fixes #123 - Short Description"

Use the appropriate action word:
- Fixes #123 (for bug fixes)
- Closes #456 (for features)  
- Resolves #789 (for other changes)

Example: "Fixes #520 - Add Python version requirements to documentation"
-->
