### PR TITLE
#758 Add missing documentation on Org App Item Type

### DIFF
--- a/docs/how_to/item_types.md
+++ b/docs/how_to/item_types.md
@@ -126,6 +126,12 @@
     - Notebooks attached to lakehouses always point to the original lakehouse unless parameterized in the `find_replace` section of the `parameter.yml` file.
 - **Resources** are not source controlled and will not be deployed.
 
+## Org App
+
+- **Parameterization:**
+    - The `find_replace` section in the `parameter.yml` file is not applied.
+- SPN is currently not a supported authentication method for deploying Org App items.
+
 ## Real-Time Dashboard
 
 - **Parameterization:**


### PR DESCRIPTION
This pull request updates the documentation to clarify the behavior and limitations of Org App item types, specifically around parameterization and authentication methods.

**Org App documentation updates:**

* Added a new section describing Org App item types, explicitly stating that the `find_replace` section in `parameter.yml` is not applied to Org App items.
* Documented that SPN (Service Principal Name) is not currently a supported authentication method for deploying Org App items.