### PR TITLE
Fixes #776 - Refactor the Environment deployment

### DIFF
--- a/.changes/unreleased/fixed-20260424-103120.yaml
+++ b/.changes/unreleased/fixed-20260424-103120.yaml
@@ -1,0 +1,8 @@
+kind: fixed
+body: Fix not setting Native Execution Engine and Live Pool settings when deploying Environments
+time: 2026-04-24T10:31:20.3568472+02:00
+custom:
+    Author: lassevalentini
+    AuthorLink: https://github.com/lassevalentini
+    Issue: "776"
+    IssueLink: https://github.com/microsoft/fabric-cicd/issues/776

--- a/.changes/unreleased/fixed-20260424-103120.yaml
+++ b/.changes/unreleased/fixed-20260424-103120.yaml
@@ -1,5 +1,5 @@
 kind: fixed
-body: Fix not setting Native Execution Engine and Live Pool settings when deploying Environments
+body: Fix incomplete Sparkcompute settings deployment by using the item definition API instead of the staging/sparkcompute API when deploying Environments
 time: 2026-04-24T10:31:20.3568472+02:00
 custom:
     Author: lassevalentini

--- a/docs/how_to/parameterization.md
+++ b/docs/how_to/parameterization.md
@@ -890,7 +890,7 @@ key_value_replace:
 
 #### `spark_pool` Parameterization Case
 
-**Case:** An Environment is attached to a Capacity level Custom Pool. The `instance_pool_id` in `Sparkcompute.yml` is workspace-specific and will differ between environments. The Spark Pool needs to be parameterized so fabric-cicd can resolve the correct pool in the target workspace. **Note:** Defining different names per environment is supported in the `parameter.yml` file. In the `Sparkcompute.yaml` file, the referenced instance_pool_id `72c68dbc-0775-4d59-909d-a47896f4573b` points to a capacity custom pool named `CapacityPool_Large` of pool type `Capacity` for the `PROD` environment.
+**Case:** An Environment is attached to a Capacity level Custom Pool. The `instance_pool_id` in `Sparkcompute.yml` is workspace-specific and will differ between environments. The Spark Pool needs to be parameterized so fabric-cicd can resolve the correct pool in the target workspace. **Note:** Defining different names per environment is supported in the `parameter.yml` file. In the `Sparkcompute.yml` file, the referenced instance_pool_id `72c68dbc-0775-4d59-909d-a47896f4573b` points to a capacity custom pool named `CapacityPool_Large` of pool type `Capacity` for the `PROD` environment.
 
 **Solution:** This replacement is managed by the `spark_pool` input in the `parameter.yml` file where fabric-cicd finds every instance of the `instance_pool_id` and replaces it with the pool type and pool name for the _specified_ environment file.
 

--- a/docs/how_to/parameterization.md
+++ b/docs/how_to/parameterization.md
@@ -131,7 +131,7 @@ key_value_replace:
 
 ### `spark_pool`
 
