### PR TITLE
Add token_credential parameter to all docstring examples

### DIFF
--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -82,7 +82,7 @@ class FabricWorkspace:
             ...     token_credential=AzureCliCredential()  # or any other TokenCredential
             ... )
 
-            With SPN credential
+            With service principal credentials
             >>> from fabric_cicd import FabricWorkspace
             >>> from azure.identity import ClientSecretCredential
             >>> client_id = "your-client-id"

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -54,6 +54,7 @@ class FabricWorkspace:
         Examples:
             Basic usage
             >>> from fabric_cicd import FabricWorkspace
+            >>> from azure.identity import AzureCliCredential
             >>> workspace = FabricWorkspace(
             ...     workspace_id="your-workspace-id",
             ...     repository_directory="/path/to/repo",
@@ -63,6 +64,7 @@ class FabricWorkspace:
 
             Basic usage with workspace_name
             >>> from fabric_cicd import FabricWorkspace
+            >>> from azure.identity import AzureCliCredential
             >>> workspace = FabricWorkspace(
             ...     workspace_name="your-workspace-name",
             ...     repository_directory="/path/to/repo",
@@ -71,6 +73,7 @@ class FabricWorkspace:
 
             With optional parameters
             >>> from fabric_cicd import FabricWorkspace
+            >>> from azure.identity import AzureCliCredential
             >>> workspace = FabricWorkspace(
             ...     workspace_id="your-workspace-id",
             ...     repository_directory="/your/path/to/repo",
@@ -79,7 +82,7 @@ class FabricWorkspace:
             ...     token_credential=AzureCliCredential()  # or any other TokenCredential
             ... )
 
-            With token credential
+            With SPN credential
             >>> from fabric_cicd import FabricWorkspace
             >>> from azure.identity import ClientSecretCredential
             >>> client_id = "your-client-id"

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -83,79 +83,93 @@ def publish_all_items(
     Examples:
         Basic usage
         >>> from fabric_cicd import FabricWorkspace, publish_all_items
+        >>> from azure.identity import AzureCliCredential
         >>> workspace = FabricWorkspace(
         ...     workspace_id="your-workspace-id",
         ...     repository_directory="/path/to/repo",
-        ...     item_type_in_scope=["Environment", "Notebook", "DataPipeline"]
+        ...     item_type_in_scope=["Environment", "Notebook", "DataPipeline"],
+        ...     token_credential=AzureCliCredential()  # or any other TokenCredential
         ... )
         >>> publish_all_items(workspace)
 
         With regex name exclusion
         >>> from fabric_cicd import FabricWorkspace, publish_all_items
+        >>> from azure.identity import AzureCliCredential
         >>> workspace = FabricWorkspace(
         ...     workspace_id="your-workspace-id",
         ...     repository_directory="/path/to/repo",
-        ...     item_type_in_scope=["Environment", "Notebook", "DataPipeline"]
+        ...     item_type_in_scope=["Environment", "Notebook", "DataPipeline"],
+        ...     token_credential=AzureCliCredential()  # or any other TokenCredential
         ... )
         >>> exclude_regex = ".*_do_not_publish"
         >>> publish_all_items(workspace, item_name_exclude_regex=exclude_regex)
 
         With folder exclusion
         >>> from fabric_cicd import FabricWorkspace, publish_all_items, append_feature_flag
+        >>> from azure.identity import AzureCliCredential
         >>> append_feature_flag("enable_experimental_features")
         >>> append_feature_flag("enable_exclude_folder")
         >>> workspace = FabricWorkspace(
         ...     workspace_id="your-workspace-id",
         ...     repository_directory="/path/to/repo",
-        ...     item_type_in_scope=["Environment", "Notebook", "DataPipeline"]
+        ...     item_type_in_scope=["Environment", "Notebook", "DataPipeline"],
+        ...     token_credential=AzureCliCredential()  # or any other TokenCredential
         ... )
         >>> folder_exclude_regex = "^/legacy"
         >>> publish_all_items(workspace, folder_path_exclude_regex=folder_exclude_regex)
 
         With folder inclusion
         >>> from fabric_cicd import FabricWorkspace, publish_all_items, append_feature_flag
+        >>> from azure.identity import AzureCliCredential
         >>> append_feature_flag("enable_experimental_features")
         >>> append_feature_flag("enable_include_folder")
         >>> workspace = FabricWorkspace(
         ...     workspace_id="your-workspace-id",
         ...     repository_directory="/path/to/repo",
-        ...     item_type_in_scope=["Environment", "Notebook", "DataPipeline"]
+        ...     item_type_in_scope=["Environment", "Notebook", "DataPipeline"],
+        ...     token_credential=AzureCliCredential()  # or any other TokenCredential
         ... )
         >>> folder_path_to_include = ["/subfolder"]
         >>> publish_all_items(workspace, folder_path_to_include=folder_path_to_include)
 
         With items to include
         >>> from fabric_cicd import FabricWorkspace, publish_all_items, append_feature_flag
+        >>> from azure.identity import AzureCliCredential
         >>> append_feature_flag("enable_experimental_features")
         >>> append_feature_flag("enable_items_to_include")
         >>> workspace = FabricWorkspace(
         ...     workspace_id="your-workspace-id",
         ...     repository_directory="/path/to/repo",
-        ...     item_type_in_scope=["Environment", "Notebook", "DataPipeline"]
+        ...     item_type_in_scope=["Environment", "Notebook", "DataPipeline"],
+        ...     token_credential=AzureCliCredential()  # or any other TokenCredential
         ... )
         >>> items_to_include = ["Hello World.Notebook", "Hello.Environment"]
         >>> publish_all_items(workspace, items_to_include=items_to_include)
 
         With shortcut exclusion
         >>> from fabric_cicd import FabricWorkspace, publish_all_items, append_feature_flag
+        >>> from azure.identity import AzureCliCredential
         >>> append_feature_flag("enable_experimental_features")
         >>> append_feature_flag("enable_shortcut_exclude")
         >>> append_feature_flag("enable_shortcut_publish")
         >>> workspace = FabricWorkspace(
         ...     workspace_id="your-workspace-id",
         ...     repository_directory="/path/to/repo",
-        ...     item_type_in_scope=["Lakehouse"]
+        ...     item_type_in_scope=["Lakehouse"],
+        ...     token_credential=AzureCliCredential()  # or any other TokenCredential
         ... )
         >>> shortcut_exclude_regex = "^temp_.*"  # Exclude shortcuts starting with "temp_"
         >>> publish_all_items(workspace, shortcut_exclude_regex=shortcut_exclude_regex)
 
         With response collection
         >>> from fabric_cicd import FabricWorkspace, publish_all_items, append_feature_flag
+        >>> from azure.identity import AzureCliCredential
         >>> append_feature_flag("enable_response_collection")
         >>> workspace = FabricWorkspace(
         ...     workspace_id="your-workspace-id",
         ...     repository_directory="/path/to/repo",
-        ...     item_type_in_scope=["Environment", "Notebook", "DataPipeline"]
+        ...     item_type_in_scope=["Environment", "Notebook", "DataPipeline"],
+        ...     token_credential=AzureCliCredential()  # or any other TokenCredential
         ... )
         >>> responses = publish_all_items(workspace)
         >>> # Access all responses
@@ -269,10 +283,12 @@ def unpublish_all_orphan_items(
     Examples:
         Basic usage
         >>> from fabric_cicd import FabricWorkspace, publish_all_items, unpublish_all_orphan_items
+        >>> from azure.identity import AzureCliCredential
         >>> workspace = FabricWorkspace(
         ...     workspace_id="your-workspace-id",
         ...     repository_directory="/path/to/repo",
-        ...     item_type_in_scope=["Environment", "Notebook", "DataPipeline"]
+        ...     item_type_in_scope=["Environment", "Notebook", "DataPipeline"],
+        ...     token_credential=AzureCliCredential()  # or any other TokenCredential
         ... )
         >>> publish_all_items(workspace)
         >>> unpublish_all_orphan_items(workspace)
@@ -290,12 +306,14 @@ def unpublish_all_orphan_items(
 
         With items to include
         >>> from fabric_cicd import FabricWorkspace, publish_all_items, unpublish_all_orphan_items, append_feature_flag
+        >>> from azure.identity import AzureCliCredential
         >>> append_feature_flag("enable_experimental_features")
         >>> append_feature_flag("enable_items_to_include")
         >>> workspace = FabricWorkspace(
         ...     workspace_id="your-workspace-id",
         ...     repository_directory="/path/to/repo",
-        ...     item_type_in_scope=["Environment", "Notebook", "DataPipeline"]
+        ...     item_type_in_scope=["Environment", "Notebook", "DataPipeline"],
+        ...     token_credential=AzureCliCredential()  # or any other TokenCredential
         ... )
         >>> publish_all_items(workspace)
         >>> items_to_include = ["Hello World.Notebook", "Run Hello World.DataPipeline"]
@@ -303,11 +321,13 @@ def unpublish_all_orphan_items(
 
         With response collection
         >>> from fabric_cicd import FabricWorkspace, publish_all_items, unpublish_all_orphan_items, append_feature_flag
+        >>> from azure.identity import AzureCliCredential
         >>> append_feature_flag("enable_response_collection")
         >>> workspace = FabricWorkspace(
         ...     workspace_id="your-workspace-id",
         ...     repository_directory="/path/to/repo",
-        ...     item_type_in_scope=["Environment", "Notebook", "DataPipeline"]
+        ...     item_type_in_scope=["Environment", "Notebook", "DataPipeline"],
+        ...     token_credential=AzureCliCredential()  # or any other TokenCredential
         ... )
         >>> publish_all_items(workspace)
         >>> responses = unpublish_all_orphan_items(workspace)

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -295,10 +295,12 @@ def unpublish_all_orphan_items(
 
         With regex name exclusion
         >>> from fabric_cicd import FabricWorkspace, publish_all_items, unpublish_all_orphan_items
+        >>> from azure.identity import AzureCliCredential
         >>> workspace = FabricWorkspace(
         ...     workspace_id="your-workspace-id",
         ...     repository_directory="/path/to/repo",
-        ...     item_type_in_scope=["Environment", "Notebook", "DataPipeline"]
+        ...     item_type_in_scope=["Environment", "Notebook", "DataPipeline"],
+        ...     token_credential=AzureCliCredential()
         ... )
         >>> publish_all_items(workspace)
         >>> exclude_regex = ".*_do_not_delete"


### PR DESCRIPTION
This pull request updates the usage examples in the `FabricWorkspace`, `publish_all_items`, and `unpublish_all_orphan_items` documentation to explicitly show how to provide Azure credentials using `AzureCliCredential`. This clarifies authentication requirements for users and ensures the examples are accurate for real-world usage.

**Documentation improvements for authentication:**

* Added `from azure.identity import AzureCliCredential` and `token_credential=AzureCliCredential()` to all relevant usage examples in the `FabricWorkspace` constructor docstring in `fabric_workspace.py`, demonstrating how to provide Azure credentials. [[1]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0R57) [[2]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0R67) [[3]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0R76) [[4]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L82-R85)
* Updated all usage examples in the `publish_all_items` and `unpublish_all_orphan_items` docstrings in `publish.py` to include Azure credential imports and the `token_credential` parameter, ensuring that authentication is properly demonstrated in every scenario. [[1]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R86-R172) [[2]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R286-R291) [[3]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R309-R330)