### PR TITLE
Closes #909 Remove defaultazurecredential fallback path

### DIFF
--- a/.changes/unreleased/breaking-20260329-150739.yaml
+++ b/.changes/unreleased/breaking-20260329-150739.yaml
@@ -1,0 +1,8 @@
+kind: breaking
+body: Remove default credential fallback; explicit token credential is now required
+time: 2026-03-29T15:07:39.9569937+03:00
+custom:
+    Author: shirasassoon
+    AuthorLink: https://github.com/shirasassoon
+    Issue: "909"
+    IssueLink: https://github.com/microsoft/fabric-cicd/issues/909

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -102,7 +102,7 @@ class FabricWorkspace:
 
         if token_credential is None:
             if _is_fabric_runtime():
-                token_credential = _generate_fabric_credential()
+                token_credential = validate_token_credential(_generate_fabric_credential())
                 logger.debug("Running in Fabric runtime - using generated Fabric credential for authentication.")
             else:
                 msg = "A TokenCredential is required to authenticate API requests. Please pass a 'token_credential' (e.g., AzureCliCredential, ClientSecretCredential)."

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -35,7 +35,7 @@ class FabricWorkspace:
         environment: str = "N/A",
         workspace_id: Optional[str] = None,
         workspace_name: Optional[str] = None,
