### PR TITLE
v1.0.0

### DIFF
--- a/.changes/unreleased/added-20260312-113803.yaml
+++ b/.changes/unreleased/added-20260312-113803.yaml
@@ -1,8 +1,0 @@
-kind: added
-body: Improve transparency of `deploy_with_config` function in success and failure scenarios
-time: 2026-03-12T11:38:03.0656028+02:00
-custom:
-    Author: shirasassoon
-    AuthorLink: https://github.com/shirasassoon
-    Issue: "695"
-    IssueLink: https://github.com/microsoft/fabric-cicd/issues/695

--- a/.changes/unreleased/added-20260315-152312.yaml
+++ b/.changes/unreleased/added-20260315-152312.yaml
@@ -1,8 +1,0 @@
-kind: added
-body: Extend API response collection to unpublish operations
-time: 2026-03-15T15:23:12.619996+02:00
-custom:
-    Author: shirasassoon
-    AuthorLink: https://github.com/shirasassoon
-    Issue: "877"
-    IssueLink: https://github.com/microsoft/fabric-cicd/issues/877

--- a/.changes/unreleased/added-20260319-095618.yaml
+++ b/.changes/unreleased/added-20260319-095618.yaml
@@ -1,9 +1,0 @@
-kind: added
-body: Add `get_changed_items()` utility function to detect Fabric items changed via git diff for use with selective deployment
-time: 2026-03-19T09:56:18.0000000+00:00
-custom:
-    Author: vipulb91
-    AuthorLink: https://github.com/vipulb91
-    Issue: "865"
-    IssueLink: https://github.com/microsoft/fabric-cicd/issues/865
-

--- a/.changes/unreleased/breaking-20260329-150739.yaml
+++ b/.changes/unreleased/breaking-20260329-150739.yaml
@@ -1,8 +1,0 @@
-kind: breaking
-body: Remove default credential fallback; explicit token credential is now required
-time: 2026-03-29T15:07:39.9569937+03:00
-custom:
-    Author: shirasassoon
-    AuthorLink: https://github.com/shirasassoon
-    Issue: "909"
-    IssueLink: https://github.com/microsoft/fabric-cicd/issues/909

--- a/.changes/unreleased/breaking-20260413-145436.yaml
+++ b/.changes/unreleased/breaking-20260413-145436.yaml
@@ -1,8 +1,0 @@
-kind: breaking
-body: Remove implicit authentication in Microsoft Fabric Notebook and identity logging; require explicit token credential and keyword-only arguments for `FabricWorkspace` and `deploy_with_config`
-time: 2026-04-13T14:54:36.4162537+03:00
-custom:
-    Author: shirasassoon
-    AuthorLink: https://github.com/shirasassoon
-    Issue: "930"
-    IssueLink: https://github.com/microsoft/fabric-cicd/issues/930

--- a/.changes/unreleased/fixed-20260316-153630.yaml
+++ b/.changes/unreleased/fixed-20260316-153630.yaml
@@ -1,8 +1,0 @@
-kind: fixed
-body: Prevent unintended GUID replacements in Variable Library item files during publish
-time: 2026-03-16T15:36:30.7161217+02:00
-custom:
-    Author: shirasassoon
-    AuthorLink: https://github.com/shirasassoon
-    Issue: "884"
-    IssueLink: https://github.com/microsoft/fabric-cicd/issues/884

--- a/.changes/unreleased/fixed-20260319-113604.yaml
+++ b/.changes/unreleased/fixed-20260319-113604.yaml
@@ -1,8 +1,0 @@
-kind: fixed
-body: Fix YAML content check to reject notebook and other non-YAML files during `key_value_replace` parameterization, preventing file corruption
-time: 2026-03-19T11:36:04.309303+02:00
-custom:
-    Author: shirasassoon
-    AuthorLink: https://github.com/shirasassoon
-    Issue: "890"
-    IssueLink: https://github.com/microsoft/fabric-cicd/issues/890

--- a/.changes/unreleased/fixed-20260325-124736.yaml
+++ b/.changes/unreleased/fixed-20260325-124736.yaml
@@ -1,8 +1,0 @@
-kind: fixed
-body: Fix Notebook deployment failure caused by non-deterministic ordering of definition files in API payload
-time: 2026-03-25T12:47:36.1355405+02:00
-custom:
-    Author: shirasassoon
-    AuthorLink: https://github.com/shirasassoon
-    Issue: "869"
-    IssueLink: https://github.com/microsoft/fabric-cicd/issues/869