-Environments attached to custom spark pools need to be parameterized because the `instance_pool_id` in the `Sparkcompute.yml` file isn't supported in the create/update environment APIs. Provide the `instance_pool_id` value, and the pool `type` and `name` values as the `replace_value` for each environment (e.g., PPE, PROD). An optional field, `item_name`, can be used to filter the specific environment item where the replacement will occur.
+Environments attached to custom spark pools need to be parameterized because the `instance_pool_id` in the `Sparkcompute.yml` file is workspace-specific and must be mapped to the target workspace's pool. Provide the `instance_pool_id` value, and the pool `type` and `name` values as the `replace_value` for each environment (e.g., PPE, PROD). An optional field, `item_name`, can be used to filter the specific environment item where the replacement will occur.
 
 ```yaml
 spark_pool:
@@ -890,7 +890,7 @@ key_value_replace:
 
 #### `spark_pool` Parameterization Case
 
-**Case:** An Environment is attached to a Capacity level Custom Pool. Source control for Environments does not output the right fields necessary to deploy, so the Spark Pool needs to be parameterized. **Note:** Defining different names per environment is supported in the `parameter.yml` file. In the `Sparkcompute.yaml` file, the referenced instance_pool_id `72c68dbc-0775-4d59-909d-a47896f4573b` points to a capacity custom pool named `CapacityPool_Large` of pool type `Capacity` for the `PROD` environment.
+**Case:** An Environment is attached to a Capacity level Custom Pool. The `instance_pool_id` in `Sparkcompute.yml` is workspace-specific and will differ between environments. The Spark Pool needs to be parameterized so fabric-cicd can resolve the correct pool in the target workspace. **Note:** Defining different names per environment is supported in the `parameter.yml` file. In the `Sparkcompute.yaml` file, the referenced instance_pool_id `72c68dbc-0775-4d59-909d-a47896f4573b` points to a capacity custom pool named `CapacityPool_Large` of pool type `Capacity` for the `PROD` environment.
 
 **Solution:** This replacement is managed by the `spark_pool` input in the `parameter.yml` file where fabric-cicd finds every instance of the `instance_pool_id` and replaces it with the pool type and pool name for the _specified_ environment file.
 

--- a/src/fabric_cicd/_common/_exceptions.py
+++ b/src/fabric_cicd/_common/_exceptions.py
@@ -54,10 +54,6 @@ class FailedPublishedItemStatusError(BaseCustomError):
     pass
 
 
-class MissingFileError(BaseCustomError):
-    pass
-
-
 class PublishError(BaseCustomError):
     """Exception raised when one or more publish operations fail.
 

--- a/src/fabric_cicd/_items/_environment.py
+++ b/src/fabric_cicd/_items/_environment.py
@@ -10,6 +10,7 @@ import dpath
 import yaml
 
 from fabric_cicd import FabricWorkspace, constants
+from fabric_cicd._common._exceptions import InputError
 from fabric_cicd._common._fabric_endpoint import handle_retry
 from fabric_cicd._common._file import File
 from fabric_cicd._common._item import Item
@@ -131,7 +132,7 @@ def _resolve_pool_id(pools: list[dict], pool_name: str, pool_type: str) -> str:
         f"Could not resolve custom Spark pool: name='{pool_name}', type='{pool_type}'. "
         f"No matching pool found in the target workspace."
     )
-    raise Exception(msg)
+    raise InputError(msg, logger)
 
 
 def _check_environment_publish_state(fabric_workspace_obj: FabricWorkspace, initial_check: bool = False) -> None:

--- a/src/fabric_cicd/_items/_environment.py
+++ b/src/fabric_cicd/_items/_environment.py
@@ -85,10 +85,9 @@ def _replace_instance_pool_id(fabric_workspace_obj: FabricWorkspace, yaml_body: 
     """
     from fabric_cicd._parameter._utils import process_environment_key
 
-    pools = fabric_workspace_obj._get_workspace_pools()
-
     pool_id = yaml_body["instance_pool_id"]
     if "spark_pool" in fabric_workspace_obj.environment_parameter:
+        pools = fabric_workspace_obj._get_workspace_pools()
         parameter_dict = fabric_workspace_obj.environment_parameter["spark_pool"]
         for key in parameter_dict:
             instance_pool_id = key["instance_pool_id"]
@@ -121,7 +120,7 @@ def _resolve_pool_id(pools: list[dict], pool_name: str, pool_type: str) -> str:
         The matching pool GUID.
 
     Raises:
-        Exception: If no pool exists with the specified ``name`` and ``type``.
+        InputError: If no pool exists with the specified ``name`` and ``type``.
     """
     for pool in pools:
         if pool["name"] == pool_name and pool["type"] == pool_type:

--- a/src/fabric_cicd/_items/_environment.py
+++ b/src/fabric_cicd/_items/_environment.py
@@ -5,59 +5,129 @@
 
 import logging
 import re
-from pathlib import Path
 
 import dpath
 import yaml
 
 from fabric_cicd import FabricWorkspace, constants
-from fabric_cicd._common._exceptions import MissingFileError
 from fabric_cicd._common._fabric_endpoint import handle_retry
+from fabric_cicd._common._file import File
 from fabric_cicd._common._item import Item
 from fabric_cicd._items._base_publisher import ItemPublisher
-from fabric_cicd.constants import EXCLUDE_PATH_REGEX_MAPPING, ItemType
+from fabric_cicd.constants import ItemType
 
 logger = logging.getLogger(__name__)
 
 
-def set_environment_deployment_type(item: Item) -> bool:
+def _process_environment_file(fabric_workspace_obj: FabricWorkspace, item: Item, file_obj: File) -> str:
     """
-    Return True if this Environment deployment should be treated as "shell-only".
+    Process an Environment item file before it is included in the item definition payload.
 
-    Shell-only when `Setting/Sparkcompute.yml` exists and there are no other
-    non-`.platform` repository files under the environment root.
+    For ``Setting/Sparkcompute.yml`` this performs ``instance_pool_id`` replacement
+    using the ``spark_pool`` parameter configuration so that the correct pool
+    reference is embedded directly in the YAML sent to the Fabric Items API.
+
+    All other files are returned unchanged.
 
     Args:
+        fabric_workspace_obj: The FabricWorkspace object.
         item: The Item object representing the Environment.
+        file_obj: The File object being processed.
+
+    Returns:
+        The (possibly modified) file contents as a string.
     """
-    root = Path(item.path) if item.path else None
-    shell_only = False
+    if not (file_obj.file_path.name == "Sparkcompute.yml" and file_obj.file_path.parent.name == "Setting"):
+        return file_obj.contents
 
-    for file in item.item_files:
-        fp = file.file_path
+    contents = file_obj.contents
+    yaml_body = yaml.safe_load(contents)
+    if not isinstance(yaml_body, dict):
+        return contents
 
-        # Ignore .platform metadata file
-        if fp.name == ".platform":
-            continue
+    if "instance_pool_id" in yaml_body:
+        yaml_body = _replace_instance_pool_id(fabric_workspace_obj, yaml_body, item.name)
 
-        # Use the path relative to the environment root, or full path if root is None
-        try:
-            rel_path = fp.relative_to(root) if root else fp
-        except ValueError:
-            logger.debug(f"Path '{fp}' is not relative to root '{root}'; using full path")
-            rel_path = fp
+    return yaml.dump(yaml_body, default_flow_style=False, sort_keys=False)
 
-        path_parts = list(rel_path.parts)
-        # Detect Setting/Sparkcompute.yml (case-sensitive)
-        if len(path_parts) >= 2 and path_parts[0] == "Setting" and path_parts[1] == "Sparkcompute.yml":
-            shell_only = True
-            # Continue checking for other non-.platform files
-            continue
 
-        # Any other files -> not shell-only
-        return False
+def _replace_instance_pool_id(fabric_workspace_obj: FabricWorkspace, yaml_body: dict, item_name: str) -> dict:
+    """
+    Replace ``instance_pool_id`` in parsed Sparkcompute YAML with a resolved pool GUID.
 
-    return shell_only
+    This function reads ``spark_pool`` parameter mappings from
+    ``fabric_workspace_obj.environment_parameter`` and finds the entry whose
+    ``instance_pool_id`` matches the current YAML value. If an ``item_name`` is
+    provided in the mapping, it must match the current Environment item name;
+    otherwise, the mapping applies globally.
+
+    The mapped target pool ``name`` and ``type`` are then resolved against the
+    workspace custom pool list returned by the Fabric API, and the resolved pool
+    ``id`` is written back to ``yaml_body["instance_pool_id"]``.
+
+    Args:
+        fabric_workspace_obj: Workspace context containing environment, parameters,
+            and endpoint configuration.
+        yaml_body: Parsed contents of ``Setting/Sparkcompute.yml``.
+        item_name: Environment item name used for optional per-item mapping filters.
+
+    Returns:
+        The YAML dictionary, updated if a matching mapping is found; otherwise unchanged.
+    """
+    from fabric_cicd._parameter._utils import process_environment_key
+
+    # https://learn.microsoft.com/en-us/rest/api/fabric/spark/workspace-custom-pools/list-workspace-custom-pools
+    response = fabric_workspace_obj.endpoint.invoke(
+        method="GET",
+        url=f"{fabric_workspace_obj.base_api_url}/spark/pools",
+    )
+    pools = response["body"]["value"] or []
+
+    pool_id = yaml_body["instance_pool_id"]
+    if "spark_pool" in fabric_workspace_obj.environment_parameter:
+        parameter_dict = fabric_workspace_obj.environment_parameter["spark_pool"]
+        for key in parameter_dict:
+            instance_pool_id = key["instance_pool_id"]
+            replace_value = process_environment_key(fabric_workspace_obj.environment, key["replace_value"])
+            input_name = key.get("item_name")
+            if instance_pool_id == pool_id and (input_name == item_name or not input_name):
+                pool_config = replace_value[fabric_workspace_obj.environment]
+                resolved_id = _resolve_pool_id(
+                    pools,
+                    pool_name=pool_config["name"],
+                    pool_type=pool_config["type"],
+                )
+                yaml_body["instance_pool_id"] = resolved_id
+                break
+
+    return yaml_body
+
+
+def _resolve_pool_id(pools: list[dict], pool_name: str, pool_type: str) -> str:
+    """
+    Resolve a workspace custom Spark pool ID by pool ``name`` and ``type``.
+
+    Args:
+        pools: Pool objects from ``GET /spark/pools`` (expected to include
+            ``name``, ``type``, and ``id`` fields).
+        pool_name: Target pool display name.
+        pool_type: Target pool type (for example, ``"Capacity"`` or ``"Workspace"``).
+
+    Returns:
+        The matching pool GUID.
+
+    Raises:
+        Exception: If no pool exists with the specified ``name`` and ``type``.
+    """
+    for pool in pools:
+        if pool["name"] == pool_name and pool["type"] == pool_type:
+            return pool["id"]
+
+    msg = (
+        f"Could not resolve custom Spark pool: name='{pool_name}', type='{pool_type}'. "
+        f"No matching pool found in the target workspace."
+    )
+    raise Exception(msg)
 
 
 def _check_environment_publish_state(fabric_workspace_obj: FabricWorkspace, initial_check: bool = False) -> None:
@@ -130,25 +200,20 @@ def _check_environment_publish_state(fabric_workspace_obj: FabricWorkspace, init
         logger.info(f"{constants.INDENT}Published: {completed}")
 
 
-def _publish_environment_metadata(fabric_workspace_obj: FabricWorkspace, item_name: str) -> None:
+def _submit_environment_publish(fabric_workspace_obj: FabricWorkspace, item_name: str) -> None:
     """
-    Updates compute settings and publishes compute settings and libraries for a given environment item.
+    Submit a publish request for an Environment item.
 
-    This process involves two steps:
-    1. Check for ongoing publish.
-    2. Updating the compute settings.
-    3. Publish the updated settings and libraries.
+    Triggers the asynchronous publish of the environment's staged settings and
+    libraries. The publish state is monitored separately by the async publish
+    check hooks.
 
     Args:
         fabric_workspace_obj: The FabricWorkspace object.
-        item_name: Name of the environment item whose compute settings are to be published.
-        is_excluded: Flag indicating if Sparkcompute.yml was excluded from definition deployment.
+        item_name: Name of the environment item to publish.
     """
     item_type = ItemType.ENVIRONMENT.value
     item_guid = fabric_workspace_obj.repository_items[item_type][item_name].guid
-
-    # Update compute settings
-    _update_compute_settings(fabric_workspace_obj, item_guid, item_name)
 
     # Publish updated settings - compute settings and libraries (long-running operation)
     # https://learn.microsoft.com/en-us/rest/api/fabric/environment/items/publish-environment
@@ -160,93 +225,6 @@ def _publish_environment_metadata(fabric_workspace_obj: FabricWorkspace, item_na
     logger.info(f"{constants.INDENT}Publish Submitted for Environment '{item_name}'")
 
 
-def _update_compute_settings(fabric_workspace_obj: FabricWorkspace, item_guid: str, item_name: str) -> None:
-    """
-    Update spark compute settings.
-
-    Args:
-        fabric_workspace_obj: The FabricWorkspace object.
-        item_guid: The GUID of the environment item.
-        item_name: Name of the environment item.
-    """
-    from fabric_cicd._parameter._utils import process_environment_key
-
-    # Get Setting/Sparkcompute.yml content from repository
-    yaml_contents = None
-    item = fabric_workspace_obj.repository_items[ItemType.ENVIRONMENT.value][item_name]
-    item_files = item.item_files
-    for file in item_files:
-        if file.file_path.name == "Sparkcompute.yml" and file.file_path.parent.name == "Setting":
-            file.contents = fabric_workspace_obj._replace_parameters(file, item)
-            yaml_contents = file.contents
-            break
-
-    if not yaml_contents:
-        msg = (
-            "Required file missing: Setting/Sparkcompute.yml for Environment "
-            f"'{item_name}'. Each Environment must include Setting/Sparkcompute.yml."
-        )
-        raise MissingFileError(msg, logger)
-
-    yaml_body = yaml.safe_load(yaml_contents)
-
-    # Update instance pool settings if present
-    if "instance_pool_id" in yaml_body:
-        pool_id = yaml_body["instance_pool_id"]
-        if "spark_pool" in fabric_workspace_obj.environment_parameter:
-            parameter_dict = fabric_workspace_obj.environment_parameter["spark_pool"]
-            for key in parameter_dict:
-                instance_pool_id = key["instance_pool_id"]
-                replace_value = process_environment_key(fabric_workspace_obj.environment, key["replace_value"])
-                input_name = key.get("item_name")
-                if instance_pool_id == pool_id and (input_name == item_name or not input_name):
-                    # replace any found references with specified environment value
-                    yaml_body["instancePool"] = replace_value[fabric_workspace_obj.environment]
-                    del yaml_body["instance_pool_id"]
-
-    yaml_body = _convert_environment_compute_to_camel(fabric_workspace_obj, yaml_body)
-
-    # Update compute settings
-    # https://learn.microsoft.com/en-us/rest/api/fabric/environment/staging/update-spark-compute
-    fabric_workspace_obj.endpoint.invoke(
-        method="PATCH",
-        url=f"{fabric_workspace_obj.base_api_url}/environments/{item_guid}/staging/sparkcompute?beta=False",
-        body=yaml_body,
-    )
-    logger.info(f"{constants.INDENT}Updated Spark Settings")
-
-
-def _convert_environment_compute_to_camel(fabric_workspace_obj: FabricWorkspace, input_dict: dict) -> dict:
-    """
-    Converts dictionary keys stored in snake_case to camelCase, except for 'spark_conf'.
-
-    Args:
-        fabric_workspace_obj: The FabricWorkspace object.
-        input_dict: Dictionary with snake_case keys.
-    """
-    new_input_dict = {}
-
-    for key, value in input_dict.items():
-        if key == "spark_conf":
-            # Convert spark_conf dict to sparkProperties list of {key, value} objects
-            new_key = "sparkProperties"
-            # Ensure value is treated as a mapping
-            if isinstance(value, dict):
-                value = [{"key": k, "value": v} for k, v in value.items()]
-        else:
-            # Convert the key to camelCase
-            key_components = key.split("_")
-            new_key = key_components[0] + "".join(x.title() for x in key_components[1:])
-
-        # Recursively update dictionary values if they are dictionaries
-        if isinstance(value, dict):
-            value = _convert_environment_compute_to_camel(fabric_workspace_obj, value)
-
-        new_input_dict[new_key] = value
-
-    return new_input_dict
-
-
 class EnvironmentPublisher(ItemPublisher):
     """Publisher for Environment items."""
 
@@ -255,19 +233,15 @@ class EnvironmentPublisher(ItemPublisher):
 
     def publish_one(self, item_name: str, item: Item) -> None:
         """Publish a single Environment item."""
-        is_shell_only = set_environment_deployment_type(item)
-        logger.debug(f"Environment '{item_name}'; shell_only deployment: {is_shell_only}")
-
         self.fabric_workspace_obj._publish_item(
             item_name=item_name,
             item_type=self.item_type,
-            exclude_path=EXCLUDE_PATH_REGEX_MAPPING.get(self.item_type),
+            func_process_file=_process_environment_file,
             skip_publish_logging=True,
-            shell_only_publish=is_shell_only,
         )
         if item.skip_publish:
             return
-        _publish_environment_metadata(self.fabric_workspace_obj, item_name)
+        _submit_environment_publish(self.fabric_workspace_obj, item_name)
 
     def pre_publish_all(self) -> None:
         """Check environment publish state before publishing."""

--- a/src/fabric_cicd/_items/_environment.py
+++ b/src/fabric_cicd/_items/_environment.py
@@ -47,7 +47,7 @@ def _process_environment_file(
 
     contents = file_obj.contents
 
-    if not "instance_pool_id" in contents:
+    if "instance_pool_id" not in contents:
         return contents
 
     yaml_body = yaml.safe_load(contents)

--- a/src/fabric_cicd/_items/_environment.py
+++ b/src/fabric_cicd/_items/_environment.py
@@ -41,6 +41,10 @@ def _process_environment_file(fabric_workspace_obj: FabricWorkspace, item: Item,
         return file_obj.contents
 
     contents = file_obj.contents
+
+    if not "instance_pool_id" in contents:
+        return contents
+
     yaml_body = yaml.safe_load(contents)
     if not isinstance(yaml_body, dict):
         return contents

--- a/src/fabric_cicd/_items/_environment.py
+++ b/src/fabric_cicd/_items/_environment.py
@@ -20,7 +20,11 @@ from fabric_cicd.constants import ItemType
 logger = logging.getLogger(__name__)
 
 
-def _process_environment_file(fabric_workspace_obj: FabricWorkspace, item: Item, file_obj: File) -> str:
+def _process_environment_file(
+    fabric_workspace_obj: FabricWorkspace,
+    item: Item,
+    file_obj: File,
+) -> str:
     """
     Process an Environment item file before it is included in the item definition payload.
 
@@ -81,12 +85,7 @@ def _replace_instance_pool_id(fabric_workspace_obj: FabricWorkspace, yaml_body: 
     """
     from fabric_cicd._parameter._utils import process_environment_key
 
-    # https://learn.microsoft.com/en-us/rest/api/fabric/spark/workspace-custom-pools/list-workspace-custom-pools
-    response = fabric_workspace_obj.endpoint.invoke(
-        method="GET",
-        url=f"{fabric_workspace_obj.base_api_url}/spark/pools",
-    )
-    pools = response["body"]["value"] or []
+    pools = fabric_workspace_obj._get_workspace_pools()
 
     pool_id = yaml_body["instance_pool_id"]
     if "spark_pool" in fabric_workspace_obj.environment_parameter:

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -200,7 +200,6 @@ EXCLUDE_PATH_REGEX_MAPPING = {
     ItemType.REPORT.value: r".*\.pbi[/\\].*",
     ItemType.SEMANTIC_MODEL.value: r".*\.pbi[/\\].*",
     ItemType.EVENTHOUSE.value: r".*\.children[/\\].*",
-    ItemType.ENVIRONMENT.value: r"\Setting",
 }
 
 # API Format Mapping for item types that require specific API formats

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -141,6 +141,10 @@ class FabricWorkspace:
         # Initialize dataflow dependencies dictionary (used in dataflow item processing)
         self.dataflow_dependencies = {}
 
+        # Initialize workspace pools cache (used in Environment item processing)
+        self._workspace_pools_cache: Optional[list[dict]] = None
+        self._workspace_pools_cache_lock = threading.Lock()
+
         # Initialize cache for _get_item_attribute method
         self._item_attribute_cache = {}
         self._item_attribute_cache_lock = threading.Lock()
@@ -247,6 +251,25 @@ class FabricWorkspace:
         with self._item_attribute_cache_lock:
             self._item_attribute_cache[cache_key] = attribute_value
         return attribute_value
+
+    def _get_workspace_pools(self) -> list[dict]:
+        """Return the list of workspace custom Spark pools, fetching from the API on first call.
+
+        The result is cached so that subsequent calls during the same deployment
+        do not make additional API requests. Thread-safe via a lock.
+
+        Returns:
+            A list of pool dictionaries from the Fabric Spark custom-pools API.
+        """
+        with self._workspace_pools_cache_lock:
+            if self._workspace_pools_cache is None:
+                # https://learn.microsoft.com/en-us/rest/api/fabric/spark/custom-pools/list-workspace-custom-pools
+                response = self.endpoint.invoke(
+                    method="GET",
+                    url=f"{self.base_api_url}/spark/pools",
+                )
+                self._workspace_pools_cache = response["body"]["value"] or []
+            return self._workspace_pools_cache
 
     def _refresh_parameter_file(self) -> None:
         """Load parameters if file is present."""

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -269,14 +269,11 @@ class FabricWorkspace:
                     url=f"{self.base_api_url}/spark/pools",
                 )
 
-                try:
-                    pools = response["body"]["value"]
-                    if not isinstance(pools, list):
-                        raise TypeError
-                    self._workspace_pools_cache = pools
-                except (KeyError, TypeError):
+                pools = response.get("body", {}).get("value") if isinstance(response, dict) else None
+                if not isinstance(pools, list):
                     msg = f"Unexpected response from Spark pools API: expected 'body.value' to be a list. Response: {response}"
                     raise InputError(msg, logger)
+                self._workspace_pools_cache = pools
 
             return self._workspace_pools_cache
 

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -268,7 +268,16 @@ class FabricWorkspace:
                     method="GET",
                     url=f"{self.base_api_url}/spark/pools",
                 )
-                self._workspace_pools_cache = response["body"]["value"] or []
+
+                try:
+                    pools = response["body"]["value"]
+                    if not isinstance(pools, list):
+                        raise TypeError
+                    self._workspace_pools_cache = pools
+                except (KeyError, TypeError):
+                    msg = f"Unexpected response from Spark pools API: expected 'body.value' to be a list. Response: {response}"
+                    raise InputError(msg, logger)
+
             return self._workspace_pools_cache
 
     def _refresh_parameter_file(self) -> None:

--- a/tests/test_environment_publish.py
+++ b/tests/test_environment_publish.py
@@ -152,11 +152,17 @@ def test_process_environment_file_pool_no_match(tmp_path):
     sc = setting_dir / "Sparkcompute.yml"
     sc.write_text("instance_pool_id: unmatched-pool\n", encoding="utf-8")
 
+    class FakeEndpoint:
+        def invoke(self, _method=None, _url=None, **_kwargs):
+            return {"body": {"value": [{"id": "guid-other", "name": "OtherPool", "type": "Capacity"}]}}
+
     class FakeWS:
         environment = "DEV"
         environment_parameter: ClassVar[dict] = {
             "spark_pool": [{"instance_pool_id": "different-pool", "replace_value": {"DEV": "something"}}]
         }
+        base_api_url = "https://api.example/v1/workspaces/ws-id"
+        endpoint = FakeEndpoint()
 
     dummy = DummyFile(sc)
     result = env_module._process_environment_file(FakeWS(), DummyItem("EnvE", [sc]), dummy)
@@ -173,9 +179,15 @@ def test_process_environment_file_no_spark_pool_param(tmp_path):
     sc = setting_dir / "Sparkcompute.yml"
     sc.write_text("instance_pool_id: some-pool\n", encoding="utf-8")
 
+    class FakeEndpoint:
+        def invoke(self, _method=None, _url=None, **_kwargs):
+            return {"body": {"value": []}}
+
     class FakeWS:
         environment = "DEV"
         environment_parameter: ClassVar[dict] = {}
+        base_api_url = "https://api.example/v1/workspaces/ws-id"
+        endpoint = FakeEndpoint()
 
     dummy = DummyFile(sc)
     result = env_module._process_environment_file(FakeWS(), DummyItem("EnvF", [sc]), dummy)
@@ -185,40 +197,22 @@ def test_process_environment_file_no_spark_pool_param(tmp_path):
 
 def test_resolve_pool_id_success():
     """_resolve_pool_id returns the matching pool GUID from the API response."""
-
-    class FakeEndpoint:
-        def invoke(self, _method=None, _url=None, **_kwargs):
-            return {
-                "body": {
-                    "value": [
-                        {"id": "guid-cap", "name": "CapPool", "type": "Capacity"},
-                        {"id": "guid-ws", "name": "WsPool", "type": "Workspace"},
-                    ]
-                }
-            }
-
-    class FakeWS:
-        base_api_url = "https://api.example/v1/workspaces/ws-id"
-        endpoint = FakeEndpoint()
-
-    assert env_module._resolve_pool_id(FakeWS(), pool_name="CapPool", pool_type="Capacity") == "guid-cap"
-    assert env_module._resolve_pool_id(FakeWS(), pool_name="WsPool", pool_type="Workspace") == "guid-ws"
+    pools = [
+        {"id": "guid-cap", "name": "CapPool", "type": "Capacity"},
+        {"id": "guid-ws", "name": "WsPool", "type": "Workspace"},
+    ]
+    assert env_module._resolve_pool_id(pools, pool_name="CapPool", pool_type="Capacity") == "guid-cap"
+    assert env_module._resolve_pool_id(pools, pool_name="WsPool", pool_type="Workspace") == "guid-ws"
 
 
 def test_resolve_pool_id_not_found():
     """_resolve_pool_id raises when no matching pool is found."""
     import pytest
 
-    class FakeEndpoint:
-        def invoke(self, _method=None, _url=None, **_kwargs):
-            return {"body": {"value": [{"id": "guid-other", "name": "OtherPool", "type": "Capacity"}]}}
-
-    class FakeWS:
-        base_api_url = "https://api.example/v1/workspaces/ws-id"
-        endpoint = FakeEndpoint()
+    pools = [{"id": "guid-other", "name": "OtherPool", "type": "Capacity"}]
 
     with pytest.raises(Exception, match="Could not resolve custom Spark pool"):
-        env_module._resolve_pool_id(FakeWS(), pool_name="MissingPool", pool_type="Workspace")
+        env_module._resolve_pool_id(pools, pool_name="MissingPool", pool_type="Workspace")
 
 
 # ---------- Publisher integration tests ----------

--- a/tests/test_environment_publish.py
+++ b/tests/test_environment_publish.py
@@ -1,4 +1,7 @@
 from pathlib import Path
+from typing import ClassVar
+
+import yaml
 
 from fabric_cicd._items import _environment as env_module
 
@@ -35,68 +38,205 @@ class DummyItem:
         self.skip_publish = False
 
 
-def test_set_env_setting_only(tmp_path):
-    # Only Setting segment present
-    p = tmp_path / "EnvA" / "Setting" / "Sparkcompute.yml"
-    item = DummyItem("EnvA", [p])
-    assert env_module.set_environment_deployment_type(item) is True
+# ---------- func_process_file tests ----------
 
 
-def test_set_env_with_publiclibraries(tmp_path):
-    # Both Setting and Libraries present -> not shell-only
-    p1 = tmp_path / "EnvB" / "Setting" / "Sparkcompute.yml"
-    p2 = tmp_path / "EnvB" / "Libraries" / "PublicLibraries" / "lib.zip"
-    item = DummyItem("EnvB", [p1, p2])
-    assert env_module.set_environment_deployment_type(item) is False
+def test_process_environment_file_non_sparkcompute(tmp_path):
+    """Non-Sparkcompute files are returned unchanged."""
+    f = tmp_path / "EnvA" / "Libraries" / "lib.txt"
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text("original content", encoding="utf-8")
+
+    dummy = DummyFile(f)
+    result = env_module._process_environment_file(None, DummyItem("EnvA", [f]), dummy)
+    assert result == "original content"
 
 
-def test_set_env_with_customlibraries(tmp_path):
-    # CustomLibraries lives inside Libraries (standardized) -> counts as Libraries
-    p1 = tmp_path / "EnvC" / "Setting" / "Sparkcompute.yml"
-    p2 = tmp_path / "EnvC" / "Libraries" / "CustomLibraries" / "x.jar"
-    item = DummyItem("EnvC", [p1, p2])
-    assert env_module.set_environment_deployment_type(item) is False
+def test_process_environment_file_no_instance_pool(tmp_path):
+    """Sparkcompute.yml without instance_pool_id is returned as re-serialized YAML."""
+    env_dir = tmp_path / "EnvB"
+    setting_dir = env_dir / "Setting"
+    setting_dir.mkdir(parents=True, exist_ok=True)
+    sc = setting_dir / "Sparkcompute.yml"
+    sc.write_text("driver_cores: 8\ndriver_memory: 56g\n", encoding="utf-8")
+
+    dummy = DummyFile(sc)
+    result = env_module._process_environment_file(None, DummyItem("EnvB", [sc]), dummy)
+    parsed = yaml.safe_load(result)
+    assert parsed["driver_cores"] == 8
+    assert parsed["driver_memory"] == "56g"
+    assert "instance_pool_id" not in parsed
 
 
-def test_set_env_with_both_libraries(tmp_path):
-    # Environment contains Setting plus both Public and Custom libraries under Libraries
-    p1 = tmp_path / "EnvD" / "Setting" / "Sparkcompute.yml"
-    p2 = tmp_path / "EnvD" / "Libraries" / "PublicLibraries" / "lib.zip"
-    p3 = tmp_path / "EnvD" / "Libraries" / "CustomLibraries" / "custom.jar"
-    item = DummyItem("EnvD", [p1, p2, p3])
-    assert env_module.set_environment_deployment_type(item) is False
+def test_process_environment_file_replaces_instance_pool(tmp_path):
+    """Sparkcompute.yml with instance_pool_id is resolved to the target pool GUID via API."""
+    env_dir = tmp_path / "EnvC"
+    setting_dir = env_dir / "Setting"
+    setting_dir.mkdir(parents=True, exist_ok=True)
+    sc = setting_dir / "Sparkcompute.yml"
+    sc.write_text("instance_pool_id: pool-123\ndriver_cores: 4\n", encoding="utf-8")
+
+    class FakeEndpoint:
+        def invoke(self, method=None, url=None, **_kwargs):
+            if method == "GET" and url.endswith("/spark/pools"):
+                return {
+                    "body": {
+                        "value": [
+                            {"id": "resolved-guid-abc", "name": "MyPool", "type": "Capacity"},
+                            {"id": "other-guid", "name": "OtherPool", "type": "Workspace"},
+                        ]
+                    }
+                }
+            return {}
+
+    class FakeWS:
+        environment = "DEV"
+        environment_parameter: ClassVar[dict] = {
+            "spark_pool": [
+                {
+                    "instance_pool_id": "pool-123",
+                    "replace_value": {"DEV": {"type": "Capacity", "name": "MyPool"}},
+                }
+            ]
+        }
+        base_api_url = "https://api.example/v1/workspaces/ws-id"
+        endpoint = FakeEndpoint()
+
+    dummy = DummyFile(sc)
+    result = env_module._process_environment_file(FakeWS(), DummyItem("EnvC", [sc]), dummy)
+    parsed = yaml.safe_load(result)
+    assert parsed["instance_pool_id"] == "resolved-guid-abc"
+    assert "instance_pool" not in parsed
+    assert parsed["driver_cores"] == 4
 
 
-def test_set_env_with_empty_libraries_is_shell_only(tmp_path):
-    # Libraries folder exists but contains no files -> should be treated as shell-only
+def test_process_environment_file_pool_with_item_name_filter(tmp_path):
+    """instance_pool_id replacement respects the optional item_name filter."""
+    env_dir = tmp_path / "EnvD"
+    setting_dir = env_dir / "Setting"
+    setting_dir.mkdir(parents=True, exist_ok=True)
+    sc = setting_dir / "Sparkcompute.yml"
+    sc.write_text("instance_pool_id: pool-456\n", encoding="utf-8")
+
+    class FakeEndpoint:
+        def invoke(self, method=None, url=None, **_kwargs):
+            if method == "GET" and url.endswith("/spark/pools"):
+                return {"body": {"value": [{"id": "ws-pool-guid", "name": "WsPool", "type": "Workspace"}]}}
+            return {}
+
+    class FakeWS:
+        environment = "PROD"
+        environment_parameter: ClassVar[dict] = {
+            "spark_pool": [
+                {
+                    "instance_pool_id": "pool-456",
+                    "replace_value": {"PROD": {"type": "Workspace", "name": "WsPool"}},
+                    "item_name": "EnvD",
+                }
+            ]
+        }
+        base_api_url = "https://api.example/v1/workspaces/ws-id"
+        endpoint = FakeEndpoint()
+
+    dummy = DummyFile(sc)
+    result = env_module._process_environment_file(FakeWS(), DummyItem("EnvD", [sc]), dummy)
+    parsed = yaml.safe_load(result)
+    assert parsed["instance_pool_id"] == "ws-pool-guid"
+
+
+def test_process_environment_file_pool_no_match(tmp_path):
+    """When no spark_pool entry matches, instance_pool_id is left as-is."""
     env_dir = tmp_path / "EnvE"
-    (env_dir / "Setting").mkdir(parents=True, exist_ok=True)
-    (env_dir / "Libraries").mkdir(parents=True, exist_ok=True)  # empty libraries folder
+    setting_dir = env_dir / "Setting"
+    setting_dir.mkdir(parents=True, exist_ok=True)
+    sc = setting_dir / "Sparkcompute.yml"
+    sc.write_text("instance_pool_id: unmatched-pool\n", encoding="utf-8")
 
-    p_setting = env_dir / "Setting" / "Sparkcompute.yml"
-    # We don't need to actually write Sparkcompute.yml for this unit test, but
-    # create the path to reflect the layout and pass it to DummyItem
-    item = DummyItem("EnvE", [p_setting])
+    class FakeWS:
+        environment = "DEV"
+        environment_parameter: ClassVar[dict] = {
+            "spark_pool": [{"instance_pool_id": "different-pool", "replace_value": {"DEV": "something"}}]
+        }
 
-    assert env_module.set_environment_deployment_type(item) is True
+    dummy = DummyFile(sc)
+    result = env_module._process_environment_file(FakeWS(), DummyItem("EnvE", [sc]), dummy)
+    parsed = yaml.safe_load(result)
+    assert "instance_pool_id" in parsed
+    assert parsed["instance_pool_id"] == "unmatched-pool"
 
 
-def test_publish_environments_passes_shell_flag(tmp_path):
+def test_process_environment_file_no_spark_pool_param(tmp_path):
+    """When environment_parameter has no spark_pool, instance_pool_id is left as-is."""
+    env_dir = tmp_path / "EnvF"
+    setting_dir = env_dir / "Setting"
+    setting_dir.mkdir(parents=True, exist_ok=True)
+    sc = setting_dir / "Sparkcompute.yml"
+    sc.write_text("instance_pool_id: some-pool\n", encoding="utf-8")
+
+    class FakeWS:
+        environment = "DEV"
+        environment_parameter: ClassVar[dict] = {}
+
+    dummy = DummyFile(sc)
+    result = env_module._process_environment_file(FakeWS(), DummyItem("EnvF", [sc]), dummy)
+    parsed = yaml.safe_load(result)
+    assert parsed["instance_pool_id"] == "some-pool"
+
+
+def test_resolve_pool_id_success():
+    """_resolve_pool_id returns the matching pool GUID from the API response."""
+
+    class FakeEndpoint:
+        def invoke(self, _method=None, _url=None, **_kwargs):
+            return {
+                "body": {
+                    "value": [
+                        {"id": "guid-cap", "name": "CapPool", "type": "Capacity"},
+                        {"id": "guid-ws", "name": "WsPool", "type": "Workspace"},
+                    ]
+                }
+            }
+
+    class FakeWS:
+        base_api_url = "https://api.example/v1/workspaces/ws-id"
+        endpoint = FakeEndpoint()
+
+    assert env_module._resolve_pool_id(FakeWS(), pool_name="CapPool", pool_type="Capacity") == "guid-cap"
+    assert env_module._resolve_pool_id(FakeWS(), pool_name="WsPool", pool_type="Workspace") == "guid-ws"
+
+
+def test_resolve_pool_id_not_found():
+    """_resolve_pool_id raises when no matching pool is found."""
+    import pytest
+
+    class FakeEndpoint:
+        def invoke(self, _method=None, _url=None, **_kwargs):
+            return {"body": {"value": [{"id": "guid-other", "name": "OtherPool", "type": "Capacity"}]}}
+
+    class FakeWS:
+        base_api_url = "https://api.example/v1/workspaces/ws-id"
+        endpoint = FakeEndpoint()
+
+    with pytest.raises(Exception, match="Could not resolve custom Spark pool"):
+        env_module._resolve_pool_id(FakeWS(), pool_name="MissingPool", pool_type="Workspace")
+
+
+# ---------- Publisher integration tests ----------
+
+
+def test_publish_environments_passes_func_process_file(tmp_path):
     """
-    Ensure publish_environments computes shell-only and passes it to _publish_item.
-    We provide a fake workspace where _publish_item is intercepted and marks the
-    item as skipped so metadata publish is not attempted.
+    Ensure EnvironmentPublisher passes func_process_file to _publish_item
+    and no longer passes shell_only_publish or exclude_path.
     """
     captured = {}
 
     class FakeEndpoint:
         def invoke(self, *_args, **_kwargs):
-            # used by check_environment_publish_state and other calls
             return {"body": {"value": []}}
 
     class FakeWorkspace:
         def __init__(self):
-            # one environment with Setting only
             p = tmp_path / "EnvX" / "Setting" / "Sparkcompute.yml"
             self.repository_items = {"Environment": {"EnvX": DummyItem("EnvX", [p])}}
             self.publish_item_name_exclude_regex = None
@@ -108,63 +248,49 @@ def test_publish_environments_passes_shell_flag(tmp_path):
             self.responses = None
 
         def _publish_item(self, item_name, item_type, **kwargs):
-            # capture kwargs and mark item as skip_publish to stop metadata publishing
             captured["called_with"] = kwargs
             self.repository_items[item_type][item_name].skip_publish = True
 
     ws = FakeWorkspace()
     env_module.EnvironmentPublisher(ws).publish_all()
-    assert "shell_only_publish" in captured["called_with"]
-    assert captured["called_with"]["shell_only_publish"] is True
+    assert "func_process_file" in captured["called_with"]
+    assert captured["called_with"]["func_process_file"] is env_module._process_environment_file
+    assert "shell_only_publish" not in captured["called_with"]
+    assert "exclude_path" not in captured["called_with"]
 
 
-def test_convert_spark_conf_to_spark_properties():
-    inp = {"spark_conf": {"a": "1", "b": "2"}, "some_key": {"inner_key": "value"}}
-    out = env_module._convert_environment_compute_to_camel(None, inp)
-    assert "sparkProperties" in out
-    assert isinstance(out["sparkProperties"], list)
-    kvs = {p["key"]: p["value"] for p in out["sparkProperties"]}
-    assert kvs == {"a": "1", "b": "2"}
-
-
-# ---------- End-to-end style tests below ----------
+# ---------- End-to-end style tests ----------
 
 
 def test_end_to_end_environment_setting_only(tmp_path):
     """
     End-to-end style test for an Environment item that contains only Setting.
-    Verifies: create item (POST /items), update compute (PATCH sparkcompute), and
-    submit publish (POST /staging/publish).
+    Verifies: create item (POST /items) and submit publish (POST /staging/publish).
+    Sparkcompute.yml is included in the regular item definition—no separate
+    PATCH sparkcompute call is made.
     """
-    # Prepare workspace structure with a real Sparkcompute.yml file
     env_dir = tmp_path / "EnvEnd1"
     setting_dir = env_dir / "Setting"
     setting_dir.mkdir(parents=True, exist_ok=True)
     spark_yaml = setting_dir / "Sparkcompute.yml"
-    spark_yaml.write_text("instance_pool_id: demo_pool\n", encoding="utf-8")
+    spark_yaml.write_text("driver_cores: 4\n", encoding="utf-8")
 
-    # capture endpoint calls
     calls = []
 
     class FakeEndpoint:
         def invoke(self, method=None, url=None, body=None, **_kwargs):
             calls.append((method, url, body))
-            # Respond as the real endpoints would for these calls
             if method == "GET" and url.endswith("/environments/"):
                 return {"body": {"value": []}}
             if method == "POST" and url.endswith("/items"):
                 return {"body": {"id": "guid-123"}}
-            if method == "PATCH" and "sparkcompute" in url:
-                return {"status": 200}
             if method == "POST" and url.endswith("/staging/publish?beta=False"):
                 return {"status": 202}
-            # fallback
             return {}
 
     class FakeWorkspace:
         def __init__(self):
-            p = spark_yaml
-            self.repository_items = {"Environment": {"EnvEnd1": DummyItem("EnvEnd1", [p])}}
+            self.repository_items = {"Environment": {"EnvEnd1": DummyItem("EnvEnd1", [spark_yaml])}}
             self.publish_item_name_exclude_regex = None
             self.publish_folder_path_exclude_regex = None
             self.items_to_include = None
@@ -172,45 +298,28 @@ def test_end_to_end_environment_setting_only(tmp_path):
             self.endpoint = FakeEndpoint()
             self.repository_directory = tmp_path
             self.responses = None
-            # environment_parameter may be used by _update_compute_settings; keep empty
             self.environment_parameter = {}
 
-        def _publish_item(self, item_name, item_type, **kwargs):
-            # Simulate the create/update logic sufficiently for this test
+        def _publish_item(self, item_name, item_type, **_kwargs):
             item = self.repository_items[item_type][item_name]
-            kwargs.pop("shell_only_publish", None)
-            # If item not deployed yet, simulate creation
             if not item.guid:
                 resp = self.endpoint.invoke(method="POST", url=f"{self.base_api_url}/items", body={})
                 item.guid = resp["body"]["id"]
-            else:
-                # simulate update path (not needed for this test)
-                self.endpoint.invoke(
-                    method="POST",
-                    url=f"{self.base_api_url}/items/{item.guid}/updateDefinition?updateMetadata=True",
-                    body={},
-                )
-            # leave skip_publish False so metadata publishing runs
-
-        def _replace_parameters(self, file_obj, _item_obj):
-            # Return the file contents unchanged for testing
-            return file_obj.contents
 
     ws = FakeWorkspace()
     env_module.EnvironmentPublisher(ws).publish_all()
 
-    # Verify the sequence of important calls occurred in order
     urls = [c[1] for c in calls]
     assert any("/items" in u and u.endswith("/items") for u in urls), "Create item call missing"
-    assert any("staging/sparkcompute" in u for u in urls), "sparkcompute PATCH missing"
     assert any(u.endswith("/staging/publish?beta=False") for u in urls), "Publish submit missing"
+    assert not any("sparkcompute" in u for u in urls), "Unexpected sparkcompute PATCH call"
 
 
 def test_end_to_end_environment_with_libraries(tmp_path):
     """
     End-to-end style test for an Environment item that contains both Setting and
-    Libraries. Verifies that the flow performs create/update and still submits
-    publish and compute update.
+    Libraries. Verifies create/update flow and staging publish—no separate
+    PATCH sparkcompute call.
     """
     env_dir = tmp_path / "EnvEnd2"
     setting_dir = env_dir / "Setting"
@@ -218,7 +327,7 @@ def test_end_to_end_environment_with_libraries(tmp_path):
     setting_dir.mkdir(parents=True, exist_ok=True)
     libs_dir.mkdir(parents=True, exist_ok=True)
     spark_yaml = setting_dir / "Sparkcompute.yml"
-    spark_yaml.write_text("instance_pool_id: demo_pool\n", encoding="utf-8")
+    spark_yaml.write_text("driver_cores: 8\n", encoding="utf-8")
     (libs_dir / "lib.zip").write_text("dummy", encoding="utf-8")
 
     calls = []
@@ -231,8 +340,6 @@ def test_end_to_end_environment_with_libraries(tmp_path):
             if method == "POST" and url.endswith("/items"):
                 return {"body": {"id": "guid-456"}}
             if method == "POST" and "updateDefinition" in url:
-                return {"status": 200}
-            if method == "PATCH" and "sparkcompute" in url:
                 return {"status": 200}
             if method == "POST" and url.endswith("/staging/publish?beta=False"):
                 return {"status": 202}
@@ -252,23 +359,16 @@ def test_end_to_end_environment_with_libraries(tmp_path):
             self.responses = None
             self.environment_parameter = {}
 
-        def _publish_item(self, item_name, item_type, **kwargs):
+        def _publish_item(self, item_name, item_type, **_kwargs):
             item = self.repository_items[item_type][item_name]
-            kwargs.pop("shell_only_publish", None)
-            # For non-shell we simulate creation then update definition path
             if not item.guid:
                 resp = self.endpoint.invoke(method="POST", url=f"{self.base_api_url}/items", body={})
                 item.guid = resp["body"]["id"]
-            # simulate updateDefinition
             self.endpoint.invoke(
                 method="POST",
                 url=f"{self.base_api_url}/items/{item.guid}/updateDefinition?updateMetadata=True",
                 body={},
             )
-
-        def _replace_parameters(self, file_obj, _item_obj):
-            # Return the file contents unchanged for testing
-            return file_obj.contents
 
     ws = FakeWorkspace()
     env_module.EnvironmentPublisher(ws).publish_all()
@@ -276,39 +376,5 @@ def test_end_to_end_environment_with_libraries(tmp_path):
     urls = [c[1] for c in calls]
     assert any("/items" in u and u.endswith("/items") for u in urls), "Create item call missing"
     assert any("updateDefinition" in u for u in urls), "updateDefinition call missing"
-    assert any("staging/sparkcompute" in u for u in urls), "sparkcompute PATCH missing"
     assert any(u.endswith("/staging/publish?beta=False") for u in urls), "Publish submit missing"
-
-
-def test_update_compute_settings_replaces_instance_pool(tmp_path):
-    # create Sparkcompute.yml with instance_pool_id
-    env_dir = tmp_path / "EnvPool"
-    (env_dir / "Setting").mkdir(parents=True)
-    sc = env_dir / "Setting" / "Sparkcompute.yml"
-    sc.write_text("instance_pool_id: demo_pool\n", encoding="utf-8")
-
-    class FakeEndpoint:
-        def invoke(self, *_args, **_kwargs):
-            # return a benign response for PATCH
-            return {"status": 200}
-
-    class FakeWS:
-        def __init__(self):
-            self.environment = "DEV"
-            self.environment_parameter = {
-                "spark_pool": [{"instance_pool_id": "demo_pool", "replace_value": {"DEV": "resolved_pool"}}]
-            }
-            self.endpoint = FakeEndpoint()
-            self.base_api_url = "https://api.example"
-            # Create repository_items with Environment containing the item
-            self.repository_items = {"Environment": {"EnvPool": DummyItem("EnvPool", [sc])}}
-
-        def _replace_parameters(self, file_obj, _item_obj):
-            # Return the file contents unchanged for testing
-            return file_obj.contents
-
-    from fabric_cicd._items._environment import _update_compute_settings
-
-    # call _update_compute_settings with FakeWS, guid, name and assert it runs without error
-    ws_instance = FakeWS()
-    _update_compute_settings(ws_instance, "guid", "EnvPool")
+    assert not any("sparkcompute" in u for u in urls), "Unexpected sparkcompute PATCH call"

--- a/tests/test_environment_publish.py
+++ b/tests/test_environment_publish.py
@@ -76,19 +76,6 @@ def test_process_environment_file_replaces_instance_pool(tmp_path):
     sc = setting_dir / "Sparkcompute.yml"
     sc.write_text("instance_pool_id: pool-123\ndriver_cores: 4\n", encoding="utf-8")
 
-    class FakeEndpoint:
-        def invoke(self, method=None, url=None, **_kwargs):
-            if method == "GET" and url.endswith("/spark/pools"):
-                return {
-                    "body": {
-                        "value": [
-                            {"id": "resolved-guid-abc", "name": "MyPool", "type": "Capacity"},
-                            {"id": "other-guid", "name": "OtherPool", "type": "Workspace"},
-                        ]
-                    }
-                }
-            return {}
-
     class FakeWS:
         environment = "DEV"
         environment_parameter: ClassVar[dict] = {
@@ -100,7 +87,12 @@ def test_process_environment_file_replaces_instance_pool(tmp_path):
             ]
         }
         base_api_url = "https://api.example/v1/workspaces/ws-id"
-        endpoint = FakeEndpoint()
+
+        def _get_workspace_pools(self):
+            return [
+                {"id": "resolved-guid-abc", "name": "MyPool", "type": "Capacity"},
+                {"id": "other-guid", "name": "OtherPool", "type": "Workspace"},
+            ]
 
     dummy = DummyFile(sc)
     result = env_module._process_environment_file(FakeWS(), DummyItem("EnvC", [sc]), dummy)
@@ -118,12 +110,6 @@ def test_process_environment_file_pool_with_item_name_filter(tmp_path):
     sc = setting_dir / "Sparkcompute.yml"
     sc.write_text("instance_pool_id: pool-456\n", encoding="utf-8")
 
-    class FakeEndpoint:
-        def invoke(self, method=None, url=None, **_kwargs):
-            if method == "GET" and url.endswith("/spark/pools"):
-                return {"body": {"value": [{"id": "ws-pool-guid", "name": "WsPool", "type": "Workspace"}]}}
-            return {}
-
     class FakeWS:
         environment = "PROD"
         environment_parameter: ClassVar[dict] = {
@@ -136,7 +122,9 @@ def test_process_environment_file_pool_with_item_name_filter(tmp_path):
             ]
         }
         base_api_url = "https://api.example/v1/workspaces/ws-id"
-        endpoint = FakeEndpoint()
+
+        def _get_workspace_pools(self):
+            return [{"id": "ws-pool-guid", "name": "WsPool", "type": "Workspace"}]
 
     dummy = DummyFile(sc)
     result = env_module._process_environment_file(FakeWS(), DummyItem("EnvD", [sc]), dummy)
@@ -152,17 +140,15 @@ def test_process_environment_file_pool_no_match(tmp_path):
     sc = setting_dir / "Sparkcompute.yml"
     sc.write_text("instance_pool_id: unmatched-pool\n", encoding="utf-8")
 
-    class FakeEndpoint:
-        def invoke(self, _method=None, _url=None, **_kwargs):
-            return {"body": {"value": [{"id": "guid-other", "name": "OtherPool", "type": "Capacity"}]}}
-
     class FakeWS:
         environment = "DEV"
         environment_parameter: ClassVar[dict] = {
             "spark_pool": [{"instance_pool_id": "different-pool", "replace_value": {"DEV": "something"}}]
         }
         base_api_url = "https://api.example/v1/workspaces/ws-id"
-        endpoint = FakeEndpoint()
+
+        def _get_workspace_pools(self):
+            return [{"id": "guid-other", "name": "OtherPool", "type": "Capacity"}]
 
     dummy = DummyFile(sc)
     result = env_module._process_environment_file(FakeWS(), DummyItem("EnvE", [sc]), dummy)
@@ -179,15 +165,13 @@ def test_process_environment_file_no_spark_pool_param(tmp_path):
     sc = setting_dir / "Sparkcompute.yml"
     sc.write_text("instance_pool_id: some-pool\n", encoding="utf-8")
 
-    class FakeEndpoint:
-        def invoke(self, _method=None, _url=None, **_kwargs):
-            return {"body": {"value": []}}
-
     class FakeWS:
         environment = "DEV"
         environment_parameter: ClassVar[dict] = {}
         base_api_url = "https://api.example/v1/workspaces/ws-id"
-        endpoint = FakeEndpoint()
+
+        def _get_workspace_pools(self):
+            return []
 
     dummy = DummyFile(sc)
     result = env_module._process_environment_file(FakeWS(), DummyItem("EnvF", [sc]), dummy)
@@ -241,6 +225,9 @@ def test_publish_environments_passes_func_process_file(tmp_path):
             self.repository_directory = tmp_path
             self.responses = None
 
+        def _get_workspace_pools(self):
+            return []
+
         def _publish_item(self, item_name, item_type, **kwargs):
             captured["called_with"] = kwargs
             self.repository_items[item_type][item_name].skip_publish = True
@@ -293,6 +280,9 @@ def test_end_to_end_environment_setting_only(tmp_path):
             self.repository_directory = tmp_path
             self.responses = None
             self.environment_parameter = {}
+
+        def _get_workspace_pools(self):
+            return []
 
         def _publish_item(self, item_name, item_type, **_kwargs):
             item = self.repository_items[item_type][item_name]
@@ -352,6 +342,9 @@ def test_end_to_end_environment_with_libraries(tmp_path):
             self.repository_directory = tmp_path
             self.responses = None
             self.environment_parameter = {}
+
+        def _get_workspace_pools(self):
+            return []
 
         def _publish_item(self, item_name, item_type, **_kwargs):
             item = self.repository_items[item_type][item_name]

--- a/tests/test_git_diff_utils.py
+++ b/tests/test_git_diff_utils.py
@@ -138,9 +138,7 @@ class TestFindPlatformItem:
     def test_returns_none_when_metadata_missing_type(self, tmp_path):
         item_dir = tmp_path / "NoType"
         item_dir.mkdir()
-        (item_dir / ".platform").write_text(
-            '{"metadata": {"displayName": "NoType"}}', encoding="utf-8"
-        )
+        (item_dir / ".platform").write_text('{"metadata": {"displayName": "NoType"}}', encoding="utf-8")
         file_path = item_dir / "file.py"
         file_path.touch()
         result = git_utils._find_platform_item(file_path, tmp_path)

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1028,4 +1028,3 @@ class TestNotebookPublisher:
         assert mock_item.item_files[1].file_path.name == "notebook.py"
         assert mock_item.item_files[2].file_path.name == "readme.md"
         assert mock_item.item_files[3].file_path.name == "notebook.json"
-


### PR DESCRIPTION
## Description

Refactors the Environment deployment to deploy settings via the item definition instead of the Update Spark Compute REST API (workspaces/{workspaceId}/environments/{environmentId}/staging/sparkcompute).
Since the Update Spark Compute REST api is missing a lot of properties, this will enable deployment of these properties via fabric-cicd.
Most notable changes are allowing deployment of the enable_native_execution_engine and live_pool properties.

## Linked Issue
#776 