-        token_credential: TokenCredential = None,
+        token_credential: Optional[TokenCredential] = None,
         **kwargs,
     ) -> None:
         """
@@ -47,7 +47,7 @@ class FabricWorkspace:
             repository_directory: Local directory path of the repository where items are to be deployed from.
             item_type_in_scope: Item types that should be deployed for a given workspace. If omitted, defaults to all available item types.
             environment: The environment to be used for parameterization.
-            token_credential: The token credential to use for API requests.
+            token_credential: The token credential to use for API requests (e.g., AzureCliCredential, ClientSecretCredential).
             kwargs: Additional keyword arguments.
 
         Examples:
@@ -103,11 +103,10 @@ class FabricWorkspace:
         if token_credential is None:
             if _is_fabric_runtime():
                 token_credential = _generate_fabric_credential()
+                logger.debug("Running in Fabric runtime - using generated Fabric credential for authentication.")
             else:
-                # if credential is not defined, use DefaultAzureCredential
-                from azure.identity import DefaultAzureCredential
-
-                token_credential = DefaultAzureCredential()
+                msg = "A TokenCredential is required to authenticate API requests. Please pass a 'token_credential' (e.g., AzureCliCredential, ClientSecretCredential)."
+                raise InputError(msg, logger)
         else:
             token_credential = validate_token_credential(token_credential)
 

--- a/tests/test_fabric_workspace.py
+++ b/tests/test_fabric_workspace.py
@@ -10,6 +10,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 import yaml
 
+from fixtures.credentials import DummyTokenCredential
+
 from fabric_cicd.fabric_workspace import FabricWorkspace, constants
 
 
@@ -120,6 +122,7 @@ def patched_fabric_workspace(mock_endpoint):
                 workspace_id=workspace_id,
                 repository_directory=repository_directory,
                 item_type_in_scope=item_type_in_scope,
+                token_credential=DummyTokenCredential(),
                 **kwargs,
             )
             # Call refresh methods to populate workspace data
@@ -1031,6 +1034,7 @@ def test_base_api_url_kwarg_raises_error(temp_workspace_dir, valid_workspace_id)
                 workspace_id=valid_workspace_id,
                 repository_directory=str(temp_workspace_dir),
                 base_api_url="https://custom.api.url",
+                token_credential=DummyTokenCredential(),
             )
 
         # Verify the error message contains the expected text

--- a/tests/test_fabric_workspace.py
+++ b/tests/test_fabric_workspace.py
@@ -9,7 +9,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
-
 from fixtures.credentials import DummyTokenCredential
 
 from fabric_cicd.fabric_workspace import FabricWorkspace, constants
@@ -1581,6 +1580,7 @@ def test_mix_of_default_and_non_default_logical_ids(temp_workspace_dir, patched_
     assert workspace.repository_items["Notebook"]["Exported Notebook"].logical_id == constants.DEFAULT_GUID
     assert workspace.repository_items["Notebook"]["Git Notebook"].logical_id == unique_logical_id
     assert workspace.repository_items["DataPipeline"]["Exported Pipeline"].logical_id == constants.DEFAULT_GUID
+
 
 def test_publish_variable_library_only_calls_replace_parameters(
     temp_workspace_dir, patched_fabric_workspace, valid_workspace_id

--- a/tests/test_fabric_workspace.py
+++ b/tests/test_fabric_workspace.py
@@ -1009,6 +1009,32 @@ def test_parameter_file_path_invalid_type_rejected(temp_workspace_dir, patched_f
     assert not workspace.environment_parameter
 
 
+def test_no_token_credential_outside_fabric_runtime_raises_error(temp_workspace_dir, valid_workspace_id):
+    """Test that constructing FabricWorkspace without token_credential outside Fabric runtime raises InputError."""
+    from fabric_cicd._common._exceptions import InputError
+
+    # Create a simple platform file so directory validation passes
+    notebook_dir = temp_workspace_dir / "Test Notebook"
+    notebook_dir.mkdir()
+    platform_file = notebook_dir / ".platform"
+    platform_content = {
+        "metadata": {"type": "Notebook", "displayName": "Test Notebook"},
+        "config": {"logicalId": "12345678-1234-5678-abcd-1234567890ab"},
+    }
+    with platform_file.open("w", encoding="utf-8") as f:
+        json.dump(platform_content, f)
+
+    with patch("fabric_cicd.fabric_workspace._is_fabric_runtime", return_value=False):
+        with pytest.raises(InputError) as exc_info:
+            FabricWorkspace(
+                workspace_id=valid_workspace_id,
+                repository_directory=str(temp_workspace_dir),
+            )
+
+        assert "TokenCredential is required" in str(exc_info.value)
+        assert "token_credential" in str(exc_info.value)
+
+
 def test_base_api_url_kwarg_raises_error(temp_workspace_dir, valid_workspace_id):
     """Test that passing base_api_url as kwarg raises an error."""
     from fabric_cicd._common._exceptions import InputError

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -11,13 +11,13 @@ from typing import Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
+from fixtures.credentials import DummyTokenCredential
 
 import fabric_cicd.publish as publish
 from fabric_cicd import constants
 from fabric_cicd._common._exceptions import InputError
 from fabric_cicd._items._notebook import NotebookPublisher
 from fabric_cicd.constants import API_FORMAT_MAPPING, ItemType
-from fixtures.credentials import DummyTokenCredential
 from fabric_cicd.fabric_workspace import FabricWorkspace
 
 # =============================================================================

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -17,6 +17,7 @@ from fabric_cicd import constants
 from fabric_cicd._common._exceptions import InputError
 from fabric_cicd._items._notebook import NotebookPublisher
 from fabric_cicd.constants import API_FORMAT_MAPPING, ItemType
+from fixtures.credentials import DummyTokenCredential
 from fabric_cicd.fabric_workspace import FabricWorkspace
 
 # =============================================================================
@@ -124,6 +125,7 @@ def test_publish_only_existing_item_types(mock_endpoint, temp_workspace_dir):
         workspace = FabricWorkspace(
             workspace_id="12345678-1234-5678-abcd-1234567890ab",
             repository_directory=str(temp_workspace_dir),
+            token_credential=DummyTokenCredential(),
         )
 
         publish.publish_all_items(workspace)
@@ -148,6 +150,7 @@ def test_default_none_item_type_in_scope_includes_all_types(mock_endpoint, temp_
         workspace = FabricWorkspace(
             workspace_id="12345678-1234-5678-abcd-1234567890ab",
             repository_directory=str(temp_workspace_dir),
+            token_credential=DummyTokenCredential(),
         )
 
         expected_types = list(constants.ACCEPTED_ITEM_TYPES)
@@ -161,6 +164,7 @@ def test_empty_item_type_in_scope_list(mock_endpoint, temp_workspace_dir):
             workspace_id="12345678-1234-5678-abcd-1234567890ab",
             repository_directory=str(temp_workspace_dir),
             item_type_in_scope=[],
+            token_credential=DummyTokenCredential(),
         )
         assert workspace.item_type_in_scope == []
 
@@ -180,6 +184,7 @@ def test_invalid_item_types_in_scope(mock_endpoint, temp_workspace_dir):
             workspace_id="12345678-1234-5678-abcd-1234567890ab",
             repository_directory=str(temp_workspace_dir),
             item_type_in_scope=["InvalidItemType"],
+            token_credential=DummyTokenCredential(),
         )
 
 
@@ -193,6 +198,7 @@ def test_multiple_invalid_item_types_in_scope(mock_endpoint, temp_workspace_dir)
             workspace_id="12345678-1234-5678-abcd-1234567890ab",
             repository_directory=str(temp_workspace_dir),
             item_type_in_scope=["FakeType", "AnotherInvalidType"],
+            token_credential=DummyTokenCredential(),
         )
 
 
@@ -206,6 +212,7 @@ def test_mixed_valid_and_invalid_item_types_in_scope(mock_endpoint, temp_workspa
             workspace_id="12345678-1234-5678-abcd-1234567890ab",
             repository_directory=str(temp_workspace_dir),
             item_type_in_scope=["Notebook", "BadType", "Environment"],
+            token_credential=DummyTokenCredential(),
         )
 
 
@@ -245,6 +252,7 @@ def test_unpublish_feature_flag_warnings(mock_endpoint, temp_workspace_dir, capl
             workspace_id="12345678-1234-5678-abcd-1234567890ab",
             repository_directory=str(temp_workspace_dir),
             item_type_in_scope=["Lakehouse", "Warehouse", "SQLDatabase", "Eventhouse"],
+            token_credential=DummyTokenCredential(),
         )
 
         publish.unpublish_all_orphan_items(workspace)
@@ -288,6 +296,7 @@ def test_unpublish_with_feature_flags_enabled(mock_endpoint, temp_workspace_dir,
                 workspace_id="12345678-1234-5678-abcd-1234567890ab",
                 repository_directory=str(temp_workspace_dir),
                 item_type_in_scope=["Lakehouse"],
+                token_credential=DummyTokenCredential(),
             )
 
             publish.unpublish_all_orphan_items(workspace)
@@ -339,6 +348,7 @@ def test_unpublish_orphan_item_is_deleted(mock_endpoint, temp_workspace_dir):
             workspace_id="12345678-1234-5678-abcd-1234567890ab",
             repository_directory=str(temp_workspace_dir),
             item_type_in_scope=["Notebook"],
+            token_credential=DummyTokenCredential(),
         )
 
         publish.unpublish_all_orphan_items(workspace)
@@ -387,6 +397,7 @@ def test_unpublish_orphan_excluded_by_regex(mock_endpoint, temp_workspace_dir):
             workspace_id="12345678-1234-5678-abcd-1234567890ab",
             repository_directory=str(temp_workspace_dir),
             item_type_in_scope=["Notebook"],
+            token_credential=DummyTokenCredential(),
         )
 
         publish.unpublish_all_orphan_items(workspace, item_name_exclude_regex=r"^Protected.*")
@@ -436,6 +447,7 @@ def test_unpublish_orphan_filtered_by_items_to_include(mock_endpoint, temp_works
             workspace_id="12345678-1234-5678-abcd-1234567890ab",
             repository_directory=str(temp_workspace_dir),
             item_type_in_scope=["Notebook"],
+            token_credential=DummyTokenCredential(),
         )
 
         publish.unpublish_all_orphan_items(workspace, items_to_include=["TargetOrphan.Notebook"])
@@ -477,6 +489,7 @@ def test_unpublish_no_orphans_no_deletion(mock_endpoint, temp_workspace_dir):
             workspace_id="12345678-1234-5678-abcd-1234567890ab",
             repository_directory=str(temp_workspace_dir),
             item_type_in_scope=["Notebook"],
+            token_credential=DummyTokenCredential(),
         )
 
         publish.unpublish_all_orphan_items(workspace)
@@ -520,6 +533,7 @@ def test_mirrored_database_published_before_lakehouse(mock_endpoint, temp_worksp
             workspace_id="12345678-1234-5678-abcd-1234567890ab",
             repository_directory=str(temp_workspace_dir),
             item_type_in_scope=["Lakehouse", "MirroredDatabase"],
+            token_credential=DummyTokenCredential(),
         )
 
         publish.publish_all_items(workspace)
@@ -559,6 +573,7 @@ def test_folder_exclusion_with_regex(mock_endpoint, temp_workspace_dir):
             workspace_id="12345678-1234-5678-abcd-1234567890ab",
             repository_directory=str(temp_workspace_dir),
             item_type_in_scope=["Notebook", "SemanticModel"],
+            token_credential=DummyTokenCredential(),
         )
 
         exclude_regex = r".*legacy.*"
@@ -593,6 +608,7 @@ def test_folder_exclusion_with_anchored_regex(mock_endpoint, temp_workspace_dir)
             workspace_id="12345678-1234-5678-abcd-1234567890ab",
             repository_directory=str(temp_workspace_dir),
             item_type_in_scope=["Notebook"],
+            token_credential=DummyTokenCredential(),
         )
 
         exclude_regex = r"^/legacy$"
@@ -619,6 +635,7 @@ def test_item_name_exclusion_still_works(mock_endpoint, temp_workspace_dir):
             workspace_id="12345678-1234-5678-abcd-1234567890ab",
             repository_directory=str(temp_workspace_dir),
             item_type_in_scope=["Notebook"],
+            token_credential=DummyTokenCredential(),
         )
 
         exclude_regex = r".*DoNotPublish.*"
@@ -656,6 +673,7 @@ def test_folder_inclusion_with_folder_path_to_include(mock_endpoint, temp_worksp
             workspace_id="12345678-1234-5678-abcd-1234567890ab",
             repository_directory=str(temp_workspace_dir),
             item_type_in_scope=["Notebook", "SemanticModel"],
+            token_credential=DummyTokenCredential(),
         )
 
         publish.publish_all_items(
@@ -692,6 +710,7 @@ def test_folder_inclusion_and_exclusion_together(mock_endpoint, temp_workspace_d
             workspace_id="12345678-1234-5678-abcd-1234567890ab",
             repository_directory=str(temp_workspace_dir),
             item_type_in_scope=["Notebook"],
+            token_credential=DummyTokenCredential(),
         )
 
         with pytest.raises(
@@ -719,6 +738,7 @@ def test_empty_folder_path_to_include_raises_error(mock_endpoint, temp_workspace
             workspace_id="12345678-1234-5678-abcd-1234567890ab",
             repository_directory=str(temp_workspace_dir),
             item_type_in_scope=["Notebook"],
+            token_credential=DummyTokenCredential(),
         )
 
         with pytest.raises(InputError, match="folder_path_to_include must not be an empty list"):
@@ -748,6 +768,7 @@ def test_folder_exclusion_with_items_to_include(mock_endpoint, temp_workspace_di
             workspace_id="12345678-1234-5678-abcd-1234567890ab",
             repository_directory=str(temp_workspace_dir),
             item_type_in_scope=["Notebook"],
+            token_credential=DummyTokenCredential(),
         )
 
         publish.publish_all_items(
@@ -778,6 +799,7 @@ def test_folder_inclusion_with_item_exclusion(mock_endpoint, temp_workspace_dir)
             workspace_id="12345678-1234-5678-abcd-1234567890ab",
             repository_directory=str(temp_workspace_dir),
             item_type_in_scope=["Notebook"],
+            token_credential=DummyTokenCredential(),
         )
 
         publish.publish_all_items(
@@ -808,6 +830,7 @@ def test_folder_inclusion_with_items_to_include(mock_endpoint, temp_workspace_di
             workspace_id="12345678-1234-5678-abcd-1234567890ab",
             repository_directory=str(temp_workspace_dir),
             item_type_in_scope=["Notebook"],
+            token_credential=DummyTokenCredential(),
         )
 
         publish.publish_all_items(
@@ -840,6 +863,7 @@ def test_all_filters_combined(mock_endpoint, temp_workspace_dir):
             workspace_id="12345678-1234-5678-abcd-1234567890ab",
             repository_directory=str(temp_workspace_dir),
             item_type_in_scope=["Notebook"],
+            token_credential=DummyTokenCredential(),
         )
 
         publish.publish_all_items(

--- a/tests/test_response_collection.py
+++ b/tests/test_response_collection.py
@@ -9,12 +9,11 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from fixtures.credentials import DummyTokenCredential
 
 import fabric_cicd.constants as constants
 import fabric_cicd.publish as publish
 from fabric_cicd import append_feature_flag
-from fixtures.credentials import DummyTokenCredential
-
 from fabric_cicd.fabric_workspace import FabricWorkspace
 
 

--- a/tests/test_response_collection.py
+++ b/tests/test_response_collection.py
@@ -13,6 +13,8 @@ import pytest
 import fabric_cicd.constants as constants
 import fabric_cicd.publish as publish
 from fabric_cicd import append_feature_flag
+from fixtures.credentials import DummyTokenCredential
+
 from fabric_cicd.fabric_workspace import FabricWorkspace
 
 
@@ -91,6 +93,7 @@ def test_workspace_with_notebook(mock_endpoint):
                 workspace_id="12345678-1234-5678-abcd-1234567890ab",
                 repository_directory=str(temp_path),
                 item_type_in_scope=["Notebook"],
+                token_credential=DummyTokenCredential(),
             )
             # Manually set up repository items since we're patching the refresh methods
             workspace.repository_items = {

--- a/tests/test_subfolders.py
+++ b/tests/test_subfolders.py
@@ -9,7 +9,6 @@ import re
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from fixtures.credentials import DummyTokenCredential
 
 from fabric_cicd.fabric_workspace import FabricWorkspace

--- a/tests/test_subfolders.py
+++ b/tests/test_subfolders.py
@@ -10,6 +10,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from fixtures.credentials import DummyTokenCredential
+
 from fabric_cicd.fabric_workspace import FabricWorkspace
 
 
@@ -110,6 +112,7 @@ def patched_fabric_workspace(mock_endpoint):
                 workspace_id=workspace_id,
                 repository_directory=repository_directory,
                 item_type_in_scope=item_type_in_scope,
+                token_credential=DummyTokenCredential(),
                 **kwargs,
             )
 
@@ -268,6 +271,7 @@ def test_item_folder_association(repository_with_subfolders, valid_workspace_id)
             workspace_id=valid_workspace_id,
             repository_directory=str(repository_with_subfolders),
             item_type_in_scope=["Notebook", "DataPipeline"],
+            token_credential=DummyTokenCredential(),
         )
 
         # Call methods in the intended order to populate folder structures


### PR DESCRIPTION
This pull request introduces a breaking change to the authentication mechanism in `FabricWorkspace`: the default credential fallback has been removed, and an explicit `token_credential` must now be provided for API requests. The codebase and tests have been updated accordingly to enforce this requirement and provide clearer error messaging.

**Breaking change to authentication:**

* Removed the use of `DefaultAzureCredential` as a fallback; `FabricWorkspace` now requires an explicit `token_credential` to be passed for authentication. Attempting to instantiate without a credential (outside Fabric runtime) raises an `InputError` with a clear message. [[1]](diffhunk://#diff-5cc697c08271c66e9f601e755c17d2ea45267b4a20d48d4091aabbeb721fbf72R1-R8) [[2]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0R106-R109)

**Documentation and interface improvements:**

* Updated docstrings in `fabric_workspace.py` to clarify the requirement for an explicit `token_credential` and provide usage examples.

**Test suite updates:**

* All tests creating a `FabricWorkspace` now explicitly provide a `DummyTokenCredential` to comply with the new requirement, ensuring tests remain valid and pass. This affects multiple test files, including `test_publish.py`, `test_fabric_workspace.py`, `test_response_collection.py`, and `test_subfolders.py`. [[1]](diffhunk://#diff-38a69298c91571d1f1a72285d551b8e0ceaebe1ba66bd7bfc7a537620b4bfa3aR125) [[2]](diffhunk://#diff-38a69298c91571d1f1a72285d551b8e0ceaebe1ba66bd7bfc7a537620b4bfa3aR1037) [[3]](diffhunk://#diff-5f95c956aa5a4e335e0df13b1416d9448f8889ce7ff8f9806e450bdca98bef87R128) [[4]](diffhunk://#diff-5f95c956aa5a4e335e0df13b1416d9448f8889ce7ff8f9806e450bdca98bef87R153) [[5]](diffhunk://#diff-5f95c956aa5a4e335e0df13b1416d9448f8889ce7ff8f9806e450bdca98bef87R167) [[6]](diffhunk://#diff-5f95c956aa5a4e335e0df13b1416d9448f8889ce7ff8f9806e450bdca98bef87R187) [[7]](diffhunk://#diff-5f95c956aa5a4e335e0df13b1416d9448f8889ce7ff8f9806e450bdca98bef87R201) [[8]](diffhunk://#diff-5f95c956aa5a4e335e0df13b1416d9448f8889ce7ff8f9806e450bdca98bef87R215) [[9]](diffhunk://#diff-5f95c956aa5a4e335e0df13b1416d9448f8889ce7ff8f9806e450bdca98bef87R255) [[10]](diffhunk://#diff-5f95c956aa5a4e335e0df13b1416d9448f8889ce7ff8f9806e450bdca98bef87R299) [[11]](diffhunk://#diff-5f95c956aa5a4e335e0df13b1416d9448f8889ce7ff8f9806e450bdca98bef87R351) [[12]](diffhunk://#diff-5f95c956aa5a4e335e0df13b1416d9448f8889ce7ff8f9806e450bdca98bef87R400) [[13]](diffhunk://#diff-5f95c956aa5a4e335e0df13b1416d9448f8889ce7ff8f9806e450bdca98bef87R450) [[14]](diffhunk://#diff-5f95c956aa5a4e335e0df13b1416d9448f8889ce7ff8f9806e450bdca98bef87R492) [[15]](diffhunk://#diff-5f95c956aa5a4e335e0df13b1416d9448f8889ce7ff8f9806e450bdca98bef87R536) [[16]](diffhunk://#diff-5f95c956aa5a4e335e0df13b1416d9448f8889ce7ff8f9806e450bdca98bef87R576) [[17]](diffhunk://#diff-5f95c956aa5a4e335e0df13b1416d9448f8889ce7ff8f9806e450bdca98bef87R611) [[18]](diffhunk://#diff-5f95c956aa5a4e335e0df13b1416d9448f8889ce7ff8f9806e450bdca98bef87R638) [[19]](diffhunk://#diff-5f95c956aa5a4e335e0df13b1416d9448f8889ce7ff8f9806e450bdca98bef87R676) [[20]](diffhunk://#diff-5f95c956aa5a4e335e0df13b1416d9448f8889ce7ff8f9806e450bdca98bef87R713) [[21]](diffhunk://#diff-5f95c956aa5a4e335e0df13b1416d9448f8889ce7ff8f9806e450bdca98bef87R741) [[22]](diffhunk://#diff-5f95c956aa5a4e335e0df13b1416d9448f8889ce7ff8f9806e450bdca98bef87R771) [[23]](diffhunk://#diff-5f95c956aa5a4e335e0df13b1416d9448f8889ce7ff8f9806e450bdca98bef87R802) [[24]](diffhunk://#diff-5f95c956aa5a4e335e0df13b1416d9448f8889ce7ff8f9806e450bdca98bef87R833) [[25]](diffhunk://#diff-5f95c956aa5a4e335e0df13b1416d9448f8889ce7ff8f9806e450bdca98bef87R866) [[26]](diffhunk://#diff-4e3a3effb367a354b8da3e7859fac06554b469f7a08a228c0939925720f38d81R96) [[27]](diffhunk://#diff-a335b8b04c42975e71fe88a9d1aa131d52f55012ab5992e3cf99a9b8dead9d97R13-R14)

**Type annotation improvement:**

* Updated the `token_credential` parameter type in `FabricWorkspace.__init__` to be explicitly `Optional[TokenCredential]` for better type clarity.
