### PR TITLE
Resolves #1019 - Focus Getting Started page

### DIFF
--- a/.changes/unreleased/docs-20260630-143500.yaml
+++ b/.changes/unreleased/docs-20260630-143500.yaml
@@ -1,0 +1,8 @@
+kind: docs
+body: Move Git flow guidance out of Getting Started and add next steps
+time: 2026-06-30T14:35:00Z
+custom:
+    Issue: 1019
+    Author: nkwork9999
+    AuthorLink: https://github.com/nkwork9999
+    IssueLink: https://github.com/microsoft/fabric-cicd/issues/1019

--- a/docs/how_to/getting_started.md
+++ b/docs/how_to/getting_started.md
@@ -57,14 +57,9 @@ This library deploys from a directory containing files and directories committed
     /parameter.yml
 ```
 
-## GIT Flow
+## Next steps
 
-The flow pictured below is the hero scenario for this library and is the recommendation if you're just starting out.
-
-- `Deployed` branches are not connected to workspaces via [GIT Sync](https://learn.microsoft.com/en-us/fabric/cicd/git-integration/git-get-started?tabs=azure-devops%2CAzure%2Ccommit-to-git#connect-a-workspace-to-a-git-repo)
-- `Feature` branches are connected to workspaces via [GIT Sync](https://learn.microsoft.com/en-us/fabric/cicd/git-integration/git-get-started?tabs=azure-devops%2CAzure%2Ccommit-to-git#connect-a-workspace-to-a-git-repo)
-- `Deployed` workspaces are only updated through script-based deployments, such as through the fabric-cicd library
-- `Feature` branches are created from the default branch, merged back into the default `Deployed` branch, and cherry picked into the upper `Deployed` branches
-- Each deployment is a full deployment and does not consider commit diffs
-
-![GIT Flow](../config/assets/git_flow.png)
+- Review the recommended [Git flow](git_flow.md) for fabric-cicd deployments.
+- Configure deployment behavior with [Configuration Deployment](config_deployment.md).
+- Learn how to manage environment-specific values with [Parameterization](parameterization.md).
+- See [Authentication Examples](../example/authentication.md) for local and pipeline authentication patterns.

--- a/docs/how_to/git_flow.md
+++ b/docs/how_to/git_flow.md
@@ -1,0 +1,11 @@
+# Git Flow
+
+The flow pictured below is the hero scenario for this library and is the recommendation if you're just starting out.
+
+- `Deployed` branches are not connected to workspaces via [Git Sync](https://learn.microsoft.com/en-us/fabric/cicd/git-integration/git-get-started?tabs=azure-devops%2CAzure%2Ccommit-to-git#connect-a-workspace-to-a-git-repo)
+- `Feature` branches are connected to workspaces via [Git Sync](https://learn.microsoft.com/en-us/fabric/cicd/git-integration/git-get-started?tabs=azure-devops%2CAzure%2Ccommit-to-git#connect-a-workspace-to-a-git-repo)
+- `Deployed` workspaces are only updated through script-based deployments, such as through the fabric-cicd library
+- `Feature` branches are created from the default branch, merged back into the default `Deployed` branch, and cherry-picked into the upper `Deployed` branches
+- Each deployment is a full deployment and does not consider commit diffs
+
+![Git Flow](../config/assets/git_flow.png)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
     - How To:
           - How To: how_to/index.md
           - Getting Started: how_to/getting_started.md
+          - Git Flow: how_to/git_flow.md
           - Configuration Deployment: how_to/config_deployment.md
           - Parameterization: how_to/parameterization.md
           - Optional Features: how_to/optional_feature.md


### PR DESCRIPTION
## Summary
- Move the Git flow guidance from Getting Started into a dedicated How To page
- Add the new page to the MkDocs navigation
- Replace the end of Getting Started with focused next steps
- Add a changie documentation entry for #1019

## Validation
- `uv run mkdocs build --clean`

Build note: MkDocs completed successfully. It reported an existing warning for `how_to/troubleshooting.md` linking to `optional_feature.md#current-limitations`; this PR does not touch that page or anchor.