### PR TITLE
Update help info on about page

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -14,7 +14,7 @@
 
 ## Get help
 
-This project uses [GitHub Issues](https://github.com/microsoft/fabric-cicd/issues) to track bugs, feature requests, and questions. Please search the existing issues before filing new issues to avoid duplicates. For new issues, file your [bug](https://github.com/microsoft/fabric-cicd/issues/new?template=1-bug.yml), [feature request](https://github.com/microsoft/fabric-cicd/issues/new?template=2-feature.yml), or [question](https://github.com/microsoft/fabric-cicd/issues/new?template=4-question.yml) as a new Issue.
+This project uses [GitHub Issues](https://github.com/microsoft/fabric-cicd/issues) to track bugs, feature requests, and questions. Please search the existing issues before filing new issues to avoid duplicates. For new issues, file your [bug](https://github.com/microsoft/fabric-cicd/issues/new?template=1-bug.yml), [feature request](https://github.com/microsoft/fabric-cicd/issues/new?template=2-feature.yml), or [question](https://github.com/microsoft/fabric-cicd/issues/new?template=4-question.yml) as a new issue.
 
 **Found a bug or have a suggestion?**
 


### PR DESCRIPTION
Closes #821
This pull request updates the support and help section in the project documentation to provide clearer guidance and more comprehensive resources for users seeking assistance. The previous "Support" section is replaced with a new "Get help" section that offers multiple avenues for reporting issues, getting help, and accessing enterprise support.

Documentation improvements:

* Replaced the old "Support" section in `docs/about.md` with a new "Get help" section that details how to report bugs, submit feature requests, and ask questions, including direct links to GitHub Issues and the Fabric Ideas Portal. [[1]](diffhunk://#diff-049d400b4837940fc4fd4519150b7867f092f8569718b4dfedb356713a29d3a2L3-L10) [[2]](diffhunk://#diff-049d400b4837940fc4fd4519150b7867f092f8569718b4dfedb356713a29d3a2R14-R34)
* Added resources for troubleshooting, community support (GitHub Discussions, Reddit, Microsoft Developer Community), and instructions for obtaining enterprise assistance, including contacting Microsoft or opening a Fabric Support Team ticket.
