### PR TITLE
fix(_check_utils): add 2s HTTP timeout to startup version + changelog fetches

### DIFF
--- a/src/fabric_cicd/_common/_check_utils.py
+++ b/src/fabric_cicd/_common/_check_utils.py
@@ -19,6 +19,13 @@ from fabric_cicd._common._exceptions import FileTypeError
 
 logger = logging.getLogger(__name__)
 
+# Cap the upstream HTTP calls (changelog fetch, pypi version check) so a
+# slow/unreachable host can't block CLI startup. The previous code passed
+# no `timeout=` and inherited the OS socket default, which can stall for
+# minutes-to-hours under poor network conditions (corporate proxies, broken
+# IPv6 paths, transient pypi outages). See microsoft/fabric-cli#224.
+_HTTP_TIMEOUT_SECONDS = 2
+
 
 def parse_changelog() -> dict[str, list[str]]:
     """Parse the changelog file and return a dictionary of versions with their changes."""
@@ -26,7 +33,8 @@ def parse_changelog() -> dict[str, list[str]]:
 
     try:
         response = requests.get(
-            "https://raw.githubusercontent.com/microsoft/fabric-cicd/refs/heads/main/docs/changelog.md"
+            "https://raw.githubusercontent.com/microsoft/fabric-cicd/refs/heads/main/docs/changelog.md",
+            timeout=_HTTP_TIMEOUT_SECONDS,
         )
         if response.status_code == 200:
             content = response.text
@@ -59,7 +67,10 @@ def check_version() -> None:
     """Check the current version of the fabric-cicd package and compare it with the latest version."""
     try:
         current_version = constants.VERSION
-        response = requests.get("https://pypi.org/pypi/fabric-cicd/json")
+        response = requests.get(
+            "https://pypi.org/pypi/fabric-cicd/json",
+            timeout=_HTTP_TIMEOUT_SECONDS,
+        )
         latest_version = response.json()["info"]["version"]
 
         if version.parse(current_version) < version.parse(latest_version):


### PR DESCRIPTION
Reported in microsoft/fabric-cli#224 — every `fab` command was hanging
indefinitely at startup because import-time `fabric_cicd` work calls
out to pypi.org with no timeout.

## Why

`fabric_cicd/__init__.py` calls `check_version()`, which does:

```python
response = requests.get("https://pypi.org/pypi/fabric-cicd/json")
```

with no `timeout=` set, so the OS socket default applies. Under poor
network conditions (corporate proxies, broken IPv6 paths, slow DNS,
transient pypi outages) this stalls for minutes-to-hours and never
returns. The sister `parse_changelog()` request to
`raw.githubusercontent.com` had the same problem.

Both call sites are already wrapped in `try/except Exception`, so all
that's missing is the timeout — once that's set, a slow upstream just
becomes a quiet debug log and CLI startup proceeds normally.

## Fix

- New module-level constant `_HTTP_TIMEOUT_SECONDS = 2`.
- Pass it as `timeout=_HTTP_TIMEOUT_SECONDS` to both `requests.get(...)`
  calls in `_check_utils.py`.

This is the minimum possible change. The `fabric-cli` issue also
suggests moving the version check off the import path entirely
(deferred / async / TTY-gated) — that's a bigger restructure and a
separate PR if you'd like one.

## Verification

- `python -m py_compile src/fabric_cicd/_common/_check_utils.py` →
  clean.
- I confirmed the only ungated `requests.get` in this file is the
  changelog fetch already covered.