### PR TITLE
Closes #929 Add case insensitive option for find_replace

### DIFF
--- a/.changes/unreleased/added-20260603-102604.yaml
+++ b/.changes/unreleased/added-20260603-102604.yaml
@@ -1,5 +1,5 @@
 kind: added
-body: Support case-insensitive matching option in ``find_replace`` parameter
+body: Support case-insensitive matching option in `find_replace` parameter
 time: 2026-06-03T10:26:04.0288657+03:00
 custom:
     Author: shirasassoon

--- a/.changes/unreleased/added-20260603-102604.yaml
+++ b/.changes/unreleased/added-20260603-102604.yaml
@@ -1,0 +1,8 @@
+kind: added
+body: Support case-insensitive matching option in ``find_replace`` parameter
+time: 2026-06-03T10:26:04.0288657+03:00
+custom:
+    Author: shirasassoon
+    AuthorLink: https://github.com/shirasassoon
+    Issue: "929"
+    IssueLink: https://github.com/microsoft/fabric-cicd/issues/929

--- a/docs/how_to/parameterization.md
+++ b/docs/how_to/parameterization.md
@@ -72,7 +72,7 @@ Raise a [feature request](https://github.com/microsoft/fabric-cicd/issues/new?te
 
 ### `find_replace`
 
-For generic find-and-replace operations. This will replace every instance of a specified string in every file. Specify the `find_value` and the `replace_value` for each environment (e.g., PPE, PROD). Optional fields, including `item_type`, `item_name`, and `file_path`, can be used as file filters for more fine-grained control over where the replacement occurs. The `is_regex` field can be added and set to `"true"` to enable regex pattern matching for the `find_value`.
+For generic find-and-replace operations. This will replace every instance of a specified string in every file. Specify the `find_value` and the `replace_value` for each environment (e.g., PPE, PROD). Optional fields, including `item_type`, `item_name`, and `file_path`, can be used as file filters for more fine-grained control over where the replacement occurs. The `is_regex` field can be added and set to `"true"` to enable regex pattern matching for the `find_value`. The `ignore_case` field can be added and set to `"true"` to enable case-insensitive matching for the `find_value`.
 
 Note: A common use case for this function is to replace values in text based file types like notebooks.
 
@@ -86,6 +86,8 @@ find_replace:
       # Optional fields
       # Set to "true" to treat find_value as a regex pattern
       is_regex: "<true|True>"
+      # Set to "true" to enable case-insensitive matching for find_value
+      ignore_case: "<true|True>"
       # Filter values must be a string or array of strings
       item_type: <item-type-filter-value>
       item_name: <item-name-filter-value>
@@ -343,7 +345,37 @@ When optional fields are omitted or left empty, only basic parameterization func
 **Important:**
 
 - String input values should be wrapped in quotes. Remember to escape special characters, such as **\\** in `file_path` inputs.
-- `is_regex` and filter fields can be used in the same parameter configuration.
+- `is_regex`, `ignore_case`, and filter fields can be used in the same parameter configuration.
+
+### Case-Insensitive Matching
+
+#### `ignore_case`
+
+- Only applicable to the `find_replace` parameter.
+- Include `ignore_case` field to enable case-insensitive matching for the `find_value`.
+- When the `ignore_case` field is set to the **string** value `"true"` or `"True"` (case-insensitive), case-insensitive matching is enabled.
+- Works with both literal string and regex `find_value` patterns:
+    - **Literal string:** Matches and replaces all occurrences of the `find_value` regardless of casing in the file content (e.g., `"MyServer"` matches `"myserver"`, `"MYSERVER"`, etc.).
+    - **Regex pattern:** Compiles the regex with the case-insensitive flag, allowing the pattern to match regardless of character casing.
+- **Note:** The `replace_value` is always inserted literally as-is — it does not adapt to the casing of the matched text.
+
+```yaml
+find_replace:
+    # Case-insensitive literal string match
+    - find_value: "my-dev-server"
+      replace_value:
+          PPE: "my-ppe-server"
+          PROD: "my-prod-server"
+      ignore_case: "true"
+
+    # Case-insensitive regex match
+    - find_value: server_name=\"([^\"]+)\"
+      replace_value:
+          PPE: "ppe-server.database.windows.net"
+          PROD: "prod-server.database.windows.net"
+      is_regex: "true"
+      ignore_case: "true"
+```
 
 ### Regex Pattern Match
 

--- a/src/fabric_cicd/_parameter/_parameter.py
+++ b/src/fabric_cicd/_parameter/_parameter.py
@@ -29,7 +29,7 @@ class Parameter:
     PARAMETER_KEYS: ClassVar[dict] = {
         "find_replace": {
             "minimum": {"find_value", "replace_value"},
-            "maximum": {"find_value", "replace_value", "is_regex", "item_type", "item_name", "file_path"},
+            "maximum": {"find_value", "replace_value", "is_regex", "ignore_case", "item_type", "item_name", "file_path"},
         },
         "spark_pool": {
             "minimum": {"instance_pool_id", "replace_value"},

--- a/src/fabric_cicd/_parameter/_parameter.py
+++ b/src/fabric_cicd/_parameter/_parameter.py
@@ -709,9 +709,25 @@ class Parameter:
 
         # Validate find_value is a valid regex if is_regex is set to true
         if param_name == "find_replace":
+            # Validate is_regex type if present
+            if param_dict.get("is_regex") is not None:
+                is_valid, msg = self._validate_data_type(
+                    param_dict["is_regex"], "string", "is_regex", param_name
+                )
+                if not is_valid:
+                    return False, msg
+
             is_valid, msg = self._validate_find_regex(param_name, param_dict)
             if not is_valid:
                 return False, msg
+
+            # Validate ignore_case type if present
+            if param_dict.get("ignore_case") is not None:
+                is_valid, msg = self._validate_data_type(
+                    param_dict["ignore_case"], "string", "ignore_case", param_name
+                )
+                if not is_valid:
+                    return False, msg
 
         if param_name == "key_value_replace":
             is_valid, msg = self._validate_key_value_find_key(param_dict)

--- a/src/fabric_cicd/_parameter/_utils.py
+++ b/src/fabric_cicd/_parameter/_utils.py
@@ -81,18 +81,21 @@ def extract_find_value(param_dict: dict, file_content: str, filter_match: bool) 
         - 'pattern': The find pattern (original string or regex pattern)
         - 'is_regex': Whether this is a regex pattern
         - 'has_matches': Whether any matches were found
+        - 'ignore_case': Whether case-insensitive matching is enabled
     """
     find_value = param_dict.get("find_value")
     is_regex = param_dict.get("is_regex", "").lower() == "true"
+    ignore_case = param_dict.get("ignore_case", "").lower() == "true"
+    flags = re.IGNORECASE if ignore_case else 0
 
     # No find value -> nothing to do
     if not find_value:
-        return {"pattern": "", "is_regex": False, "has_matches": False}
+        return {"pattern": "", "is_regex": False, "has_matches": False, "ignore_case": ignore_case}
 
     # Regex find_value
     if is_regex:
         try:
-            compiled = re.compile(find_value)
+            compiled = re.compile(find_value, flags)
         except re.error as re_err:
             msg = f"Invalid regex '{find_value}': {re_err}"
             raise InputError(msg, logger) from re_err
@@ -102,18 +105,21 @@ def extract_find_value(param_dict: dict, file_content: str, filter_match: bool) 
 
         # If file excluded by filters, do not search — return no-match but keep validation
         if not filter_match:
-            return {"pattern": find_value, "is_regex": True, "has_matches": False}
+            return {"pattern": find_value, "is_regex": True, "has_matches": False, "ignore_case": ignore_case}
 
         matches = list(re.finditer(compiled, file_content))
         _validate_regex_pattern(matches, find_value)
 
-        return {"pattern": find_value, "is_regex": True, "has_matches": bool(matches)}
+        return {"pattern": find_value, "is_regex": True, "has_matches": bool(matches), "ignore_case": ignore_case}
 
     # Non-regex find_value
     if not filter_match:
-        return {"pattern": find_value, "is_regex": False, "has_matches": False}
+        return {"pattern": find_value, "is_regex": False, "has_matches": False, "ignore_case": ignore_case}
 
-    return {"pattern": find_value, "is_regex": False, "has_matches": find_value in file_content}
+    if ignore_case:
+        return {"pattern": find_value, "is_regex": False, "has_matches": find_value.lower() in file_content.lower(), "ignore_case": ignore_case}
+
+    return {"pattern": find_value, "is_regex": False, "has_matches": find_value in file_content, "ignore_case": ignore_case}
 
 
 def extract_replace_value(workspace_obj: FabricWorkspace, replace_value: str, get_dataflow_name: bool = False) -> str:

--- a/src/fabric_cicd/_parameter/_utils.py
+++ b/src/fabric_cicd/_parameter/_utils.py
@@ -84,8 +84,8 @@ def extract_find_value(param_dict: dict, file_content: str, filter_match: bool) 
         - 'ignore_case': Whether case-insensitive matching is enabled
     """
     find_value = param_dict.get("find_value")
-    is_regex = param_dict.get("is_regex", "").lower() == "true"
-    ignore_case = param_dict.get("ignore_case", "").lower() == "true"
+    is_regex = str(param_dict.get("is_regex", "")).lower() == "true"
+    ignore_case = str(param_dict.get("ignore_case", "")).lower() == "true"
     flags = re.IGNORECASE if ignore_case else 0
 
     # No find value -> nothing to do

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -538,6 +538,8 @@ class FabricWorkspace:
                     if replace_value:
                         pattern = find_info["pattern"]
                         is_regex = find_info["is_regex"]
+                        ignore_case = find_info["ignore_case"]
+                        flags = re.IGNORECASE if ignore_case else 0
 
                         if is_regex:
                             # For regex patterns, use re.sub with lambda to replace only the captured group
@@ -552,13 +554,17 @@ class FabricWorkspace:
                                     + match.group(0)[match.end(1) - match.start(0) :]
                                 ),
                                 raw_file,
+                                flags=flags,
                             )
                             logger.debug(
                                 f"Replacing regex pattern '{pattern}' captured group with '{replace_value}' in {item_name}.{item_type}"
                             )
                         else:
-                            # For non-regex matches, replace as before
-                            raw_file = raw_file.replace(pattern, replace_value)
+                            # For non-regex matches, use re.sub when case-insensitive, otherwise plain replace
+                            if ignore_case:
+                                raw_file = re.sub(re.escape(pattern), replace_value, raw_file, flags=re.IGNORECASE)
+                            else:
+                                raw_file = raw_file.replace(pattern, replace_value)
                             logger.debug(f"Replacing '{pattern}' with '{replace_value}' in {item_name}.{item_type}")
 
         return raw_file

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -562,7 +562,12 @@ class FabricWorkspace:
                         else:
                             # For non-regex matches, use re.sub when case-insensitive, otherwise plain replace
                             if ignore_case:
-                                raw_file = re.sub(re.escape(pattern), replace_value, raw_file, flags=re.IGNORECASE)
+                                raw_file = re.sub(
+                                    re.escape(pattern),
+                                    lambda _match, repl=replace_value: repl,
+                                    raw_file,
+                                    flags=re.IGNORECASE,
+                                )
                             else:
                                 raw_file = raw_file.replace(pattern, replace_value)
                             logger.debug(f"Replacing '{pattern}' with '{replace_value}' in {item_name}.{item_type}")

--- a/tests/test_fabric_workspace.py
+++ b/tests/test_fabric_workspace.py
@@ -601,6 +601,91 @@ find_replace:
     assert "ppe-replacement-value" in replaced_content_with_env, "Replacement should occur with matching environment"
 
 
+def test_environment_parameter_replacement_ignore_case(patched_fabric_workspace, temp_workspace_dir, valid_workspace_id):
+    """Test that find_replace with ignore_case performs case-insensitive replacement."""
+    parameter_content = """
+find_replace:
+    - find_value: "MyDevServer"
+      replace_value:
+        PPE: "my-ppe-server"
+        PROD: "my-prod-server"
+      ignore_case: "true"
+"""
+
+    notebook_dir = temp_workspace_dir / "Test Notebook.Notebook"
+    notebook_dir.mkdir(parents=True)
+
+    # Content has different casing than find_value
+    notebook_content = 'server = "MYDEVSERVER"\nbackup = "mydevserver"'
+
+    (temp_workspace_dir / "parameter.yml").write_text(parameter_content)
+    (notebook_dir / "notebook-content.py").write_text(notebook_content)
+
+    from fabric_cicd._common._file import File
+    from fabric_cicd._common._item import Item
+
+    with patch.object(FabricWorkspace, "_refresh_repository_items"):
+        workspace = patched_fabric_workspace(
+            workspace_id=valid_workspace_id,
+            repository_directory=str(temp_workspace_dir),
+            item_type_in_scope=["Notebook"],
+            environment="PPE",
+        )
+
+    test_item = Item(type="Notebook", name="Test Notebook", description="", guid="test-guid", path=notebook_dir)
+    test_file = File(item_path=notebook_dir, file_path=notebook_dir / "notebook-content.py")
+
+    result = workspace._replace_parameters(test_file, test_item)
+
+    # Both case variants should be replaced
+    assert "MYDEVSERVER" not in result
+    assert "mydevserver" not in result
+    assert result.count("my-ppe-server") == 2
+
+
+def test_environment_parameter_replacement_ignore_case_regex(
+    patched_fabric_workspace, temp_workspace_dir, valid_workspace_id
+):
+    """Test that find_replace with ignore_case and is_regex performs case-insensitive regex replacement."""
+    parameter_content = """
+find_replace:
+    - find_value: server_name="([^"]+)"
+      replace_value:
+        PPE: "ppe-server.database.windows.net"
+      is_regex: "true"
+      ignore_case: "true"
+"""
+
+    notebook_dir = temp_workspace_dir / "Test Notebook.Notebook"
+    notebook_dir.mkdir(parents=True)
+
+    # Content has different casing than regex pattern
+    notebook_content = 'SERVER_NAME="dev-server.database.windows.net"'
+
+    (temp_workspace_dir / "parameter.yml").write_text(parameter_content)
+    (notebook_dir / "notebook-content.py").write_text(notebook_content)
+
+    from fabric_cicd._common._file import File
+    from fabric_cicd._common._item import Item
+
+    with patch.object(FabricWorkspace, "_refresh_repository_items"):
+        workspace = patched_fabric_workspace(
+            workspace_id=valid_workspace_id,
+            repository_directory=str(temp_workspace_dir),
+            item_type_in_scope=["Notebook"],
+            environment="PPE",
+        )
+
+    test_item = Item(type="Notebook", name="Test Notebook", description="", guid="test-guid", path=notebook_dir)
+    test_file = File(item_path=notebook_dir, file_path=notebook_dir / "notebook-content.py")
+
+    result = workspace._replace_parameters(test_file, test_item)
+
+    # Regex captured group should be replaced, surrounding text preserved
+    assert "dev-server.database.windows.net" not in result
+    assert 'SERVER_NAME="ppe-server.database.windows.net"' in result
+
+
 def test_empty_logical_id_validation(temp_workspace_dir, patched_fabric_workspace, valid_workspace_id):
     """Test that empty logical IDs raise a ParsingError during repository refresh."""
     from fabric_cicd._common._exceptions import ParsingError

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -213,6 +213,24 @@ find_replace:
       item_type: "Notebook"
 """
 
+SAMPLE_PARAMETER_INVALID_IS_REGEX_FALSE = """
+find_replace:
+    - find_value: "some_value"
+      replace_value:
+          PPE: "ppe_value"
+          PROD: "prod_value"
+      is_regex: False
+"""
+
+SAMPLE_PARAMETER_INVALID_IGNORE_CASE = """
+find_replace:
+    - find_value: "some_value"
+      replace_value:
+          PPE: "ppe_value"
+          PROD: "prod_value"
+      ignore_case: True
+"""
+
 SAMPLE_PARAMETER_ALL_ENV = """
 find_replace:
     # Required Fields 
@@ -354,6 +372,12 @@ def repository_directory(tmp_path):
 
     invalid_parameter_file_path8 = workspace_dir / "invalid_is_regex_parameter.yml"
     invalid_parameter_file_path8.write_text(SAMPLE_PARAMETER_INVALID_IS_REGEX)
+
+    invalid_parameter_file_path9 = workspace_dir / "invalid_ignore_case_parameter.yml"
+    invalid_parameter_file_path9.write_text(SAMPLE_PARAMETER_INVALID_IGNORE_CASE)
+
+    invalid_parameter_file_path10 = workspace_dir / "invalid_is_regex_false_parameter.yml"
+    invalid_parameter_file_path10.write_text(SAMPLE_PARAMETER_INVALID_IS_REGEX_FALSE)
 
     # Create duplicate keys parameter files
     duplicate_keys_file = workspace_dir / "duplicate_keys_parameter.yml"
@@ -1195,6 +1219,8 @@ def test_validate_item_name_with_accented_characters(repository_directory, item_
         ("invalid_yaml_struc_parameter.yml", False, "invalid load"),
         ("invalid_yaml_char_parameter.yml", False, "invalid load"),
         ("invalid_is_regex_parameter.yml", False, "invalid data type"),
+        ("invalid_is_regex_false_parameter.yml", False, "invalid data type"),
+        ("invalid_ignore_case_parameter.yml", False, "invalid data type"),
     ],
 )
 def test_validate_invalid_parameters(
@@ -1289,6 +1315,45 @@ def test_validate_invalid_parameters(
         assert param_obj._validate_parameter("find_replace") == (
             result,
             constants.PARAMETER_MSGS[msg].format("is_regex", "string", "find_replace"),
+        )
+
+    # Invalid is_regex value (False boolean) in find_replace parameter
+    if param_file_name == "invalid_is_regex_false_parameter.yml":
+        param_obj.environment_parameter = {
+            "find_replace": [
+                {
+                    "find_value": "some_value",
+                    "replace_value": {
+                        "PPE": "ppe_value",
+                        "PROD": "prod_value",
+                    },
+                    "is_regex": False,  # This is a boolean, not a string
+                }
+            ]
+        }
+        assert param_obj._validate_parameter("find_replace") == (
+            result,
+            constants.PARAMETER_MSGS[msg].format("is_regex", "string", "find_replace"),
+        )
+
+    # Invalid ignore_case value in find_replace parameter
+    if param_file_name == "invalid_ignore_case_parameter.yml":
+        # Mock the environment_parameter to have the invalid ignore_case (boolean instead of string)
+        param_obj.environment_parameter = {
+            "find_replace": [
+                {
+                    "find_value": "some_value",
+                    "replace_value": {
+                        "PPE": "ppe_value",
+                        "PROD": "prod_value",
+                    },
+                    "ignore_case": True,  # This is a boolean, not a string
+                }
+            ]
+        }
+        assert param_obj._validate_parameter("find_replace") == (
+            result,
+            constants.PARAMETER_MSGS[msg].format("ignore_case", "string", "find_replace"),
         )
 
 

--- a/tests/test_parameter_utils.py
+++ b/tests/test_parameter_utils.py
@@ -128,9 +128,9 @@ class TestParameterUtilities:
         """Tests extract_find_value with string."""
         # Test with plain text
         param_dict = {"find_value": "test-value"}
-        expected = {"pattern": "test-value", "is_regex": False, "has_matches": True}
+        expected = {"pattern": "test-value", "is_regex": False, "has_matches": True, "ignore_case": False}
         assert extract_find_value(param_dict, "content with test-value", True) == expected
-        expected_no_match = {"pattern": "test-value", "is_regex": False, "has_matches": False}
+        expected_no_match = {"pattern": "test-value", "is_regex": False, "has_matches": False, "ignore_case": False}
         assert extract_find_value(param_dict, "unrelated content", True) == expected_no_match
 
     def test_extract_find_value_valid_regex(self):
@@ -138,13 +138,13 @@ class TestParameterUtilities:
         param_dict = {"find_value": "id=([\\w-]+)", "is_regex": "true"}
 
         # Test with regex
-        expected = {"pattern": "id=([\\w-]+)", "is_regex": True, "has_matches": True}
+        expected = {"pattern": "id=([\\w-]+)", "is_regex": True, "has_matches": True, "ignore_case": False}
         assert extract_find_value(param_dict, "content with id=abc-123", True) == expected
         # Test with non-matching regex
-        expected_no_match = {"pattern": "id=([\\w-]+)", "is_regex": True, "has_matches": False}
+        expected_no_match = {"pattern": "id=([\\w-]+)", "is_regex": True, "has_matches": False, "ignore_case": False}
         assert extract_find_value(param_dict, "unrelated content", True) == expected_no_match
         # Test with regex but filter_match=False - should still return is_regex=True
-        expected = {"pattern": "id=([\\w-]+)", "is_regex": True, "has_matches": False}
+        expected = {"pattern": "id=([\\w-]+)", "is_regex": True, "has_matches": False, "ignore_case": False}
         assert extract_find_value(param_dict, "content with id=abc-123", False) == expected
 
     def test_extract_find_value_invalid_regex(self):
@@ -182,13 +182,13 @@ class TestParameterUtilities:
         # Test with multiple matches in content - now returns simple dict format
         content_with_multiple = "content with id=abc-123 and id=def-456 and id=ghi-789"
         result = extract_find_value(param_dict, content_with_multiple, True)
-        expected = {"pattern": "id=([\\w-]+)", "is_regex": True, "has_matches": True}
+        expected = {"pattern": "id=([\\w-]+)", "is_regex": True, "has_matches": True, "ignore_case": False}
         assert result == expected
 
         # Test that content is detected as having matches
         content_with_duplicates = "content with id=abc-123 and id=def-456 and id=abc-123"
         result = extract_find_value(param_dict, content_with_duplicates, True)
-        expected = {"pattern": "id=([\\w-]+)", "is_regex": True, "has_matches": True}
+        expected = {"pattern": "id=([\\w-]+)", "is_regex": True, "has_matches": True, "ignore_case": False}
         assert result == expected
 
     def test_extract_replace_value_default(self, mock_workspace):

--- a/tests/test_parameter_utils.py
+++ b/tests/test_parameter_utils.py
@@ -191,6 +191,32 @@ class TestParameterUtilities:
         expected = {"pattern": "id=([\\w-]+)", "is_regex": True, "has_matches": True, "ignore_case": False}
         assert result == expected
 
+    def test_extract_find_value_ignore_case_literal(self):
+        """Tests extract_find_value with ignore_case: 'true' for literal find_value."""
+        param_dict = {"find_value": "Test-Value", "ignore_case": "true"}
+
+        # Case-insensitive match should find the value regardless of case
+        expected = {"pattern": "Test-Value", "is_regex": False, "has_matches": True, "ignore_case": True}
+        assert extract_find_value(param_dict, "content with test-value here", True) == expected
+        assert extract_find_value(param_dict, "content with TEST-VALUE here", True) == expected
+
+        # Non-matching content should still return has_matches=False
+        expected_no_match = {"pattern": "Test-Value", "is_regex": False, "has_matches": False, "ignore_case": True}
+        assert extract_find_value(param_dict, "unrelated content", True) == expected_no_match
+
+    def test_extract_find_value_ignore_case_regex(self):
+        """Tests extract_find_value with ignore_case: 'true' for regex find_value."""
+        param_dict = {"find_value": "ID=([\\w-]+)", "is_regex": "true", "ignore_case": "true"}
+
+        # Case-insensitive regex should match regardless of case
+        expected = {"pattern": "ID=([\\w-]+)", "is_regex": True, "has_matches": True, "ignore_case": True}
+        assert extract_find_value(param_dict, "content with id=abc-123", True) == expected
+        assert extract_find_value(param_dict, "content with Id=Abc-123", True) == expected
+
+        # Non-matching content
+        expected_no_match = {"pattern": "ID=([\\w-]+)", "is_regex": True, "has_matches": False, "ignore_case": True}
+        assert extract_find_value(param_dict, "unrelated content", True) == expected_no_match
+
     def test_extract_replace_value_default(self, mock_workspace):
         """Tests extract_replace_value with different inputs, get_dataflow_name=False."""
         # Regular string should be returned as is


### PR DESCRIPTION
This pull request adds support for case-insensitive matching in the `find_replace` parameterization feature. Users can now specify an `ignore_case` option to enable case-insensitive string or regex replacements, and the documentation, implementation, and tests have all been updated to reflect this new capability.

**Documentation updates:**
- Added explanation of the new `ignore_case` field for `find_replace`, including usage instructions, YAML examples, and notes on its interaction with both literal and regex patterns. [[1]](diffhunk://#diff-9cdd02ee5f5219c5426160beb19ff83c624221fd6db2ac6f8bf923d6ebb6f0ffL75-R75) [[2]](diffhunk://#diff-9cdd02ee5f5219c5426160beb19ff83c624221fd6db2ac6f8bf923d6ebb6f0ffR89-R90) [[3]](diffhunk://#diff-9cdd02ee5f5219c5426160beb19ff83c624221fd6db2ac6f8bf923d6ebb6f0ffL346-R378)

**Core implementation changes:**
- Updated the `Parameter` class and parameter validation logic to recognize `ignore_case` as a valid field for `find_replace`.
- Modified the `extract_find_value` utility to handle `ignore_case`, applying the appropriate regex flags and logic for both regex and non-regex matches. [[1]](diffhunk://#diff-08e7f8767bb7d280f82e88a77521554115ad781c1dceb4ff0a7b450d38a684abR84-R98) [[2]](diffhunk://#diff-08e7f8767bb7d280f82e88a77521554115ad781c1dceb4ff0a7b450d38a684abL105-R122)
- Enhanced the parameter replacement logic in `fabric_workspace.py` to perform case-insensitive replacements using `re.sub` when `ignore_case` is set, for both regex and plain string patterns. [[1]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0R541-R542) [[2]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0R557-R566)

**Testing updates:**
- Extended and updated unit tests to verify the new `ignore_case` logic is correctly handled and returned by `extract_find_value`. [[1]](diffhunk://#diff-fbb50113389957532aa161a4ee1bd41cea247bbe52d37e1da62dc6ddc7c1886bL131-R147) [[2]](diffhunk://#diff-fbb50113389957532aa161a4ee1bd41cea247bbe52d37e1da62dc6ddc7c1886bL185-R191)