### PR TITLE
warning still appears for users, but it won’t corrupt stdout output

### DIFF
--- a/.changes/unreleased/fix-version-notice-stdout.yaml
+++ b/.changes/unreleased/fix-version-notice-stdout.yaml
@@ -1,0 +1,6 @@
+kind: fixed
+body: Keep version update notices out of stdout so machine-readable command output is not corrupted
+time: 2026-04-27T12:00:00.0000000-04:00
+custom:
+  Issue: 944
+  Author: jjmerelo

--- a/src/fabric_cicd/_common/_check_utils.py
+++ b/src/fabric_cicd/_common/_check_utils.py
@@ -86,7 +86,7 @@ def check_version() -> None:
                 f"{Fore.CYAN}https://microsoft.github.io/fabric-cicd/latest/changelog/{Style.RESET_ALL}"
             )
 
-            print(msg)
+            logger.warning(msg)
     except Exception as e:
         # Silently handle errors, but log them if debug is needed
         logger.debug(f"Error checking version: {e}")

--- a/tests/test__check_utils.py
+++ b/tests/test__check_utils.py
@@ -2,9 +2,12 @@
 # Licensed under the MIT License.
 
 import json
+import logging
+from unittest.mock import MagicMock
 
 import pytest
 
+import fabric_cicd._common._check_utils as check_utils
 from fabric_cicd._common._check_utils import check_file_type, check_valid_json_content, check_valid_yaml_content
 
 
@@ -41,6 +44,24 @@ def test_check_file_type_binary(binary_file):
 
 def test_check_file_type_image(image_file):
     assert check_file_type(image_file) == "image"
+
+
+def test_check_version_logs_notice_without_stdout_pollution(monkeypatch, caplog, capsys):
+    """Regression test: version notices should not be written to stdout."""
+    monkeypatch.setattr(check_utils.constants, "VERSION", "0.0.0")
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"info": {"version": "9.9.9"}}
+
+    monkeypatch.setattr(check_utils.requests, "get", lambda *_args, **_kwargs: mock_response)
+    monkeypatch.setattr(check_utils, "parse_changelog", lambda: {})
+
+    with caplog.at_level(logging.WARNING, logger="fabric_cicd._common._check_utils"):
+        check_utils.check_version()
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert any("new release of fabric-cicd is available" in message for message in caplog.messages)
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes #944