### PR TITLE
add missing token_credential param to doc examples

### DIFF
--- a/docs/example/deployment_variable.md
+++ b/docs/example/deployment_variable.md
@@ -50,7 +50,7 @@ Leverage the following when you have specific values that you need to define per
         environment=environment,
         repository_directory=repository_directory,
         item_type_in_scope=item_type_in_scope,
-        token_credential=token_credential,
+        token_credential=token_credential,  # or any other TokenCredential
     )
 
     # Publish all items defined in item_type_in_scope
@@ -110,7 +110,7 @@ Leverage the following when you have specific values that you need to define per
         environment=environment,
         repository_directory=repository_directory,
         item_type_in_scope=item_type_in_scope,
-        token_credential=token_credential,
+        token_credential=token_credential,  # or any other TokenCredential
     )
 
     # Publish all items defined in item_type_in_scope
@@ -162,7 +162,7 @@ Leverage the following when you have specific values that you need to define per
         environment=environment,
         repository_directory=repository_directory,
         item_type_in_scope=item_type_in_scope,
-        token_credential=token_credential,
+        token_credential=token_credential,  # or any other TokenCredential
     )
 
     # Publish all items defined in item_type_in_scope
@@ -208,7 +208,7 @@ Leverage the following when you want to pass in variables outside of the python 
         environment=environment,
         repository_directory=repository_directory,
         item_type_in_scope=item_type_in_scope,
-        token_credential=token_credential,
+        token_credential=token_credential,  # or any other TokenCredential
     )
 
     # Publish all items defined in item_type_in_scope
@@ -264,7 +264,7 @@ Leverage the following when you want to pass in variables outside of the python 
         environment=environment,
         repository_directory=repository_directory,
         item_type_in_scope=item_type_in_scope,
-        token_credential=token_credential,
+        token_credential=token_credential,  # or any other TokenCredential
     )
 
     # Publish all items defined in item_type_in_scope

--- a/docs/how_to/getting_started.md
+++ b/docs/how_to/getting_started.md
@@ -33,7 +33,7 @@ workspace = FabricWorkspace(
     environment="your-target-environment",
     repository_directory="your-repository-directory",
     item_type_in_scope=["Notebook", "DataPipeline", "Environment"],
-    token_credential=token_credential,
+    token_credential=token_credential,  # or any other TokenCredential
 )
 ```
 

--- a/docs/how_to/optional_feature.md
+++ b/docs/how_to/optional_feature.md
@@ -117,7 +117,7 @@ workspace = FabricWorkspace(
     workspace_id="your-workspace-id",
     repository_directory="/path/to/repo",
     item_type_in_scope=["Notebook", "DataPipeline"],
-    token_credential=token_credential,
+    token_credential=token_credential,  # or any other TokenCredential
 )
 
 changed = get_changed_items(workspace.repository_directory)

--- a/docs/how_to/parameterization.md
+++ b/docs/how_to/parameterization.md
@@ -14,8 +14,9 @@ token_credential = AzureCliCredential()
 workspace = FabricWorkspace(
     workspace_id="your-workspace-id",
     repository_directory="C:/dev/workspace",
+    environment="PROD",
     item_type_in_scope=["Notebook"],
-    token_credential=token_credential,
+    token_credential=token_credential,  # or any other TokenCredential
 )
 ```
 

--- a/docs/how_to/parameterization.md
+++ b/docs/how_to/parameterization.md
@@ -7,11 +7,15 @@ To handle environment-specific values committed to git, use a `parameter.yml` fi
 Example of parameter.yml location based on provided repository directory:
 
 ```python
+from azure.identity import AzureCliCredential
 from fabric_cicd import FabricWorkspace
+
+token_credential = AzureCliCredential()
 workspace = FabricWorkspace(
     workspace_id="your-workspace-id",
     repository_directory="C:/dev/workspace",
-    item_type_in_scope=["Notebook"]
+    item_type_in_scope=["Notebook"],
+    token_credential=token_credential,
 )
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,11 +31,11 @@ token_credential = AzureCliCredential()
 
 # Initialize the FabricWorkspace object with the required parameters
 target_workspace = FabricWorkspace(
-    workspace_id = "your-workspace-id",
-    environment = "your-target-environment",
-    repository_directory = "your-repository-directory",
-    item_type_in_scope = ["Notebook", "DataPipeline", "Environment"],
-    token_credential = token_credential,
+    workspace_id="your-workspace-id",
+    environment="your-target-environment",
+    repository_directory="your-repository-directory",
+    item_type_in_scope=["Notebook", "DataPipeline", "Environment"],
+    token_credential=token_credential,  # or any other TokenCredential
 )
 
 # Publish all items defined in item_type_in_scope

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,10 @@ pip install fabric-cicd
 ## Basic Example
 
 ```python
+from azure.identity import AzureCliCredential
 from fabric_cicd import FabricWorkspace, publish_all_items, unpublish_all_orphan_items
+
+token_credential = AzureCliCredential()
 
 # Initialize the FabricWorkspace object with the required parameters
 target_workspace = FabricWorkspace(
@@ -32,6 +35,7 @@ target_workspace = FabricWorkspace(
     environment = "your-target-environment",
     repository_directory = "your-repository-directory",
     item_type_in_scope = ["Notebook", "DataPipeline", "Environment"],
+    token_credential = token_credential,
 )
 
 # Publish all items defined in item_type_in_scope


### PR DESCRIPTION
This pull request updates the documentation to include the use of `AzureCliCredential` for authentication when initializing `FabricWorkspace`. The examples now demonstrate how to obtain and pass a `token_credential` to the `FabricWorkspace` constructor.

**Documentation updates for authentication:**

* Added import and initialization of `AzureCliCredential`, and updated example code to pass `token_credential` to the `FabricWorkspace` constructor in both `docs/how_to/parameterization.md` and `docs/index.md`. [[1]](diffhunk://#diff-9cdd02ee5f5219c5426160beb19ff83c624221fd6db2ac6f8bf923d6ebb6f0ffR10-R18) [[2]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R27-R38)
