### PR TITLE
Add http trace output file validation condition

### DIFF
--- a/src/fabric_cicd/_common/_http_tracer.py
+++ b/src/fabric_cicd/_common/_http_tracer.py
@@ -174,6 +174,10 @@ class FileTracer:
         Raises:
             ValueError: If the path fails validation.
         """
+        if "\x00" in raw_path:
+            msg = f"Failed to resolve HTTP trace file path '{raw_path}': embedded null character"
+            raise ValueError(msg)
+
         try:
             resolved = Path(raw_path).resolve()
             cwd = Path.cwd().resolve()

--- a/src/fabric_cicd/_common/_http_tracer.py
+++ b/src/fabric_cicd/_common/_http_tracer.py
@@ -175,14 +175,14 @@ class FileTracer:
             ValueError: If the path fails validation.
         """
         if "\x00" in raw_path:
-            msg = f"Failed to resolve HTTP trace file path '{raw_path}': embedded null character"
+            msg = f"Failed to resolve HTTP trace file path {raw_path!r}: embedded null character"
             raise ValueError(msg)
 
         try:
             resolved = Path(raw_path).resolve()
             cwd = Path.cwd().resolve()
         except (OSError, ValueError) as e:
-            msg = f"Failed to resolve HTTP trace file path '{raw_path}': {e}"
+            msg = f"Failed to resolve HTTP trace file path {raw_path!r}: {e}"
             raise ValueError(msg) from e
 
         if resolved.suffix != ".json":

--- a/tests/test__http_tracer.py
+++ b/tests/test__http_tracer.py
@@ -51,7 +51,7 @@ def test_validate_output_path_rejects_sibling_directory_prefix(tmp_path, monkeyp
         FileTracer._validate_output_path(evil_path)
 
 
-def test_validate_output_path_rejects_unresolvable_path(tmp_path, monkeypatch):
+def test_validate_output_path_rejects_embedded_null_byte(tmp_path, monkeypatch):
     """Ensure an unresolvable path raises ValueError with context."""
     monkeypatch.chdir(tmp_path)
     with pytest.raises(ValueError, match="Failed to resolve HTTP trace file path"):

--- a/tests/test__http_tracer.py
+++ b/tests/test__http_tracer.py
@@ -54,7 +54,7 @@ def test_validate_output_path_rejects_sibling_directory_prefix(tmp_path, monkeyp
 def test_validate_output_path_rejects_embedded_null_byte(tmp_path, monkeypatch):
     """Ensure an unresolvable path raises ValueError with context."""
     monkeypatch.chdir(tmp_path)
-    with pytest.raises(ValueError, match="Failed to resolve HTTP trace file path"):
+    with pytest.raises(ValueError, match="embedded null character"):
         FileTracer._validate_output_path("\x00invalid.json")
 
 


### PR DESCRIPTION
This pull request strengthens the validation logic for HTTP trace file paths by adding a check for embedded null characters in the `_validate_output_path` function. This helps prevent potential security issues or unexpected behavior when handling file paths.

**Validation improvements:**

* Added a check in `_validate_output_path` (in `src/fabric_cicd/_common/_http_tracer.py`) to raise a `ValueError` if the input path contains an embedded null character, with a clear error message.