### PR TITLE
Closes #837 - docs: add GitHub examples to docs

### DIFF
--- a/.changes/unreleased/docs-20260524-112942.yaml
+++ b/.changes/unreleased/docs-20260524-112942.yaml
@@ -1,0 +1,8 @@
+kind: docs
+body: Add GitHub Actions workflow examples to documentation examples section
+time: 2026-05-24T11:29:42.743775+03:00
+custom:
+    Author: shirasassoon
+    AuthorLink: https://github.com/shirasassoon
+    Issue: "837"
+    IssueLink: https://github.com/microsoft/fabric-cicd/issues/837

--- a/docs/example/release_pipeline.md
+++ b/docs/example/release_pipeline.md
@@ -41,6 +41,8 @@ This approach uses the Azure CLI Credential Flow. An explicit credential method 
 
 === "GitHub"
 
+    This example uses [workload identity federation (OIDC)](https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation) for authentication. You must configure a federated identity credential on your Azure AD app registration that trusts GitHub's OIDC token issuer. See [Azure login with OIDC](https://github.com/azure/login#login-with-openid-connect-oidc-recommended) for setup instructions.
+
     ```yaml
     name: Deploy Fabric Workspace
 

--- a/docs/example/release_pipeline.md
+++ b/docs/example/release_pipeline.md
@@ -199,6 +199,8 @@ This approach is best suited for the Passed Arguments example found in the Deplo
 
 === "GitHub"
 
+    This example requires [GitHub Environments](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) named `dev` and `main` to be configured in your repository settings, with the appropriate secrets and variables defined in each environment.
+
     ```yaml
     name: Deploy Fabric Workspace
 
@@ -211,7 +213,7 @@ This approach is best suited for the Passed Arguments example found in the Deplo
     jobs:
       deploy:
         runs-on: ubuntu-latest
-        environment: ${{ github.ref_name }}  # Maps to GitHub Environment for secrets/variables
+        environment: ${{ github.ref_name }}  # Requires GitHub Environments named "dev" and "main"
         steps:
           - uses: actions/checkout@v4
           - uses: actions/setup-python@v5

--- a/docs/example/release_pipeline.md
+++ b/docs/example/release_pipeline.md
@@ -42,7 +42,33 @@ This approach uses the Azure CLI Credential Flow. An explicit credential method 
 === "GitHub"
 
     ```yaml
-    # Unconfirmed example at this time. The Azure DevOps example is a good starting point.
+    name: Deploy Fabric Workspace
+
+    on:
+      push:
+        branches:
+          - dev
+          - main
+
+    permissions:
+      id-token: write
+      contents: read
+
+    jobs:
+      deploy:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v4
+          - uses: actions/setup-python@v5
+            with:
+              python-version: '3.12'
+          - run: pip install fabric-cicd
+          - uses: azure/login@v2
+            with:
+              client-id: ${{ secrets.AZURE_CLIENT_ID }}
+              tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+              subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          - run: python .deploy/fabric_workspace.py
     ```
 
 ## Azure PowerShell
@@ -81,12 +107,6 @@ This approach uses the Azure PowerShell Credential Flow. An explicit credential 
                   pwsh: true
                   Inline: |
                     python -u $(System.DefaultWorkingDirectory)/.deploy/fabric_workspace.py
-    ```
-
-=== "GitHub"
-
-    ```yaml
-    # Unconfirmed example at this time. The Azure DevOps example is a good starting point.
     ```
 
 ## Variable Groups
@@ -143,5 +163,31 @@ This approach is best suited for the Passed Arguments example found in the Deplo
 === "GitHub"
 
     ```yaml
