### PR TITLE
Remove legacy param mention from docs

### DIFF
--- a/docs/how_to/parameterization.md
+++ b/docs/how_to/parameterization.md
@@ -147,13 +147,6 @@ spark_pool:
 
 Semantic model binding automatically connects semantic models to the appropriate data source connection (e.g., cloud or gateway/on-premises) after deployment, ensuring your models can refresh data in the target environment.
 
-**Important:** 
-
-- The legacy `gateway_binding` parameter is deprecated and will be removed in a future release.
-- The legacy `semantic_model_binding` parameter format is deprecated and will be removed in a future release. Please migrate to the recommended format below.
-
-**Recommended format:**
-
 ```yaml
 semantic_model_binding:
     # Default connection for all models not explicitly listed
@@ -174,18 +167,6 @@ semantic_model_binding:
         - semantic_model_name: ["<semantic_model_name1>", "<semantic_model_name2>", ...]
           connection_id:
               _ALL_: <connection_guid>
-```
-
-**Legacy format:**
-
-```yaml
-# Legacy format:
-semantic_model_binding:
-    - connection_id: <connection_guid>
-      # Required field: value must be a string or a list of strings
-      semantic_model_name: "<semantic_model_name>"
-      # OR
-      semantic_model_name: ["<semantic_model_name1>","<semantic_model_name2>", ...]
 ```
 
 **Notes:**


### PR DESCRIPTION
This pull request updates the documentation for semantic model binding in `parameterization.md` to remove references to deprecated legacy formats and parameters. The changes focus on streamlining the documentation to only show the recommended approach going forward.

**Documentation cleanup and deprecation removal:**

* Removed documentation for the deprecated `gateway_binding` parameter and the legacy `semantic_model_binding` parameter format, including all related explanatory notes and examples. [[1]](diffhunk://#diff-9cdd02ee5f5219c5426160beb19ff83c624221fd6db2ac6f8bf923d6ebb6f0ffL150-L156) [[2]](diffhunk://#diff-9cdd02ee5f5219c5426160beb19ff83c624221fd6db2ac6f8bf923d6ebb6f0ffL179-L190)