--- a/.changes/unreleased/fixed-20260330-131318.yaml
+++ b/.changes/unreleased/fixed-20260330-131318.yaml
@@ -1,8 +1,0 @@
-kind: fixed
-body: Ignore paramater file when not explicitly defined in config file
-time: 2026-03-30T13:13:18.023121+03:00
-custom:
-    Author: aviatco
-    AuthorLink: https://github.com/aviatco
-    Issue: "866"
-    IssueLink: https://github.com/microsoft/fabric-cicd/issues/866

--- a/.changes/unreleased/fixed-20260412-134631.yaml
+++ b/.changes/unreleased/fixed-20260412-134631.yaml
@@ -1,8 +1,0 @@
-kind: fixed
-body: Add `enable_hard_delete` feature flag to bypass workspace recycle bin during unpublish
-time: 2026-04-12T13:46:31.7502595+03:00
-custom:
-    Author: shirasassoon
-    AuthorLink: https://github.com/shirasassoon
-    Issue: "924"
-    IssueLink: https://github.com/microsoft/fabric-cicd/issues/924

--- a/.changes/unreleased/fixed-20260413-095633.yaml
+++ b/.changes/unreleased/fixed-20260413-095633.yaml
@@ -1,8 +1,0 @@
-kind: fixed
-body: Add timeout for long-running operation polling
-time: 2026-04-13T09:56:33.0600623+03:00
-custom:
-    Author: shirasassoon
-    AuthorLink: https://github.com/shirasassoon
-    Issue: "919"
-    IssueLink: https://github.com/microsoft/fabric-cicd/issues/919

--- a/.changes/unreleased/new-items-20260326-132648.yaml
+++ b/.changes/unreleased/new-items-20260326-132648.yaml
@@ -1,8 +1,0 @@
-kind: new-items
-body: Add support for Ontology item type
-time: 2026-03-26T13:26:48.8457334+02:00
-custom:
-    Author: shirasassoon
-    AuthorLink: https://github.com/shirasassoon
-    Issue: "796"
-    IssueLink: https://github.com/microsoft/fabric-cicd/issues/796