-    # Unconfirmed example at this time. The Azure DevOps example is a good starting point.
+    name: Deploy Fabric Workspace
+
+    on:
+      push:
+        branches:
+          - dev
+          - main
+
+    jobs:
+      deploy:
+        runs-on: ubuntu-latest
+        environment: ${{ github.ref_name }}  # Maps to GitHub Environment for secrets/variables
+        steps:
+          - uses: actions/checkout@v4
+          - uses: actions/setup-python@v5
+            with:
+              python-version: '3.12'
+          - run: pip install fabric-cicd
+          - run: |
+              python .deploy/fabric_workspace.py \
+                --spn_client_id ${{ secrets.SPN_CLIENT_ID }} \
+                --spn_client_secret ${{ secrets.SPN_CLIENT_SECRET }} \
+                --tenant_id ${{ secrets.TENANT_ID }} \
+                --workspace_id ${{ vars.WORKSPACE_ID }} \
+                --environment ${{ vars.ENVIRONMENT_NAME }} \
+                --repository_directory ${{ vars.REPOSITORY_DIRECTORY }} \
+                --item_types_in_scope "${{ vars.ITEMS_IN_SCOPE }}"
     ```

--- a/docs/example/release_pipeline.md
+++ b/docs/example/release_pipeline.md
@@ -111,6 +111,41 @@ This approach uses the Azure PowerShell Credential Flow. An explicit credential 
                     python -u $(System.DefaultWorkingDirectory)/.deploy/fabric_workspace.py
     ```
 
+=== "GitHub"
+
+    This example uses [workload identity federation (OIDC)](https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation) with `enable-AzPSSession: true` to set up an Azure PowerShell context. You must configure a federated identity credential on your Azure AD app registration. See [Azure login with OIDC](https://github.com/azure/login#login-with-openid-connect-oidc-recommended) for setup instructions.
+
+    ```yaml
+    name: Deploy Fabric Workspace
+
+    on:
+      push:
+        branches:
+          - dev
+          - main
+
+    permissions:
+      id-token: write
+      contents: read
+
+    jobs:
+      deploy:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v4
+          - uses: actions/setup-python@v5
+            with:
+              python-version: '3.12'
+          - run: pip install fabric-cicd
+          - uses: azure/login@v2
+            with:
+              client-id: ${{ secrets.AZURE_CLIENT_ID }}
+              tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+              subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+              enable-AzPSSession: true
+          - run: python .deploy/fabric_workspace.py
+    ```
+
 ## Variable Groups
 
 This approach is best suited for the Passed Arguments example found in the Deployment Variable Examples, in combination with a `ClientSecretCredential` as shown in the [Authentication Examples](authentication.md). The goal is to define values within the pipeline (or outside the pipeline in Azure DevOps variable groups) and inject them into the python script. Note this also doesn't take a dependency on PowerShell for those organizations or scenarios where PowerShell is not allowed.


### PR DESCRIPTION

This pull request updates the documentation to provide concrete GitHub Actions workflow examples for deploying a Fabric Workspace, replacing previous placeholders. These examples demonstrate authentication using both OIDC and explicit credentials, and clarify how to use GitHub Environments, secrets, and variables in deployment pipelines.

Documentation improvements:

* Added a detailed example GitHub Actions workflow using workload identity federation (OIDC) for Azure authentication, including setup instructions and required permissions. (`docs/example/release_pipeline.md`)
* Replaced unconfirmed/placeholder GitHub Actions YAML examples with fully specified workflows for both Azure CLI and PowerShell credential flows, showing how to use secrets and variables for deployment. (`docs/example/release_pipeline.md`) [[1]](diffhunk://#diff-2deadb2667ebc63b98d3526d833f69085174d31628b87c40e327bd80e5c55061R44-R73) [[2]](diffhunk://#diff-2deadb2667ebc63b98d3526d833f69085174d31628b87c40e327bd80e5c55061L86-L91) [[3]](diffhunk://#diff-2deadb2667ebc63b98d3526d833f69085174d31628b87c40e327bd80e5c55061L146-R194)

Changelog update:

* Added a changelog entry documenting the addition of GitHub Actions workflow examples to the documentation. (`.changes/unreleased/docs-20260524-112942.yaml`)