--- a/.changes/v1.0.0.md
+++ b/.changes/v1.0.0.md
@@ -20,6 +20,6 @@
 - Prevent unintended GUID replacements in Variable Library item files during publish by [shirasassoon](https://github.com/shirasassoon) ([#884](https://github.com/microsoft/fabric-cicd/issues/884))
 - Fix YAML content check to reject notebook and other non-YAML files during `key_value_replace` parameterization, preventing file corruption by [shirasassoon](https://github.com/shirasassoon) ([#890](https://github.com/microsoft/fabric-cicd/issues/890))
 - Fix Notebook deployment failure caused by non-deterministic ordering of definition files in API payload by [shirasassoon](https://github.com/shirasassoon) ([#869](https://github.com/microsoft/fabric-cicd/issues/869))
-- Ignore paramater file when not explicitly defined in config file by [aviatco](https://github.com/aviatco) ([#866](https://github.com/microsoft/fabric-cicd/issues/866))
+- Ignore parameter file when not explicitly defined in config file by [aviatco](https://github.com/aviatco) ([#866](https://github.com/microsoft/fabric-cicd/issues/866))
 - Add `enable_hard_delete` feature flag to bypass workspace recycle bin during unpublish by [shirasassoon](https://github.com/shirasassoon) ([#924](https://github.com/microsoft/fabric-cicd/issues/924))
 - Add timeout for long-running operation polling by [shirasassoon](https://github.com/shirasassoon) ([#919](https://github.com/microsoft/fabric-cicd/issues/919))

--- a/.changes/v1.0.0.md
+++ b/.changes/v1.0.0.md
@@ -1,0 +1,25 @@
+## [v1.0.0](https://pypi.org/project/fabric-cicd/1.0.0) - April 20, 2026
+
+### ⚠️ Breaking Change
+
+- Remove default credential fallback; explicit token credential is now required by [shirasassoon](https://github.com/shirasassoon) ([#909](https://github.com/microsoft/fabric-cicd/issues/909))
+- Remove implicit authentication in Microsoft Fabric Notebook and identity logging; require explicit token credential and keyword-only arguments for `FabricWorkspace` and `deploy_with_config` by [shirasassoon](https://github.com/shirasassoon) ([#930](https://github.com/microsoft/fabric-cicd/issues/930))
+
+### 🆕 New Items Support
+
+- Add support for Ontology item type by [shirasassoon](https://github.com/shirasassoon) ([#796](https://github.com/microsoft/fabric-cicd/issues/796))
+
+### ✨ New Functionality
+
+- Improve transparency of `deploy_with_config` function in success and failure scenarios by [shirasassoon](https://github.com/shirasassoon) ([#695](https://github.com/microsoft/fabric-cicd/issues/695))
+- Extend API response collection to unpublish operations by [shirasassoon](https://github.com/shirasassoon) ([#877](https://github.com/microsoft/fabric-cicd/issues/877))
+- Add `get_changed_items()` utility function to detect Fabric items changed via git diff for use with selective deployment by [vipulb91](https://github.com/vipulb91) ([#865](https://github.com/microsoft/fabric-cicd/issues/865))
+
+### 🔧 Bug Fix
+
+- Prevent unintended GUID replacements in Variable Library item files during publish by [shirasassoon](https://github.com/shirasassoon) ([#884](https://github.com/microsoft/fabric-cicd/issues/884))
+- Fix YAML content check to reject notebook and other non-YAML files during `key_value_replace` parameterization, preventing file corruption by [shirasassoon](https://github.com/shirasassoon) ([#890](https://github.com/microsoft/fabric-cicd/issues/890))
+- Fix Notebook deployment failure caused by non-deterministic ordering of definition files in API payload by [shirasassoon](https://github.com/shirasassoon) ([#869](https://github.com/microsoft/fabric-cicd/issues/869))
+- Ignore paramater file when not explicitly defined in config file by [aviatco](https://github.com/aviatco) ([#866](https://github.com/microsoft/fabric-cicd/issues/866))
+- Add `enable_hard_delete` feature flag to bypass workspace recycle bin during unpublish by [shirasassoon](https://github.com/shirasassoon) ([#924](https://github.com/microsoft/fabric-cicd/issues/924))
+- Add timeout for long-running operation polling by [shirasassoon](https://github.com/shirasassoon) ([#919](https://github.com/microsoft/fabric-cicd/issues/919))

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [v1.0.0](https://pypi.org/project/fabric-cicd/1.0.0) - April 20, 2026
+
+### ⚠️ Breaking Change
+
+- Remove default credential fallback; explicit token credential is now required by [shirasassoon](https://github.com/shirasassoon) ([#909](https://github.com/microsoft/fabric-cicd/issues/909))
+- Remove implicit authentication in Microsoft Fabric Notebook and identity logging; require explicit token credential and keyword-only arguments for `FabricWorkspace` and `deploy_with_config` by [shirasassoon](https://github.com/shirasassoon) ([#930](https://github.com/microsoft/fabric-cicd/issues/930))
+
+### 🆕 New Items Support
+
+- Add support for Ontology item type by [shirasassoon](https://github.com/shirasassoon) ([#796](https://github.com/microsoft/fabric-cicd/issues/796))
+
+### ✨ New Functionality
+
+- Improve transparency of `deploy_with_config` function in success and failure scenarios by [shirasassoon](https://github.com/shirasassoon) ([#695](https://github.com/microsoft/fabric-cicd/issues/695))
+- Extend API response collection to unpublish operations by [shirasassoon](https://github.com/shirasassoon) ([#877](https://github.com/microsoft/fabric-cicd/issues/877))
+- Add `get_changed_items()` utility function to detect Fabric items changed via git diff for use with selective deployment by [vipulb91](https://github.com/vipulb91) ([#865](https://github.com/microsoft/fabric-cicd/issues/865))
+
+### 🔧 Bug Fix
+
+- Prevent unintended GUID replacements in Variable Library item files during publish by [shirasassoon](https://github.com/shirasassoon) ([#884](https://github.com/microsoft/fabric-cicd/issues/884))
+- Fix YAML content check to reject notebook and other non-YAML files during `key_value_replace` parameterization, preventing file corruption by [shirasassoon](https://github.com/shirasassoon) ([#890](https://github.com/microsoft/fabric-cicd/issues/890))
+- Fix Notebook deployment failure caused by non-deterministic ordering of definition files in API payload by [shirasassoon](https://github.com/shirasassoon) ([#869](https://github.com/microsoft/fabric-cicd/issues/869))
+- Ignore paramater file when not explicitly defined in config file by [aviatco](https://github.com/aviatco) ([#866](https://github.com/microsoft/fabric-cicd/issues/866))
+- Add `enable_hard_delete` feature flag to bypass workspace recycle bin during unpublish by [shirasassoon](https://github.com/shirasassoon) ([#924](https://github.com/microsoft/fabric-cicd/issues/924))
+- Add timeout for long-running operation polling by [shirasassoon](https://github.com/shirasassoon) ([#919](https://github.com/microsoft/fabric-cicd/issues/919))
+
 ## [v0.3.1](https://pypi.org/project/fabric-cicd/0.3.1) - March 12, 2026
 
 ### 🔧 Bug Fix

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,7 +22,7 @@
 - Prevent unintended GUID replacements in Variable Library item files during publish by [shirasassoon](https://github.com/shirasassoon) ([#884](https://github.com/microsoft/fabric-cicd/issues/884))
 - Fix YAML content check to reject notebook and other non-YAML files during `key_value_replace` parameterization, preventing file corruption by [shirasassoon](https://github.com/shirasassoon) ([#890](https://github.com/microsoft/fabric-cicd/issues/890))
 - Fix Notebook deployment failure caused by non-deterministic ordering of definition files in API payload by [shirasassoon](https://github.com/shirasassoon) ([#869](https://github.com/microsoft/fabric-cicd/issues/869))
-- Ignore paramater file when not explicitly defined in config file by [aviatco](https://github.com/aviatco) ([#866](https://github.com/microsoft/fabric-cicd/issues/866))
+- Ignore parameter file when not explicitly defined in config file by [aviatco](https://github.com/aviatco) ([#866](https://github.com/microsoft/fabric-cicd/issues/866))
 - Add `enable_hard_delete` feature flag to bypass workspace recycle bin during unpublish by [shirasassoon](https://github.com/shirasassoon) ([#924](https://github.com/microsoft/fabric-cicd/issues/924))
 - Add timeout for long-running operation polling by [shirasassoon](https://github.com/shirasassoon) ([#919](https://github.com/microsoft/fabric-cicd/issues/919))
 

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -9,7 +9,7 @@ from enum import Enum
 from fabric_cicd._common._validate_env_vars import validate_env_var_api_url
 
 # General
-VERSION = "0.3.1"
+VERSION = "1.0.0"
 DEFAULT_GUID = "00000000-0000-0000-0000-000000000000"
 FEATURE_FLAG = set()
 USER_AGENT = f"ms-fabric-cicd/{VERSION}"


### PR DESCRIPTION
This pull request prepares the project for the v1.0.0 release, introducing several breaking changes, new features, bug fixes, and support for new item types. The most significant updates are the removal of implicit authentication and default credential fallback (requiring explicit token credentials), the addition of support for Ontology item types, and improvements to deployment and unpublish operations. Below are the most important changes grouped by theme:

**Breaking Changes:**
- Removed default credential fallback; explicit token credential is now required for authentication.
- Removed implicit authentication in Microsoft Fabric Notebook and identity logging; `FabricWorkspace` and `deploy_with_config` now require explicit token credentials and keyword-only arguments.

**New Features and Enhancements:**
- Added support for the Ontology item type.
- Improved transparency of the `deploy_with_config` function in both success and failure scenarios.
- Extended API response collection to include unpublish operations.
- Added a `get_changed_items()` utility function to detect changed Fabric items via `git diff` for selective deployment.

**Bug Fixes and Reliability Improvements:**
- Fixed unintended GUID replacements in Variable Library item files during publish.
- Enhanced YAML content checks to reject non-YAML files (e.g., notebooks) during `key_value_replace` parameterization, preventing file corruption.
- Fixed Notebook deployment failures caused by non-deterministic ordering of definition files in API payloads.
- Ensured parameter files are ignored when not explicitly defined in the config file.
- Added an `enable_hard_delete` feature flag to bypass the workspace recycle bin during unpublish operations.
- Added a timeout for long-running operation polling to improve reliability.

**Versioning and Documentation:**
- Updated the project version to `1.0.0` in `constants.py` and added detailed release notes to the changelog and documentation. [[1]](diffhunk://#diff-91c2d32be351f155f090c4bd57ebe3c10e646edbc1b663e2a72b697f956a949cL12-R12) [[2]](diffhunk://#diff-83afdc42495d5878f0cb3cce6e35a912fc12a6c47de45151041ea035af0208a1R1-R25) [[3]](diffhunk://#diff-77f023b99d3d58008351d3e82fc06e6d06ba1bc2da9e41be6329b7fa4f419f05R3-R28)