### PR TITLE
Fixes #1044 - Memoize parameter file_path filters and de-quadratify folder refresh

### DIFF
--- a/.changes/unreleased/optimization-20260708-143554.yaml
+++ b/.changes/unreleased/optimization-20260708-143554.yaml
@@ -1,5 +1,5 @@
 kind: optimization
-body: Improve parameter file_path filter and repository folder refresh performance
+body: Improve performance of the `file_path` parameter filter and repository folder refresh
 time: 2026-07-08T14:35:54.402+03:00
 custom:
     Author: ayeshurun

--- a/.changes/unreleased/optimization-20260708-143554.yaml
+++ b/.changes/unreleased/optimization-20260708-143554.yaml
@@ -1,0 +1,8 @@
+kind: optimization
+body: Improve parameter file_path filter and repository folder refresh performance
+time: 2026-07-08T14:35:54.402+03:00
+custom:
+    Author: ayeshurun
+    AuthorLink: https://github.com/ayeshurun
+    Issue: "1044"
+    IssueLink: https://github.com/microsoft/fabric-cicd/issues/1044

--- a/src/fabric_cicd/_parameter/_utils.py
+++ b/src/fabric_cicd/_parameter/_utils.py
@@ -406,9 +406,48 @@ def extract_parameter_filters(workspace_obj: FabricWorkspace, param_dict: dict) 
     """Extracts the item type, name, and path filters from the parameter dictionary, if present."""
     item_type = param_dict.get("item_type")
     item_name = param_dict.get("item_name")
-    file_path = process_input_path(workspace_obj.repository_directory, param_dict.get("file_path"))
+    file_path = _resolve_filter_path(workspace_obj, param_dict.get("file_path"))
 
     return item_type, item_name, file_path
+
+
+def _resolve_filter_path(
+    workspace_obj: FabricWorkspace, file_path_filter: Union[str, list[str], None]
+) -> Union[list[Path], None]:
+    """
+    Resolves a parameter ``file_path`` filter to concrete repository paths, memoizing the result.
+
+    The resolved path set depends only on ``(repository_directory, file_path filter)``, both of which
+    are invariant across every file processed in a single publish. Without memoization, a wildcard
+    filter re-globs the entire repository once per file per parameter entry, producing super-linear
+    (effectively quadratic) filesystem traversal on large repositories. Caching the result keyed on the
+    filter makes the repository glob run once per unique filter instead.
+    """
+    cache = getattr(workspace_obj, "_parameter_filter_path_cache", None)
+    cache_lock = getattr(workspace_obj, "_parameter_filter_path_cache_lock", None)
+
+    # Fall back to direct resolution when a cache is unavailable (e.g. lightweight callers).
+    if not isinstance(cache, dict):
+        return process_input_path(workspace_obj.repository_directory, file_path_filter)
+
+    # Build a hashable cache key from the filter (None, str, or list of str).
+    cache_key = tuple(file_path_filter) if isinstance(file_path_filter, list) else file_path_filter
+
+    if cache_lock is not None:
+        with cache_lock:
+            if cache_key in cache:
+                return cache[cache_key]
+
+    # Resolve outside the lock so concurrent threads resolving different filters don't serialize.
+    resolved = process_input_path(workspace_obj.repository_directory, file_path_filter)
+
+    if cache_lock is not None:
+        with cache_lock:
+            cache.setdefault(cache_key, resolved)
+            return cache[cache_key]
+
+    cache[cache_key] = resolved
+    return resolved
 
 
 def process_environment_key(environment: str, replace_value_dict: dict) -> dict:

--- a/src/fabric_cicd/_parameter/_utils.py
+++ b/src/fabric_cicd/_parameter/_utils.py
@@ -402,7 +402,9 @@ def _extract_item_attribute(workspace_obj: FabricWorkspace, variable: str, get_d
             raise error
 
 
-def extract_parameter_filters(workspace_obj: FabricWorkspace, param_dict: dict) -> tuple[str, str, Path]:
+def extract_parameter_filters(
+    workspace_obj: FabricWorkspace, param_dict: dict
+) -> tuple[Optional[str], Optional[str], Optional[list[Path]]]:
     """Extracts the item type, name, and path filters from the parameter dictionary, if present."""
     item_type = param_dict.get("item_type")
     item_name = param_dict.get("item_name")

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -155,6 +155,13 @@ class FabricWorkspace:
         self._item_attribute_cache = {}
         self._item_attribute_cache_lock = threading.Lock()
 
+        # Initialize cache for resolved parameter file_path filters. The resolved
+        # set depends only on (repository_directory, file_path filter), which is
+        # invariant across all files in a single publish, so it is memoized to
+        # avoid re-globbing the entire repository once per file per parameter entry.
+        self._parameter_filter_path_cache = {}
+        self._parameter_filter_path_cache_lock = threading.Lock()
+
         # Get parameter_file_path from kwargs
         self.parameter_file_path = kwargs.get("parameter_file_path")
 
@@ -975,22 +982,30 @@ class FabricWorkspace:
         root_path = Path(self.repository_directory)
         folder_hierarchy = {}
 
-        # Collect all folders that directly contain a .platform file
+        # Collect all folders that directly contain a .platform file (single traversal)
         platform_folders = set(p.parent for p in root_path.rglob(".platform"))
 
-        # Now, for every folder, check if any of its subfolders is in platform_folders
-        for folder in root_path.rglob("*"):
-            if not folder.is_dir() or folder == root_path or folder.name == ".children":
-                continue
+        # A folder is included if it is a strict ancestor (under the repository root) of at least
+        # one platform folder, excluding platform folders themselves and ".children" containers.
+        # Walking up each platform folder's ancestors is O(tree) overall, avoiding the previous
+        # O(tree^2) behavior of re-globbing every folder's subtree.
+        for platform_folder in platform_folders:
+            for ancestor in platform_folder.parents:
+                # Reached the repository root itself; exclude it and stop walking up.
+                if ancestor == root_path:
+                    break
 
-            # Skip folders that directly contain a .platform file
-            if folder in platform_folders:
-                continue
+                try:
+                    relative = ancestor.relative_to(root_path)
+                except ValueError:
+                    # Ancestor is above the repository root; stop walking up.
+                    break
 
-            # Check if any subfolder (at any depth) is in platform_folders
-            if any(sub in platform_folders for sub in folder.rglob("*") if sub.is_dir()):
-                relative_path = f"/{folder.relative_to(root_path).as_posix()}"
-                folder_hierarchy[relative_path] = ""
+                # Skip item folders (directly contain .platform) and ".children" containers.
+                if ancestor in platform_folders or ancestor.name == ".children":
+                    continue
+
+                folder_hierarchy[f"/{relative.as_posix()}"] = ""
 
         self.repository_folders = folder_hierarchy
 

--- a/tests/test_parameter_utils.py
+++ b/tests/test_parameter_utils.py
@@ -672,7 +672,16 @@ class TestParameterUtilities:
         ]
 
         with mock.patch("fabric_cicd._parameter._utils.process_input_path") as mock_process:
-            mock_process.return_value = []
+
+            def fake_process(_repository_directory, input_path):
+                # Mirror production: a missing/empty filter resolves to None, otherwise concrete paths.
+                if input_path is None:
+                    return None
+                if isinstance(input_path, list):
+                    return [Path(f"/mock/repository/{entry}") for entry in input_path]
+                return [Path(f"/mock/repository/{input_path}")]
+
+            mock_process.side_effect = fake_process
 
             # Resolve each unique filter three times.
             for _ in range(3):

--- a/tests/test_parameter_utils.py
+++ b/tests/test_parameter_utils.py
@@ -633,6 +633,55 @@ class TestParameterUtilities:
             assert item_name is None
             assert file_path == []
 
+    def test_extract_parameter_filters_memoizes_path_resolution(self):
+        """Resolved file_path filters are cached so the repository is not re-globbed per file."""
+        import threading
+
+        # Lightweight workspace stub carrying the real dict-backed cache from FabricWorkspace.
+        workspace = MagicMock()
+        workspace.repository_directory = Path("/mock/repository")
+        workspace._parameter_filter_path_cache = {}
+        workspace._parameter_filter_path_cache_lock = threading.Lock()
+
+        wildcard_param = {"file_path": "**/definition.pbir"}
+
+        with mock.patch("fabric_cicd._parameter._utils.process_input_path") as mock_process:
+            mock_process.return_value = [Path("/mock/repository/report/definition.pbir")]
+
+            # Simulate the per-file loop invoking the same parameter entry many times.
+            results = [extract_parameter_filters(workspace, wildcard_param)[2] for _ in range(50)]
+
+            # Resolution happens once despite 50 calls, and every call returns the same result.
+            mock_process.assert_called_once_with(workspace.repository_directory, "**/definition.pbir")
+            assert all(result == [Path("/mock/repository/report/definition.pbir")] for result in results)
+
+    def test_extract_parameter_filters_caches_per_unique_filter(self):
+        """Each distinct file_path filter is resolved exactly once."""
+        import threading
+
+        workspace = MagicMock()
+        workspace.repository_directory = Path("/mock/repository")
+        workspace._parameter_filter_path_cache = {}
+        workspace._parameter_filter_path_cache_lock = threading.Lock()
+
+        filters = [
+            {"file_path": "**/a.json"},
+            {"file_path": "**/b.json"},
+            {"file_path": ["**/a.json", "**/b.json"]},
+            {},  # None filter
+        ]
+
+        with mock.patch("fabric_cicd._parameter._utils.process_input_path") as mock_process:
+            mock_process.return_value = []
+
+            # Resolve each unique filter three times.
+            for _ in range(3):
+                for param in filters:
+                    extract_parameter_filters(workspace, param)
+
+            # 4 unique filters (two strings, one list, one None) -> 4 resolutions total.
+            assert mock_process.call_count == len(filters)
+
     def test_check_parameter_structure(self):
         """Tests _check_parameter_structure function."""
         # Test with valid list

--- a/tests/test_parameter_utils.py
+++ b/tests/test_parameter_utils.py
@@ -691,6 +691,90 @@ class TestParameterUtilities:
             # 4 unique filters (two strings, one list, one None) -> 4 resolutions total.
             assert mock_process.call_count == len(filters)
 
+    def test_extract_parameter_filters_preserves_resolved_file_path(self, temp_repository):
+        """The memoized file_path value equals the pre-change direct resolution.
+
+        Before memoization, extract_parameter_filters resolved file_path with a direct
+        process_input_path(repository_directory, file_path) call on every invocation. This
+        characterization test pins that the memoized value is equivalent for every filter
+        shape, including the None (no filter) versus empty-list (filter matched nothing)
+        distinction that check_replacement relies on. process_input_path is NOT stubbed, so
+        real filesystem resolution is exercised against the temp_repository fixture, and a
+        spy confirms the second call for a given filter is served from the cache rather than
+        re-resolved.
+        """
+        import threading
+
+        # Resolve the fixture path so regular-path resolution is exercised on every platform.
+        # (macOS mkdtemp returns a /var symlink that otherwise defeats the relative_to() check
+        # for non-wildcard paths, which would silently reduce coverage to wildcards only.)
+        repo = temp_repository.resolve()
+
+        workspace = MagicMock()
+        workspace.repository_directory = repo
+        workspace._parameter_filter_path_cache = {}
+        workspace._parameter_filter_path_cache_lock = threading.Lock()
+
+        # Filters spanning every process_input_path branch, resolved against the real fixture.
+        file_path_filters = [
+            None,  # missing filter -> None (apply to all files)
+            "",  # empty string is falsy -> None
+            [],  # empty list is falsy -> None
+            "file1.txt",  # regular relative path
+            "folder1/file3.py",  # nested regular path
+            "**/*.txt",  # recursive wildcard, multiple matches
+            "**/file4.md",  # recursive wildcard, single match
+            ["file1.txt", "folder1/file3.py"],  # list of regular paths
+            ["**/*.txt", "file2.json"],  # mixed wildcard + regular list
+            "**/does_not_exist.xyz",  # wildcard with no matches -> []
+            "missing/file.txt",  # regular path that does not exist -> []
+        ]
+
+        saw_non_empty = False
+
+        for file_path_filter in file_path_filters:
+            # Reproduce the exact pre-change resolution with a fresh, un-memoized call.
+            expected = process_input_path(repo, file_path_filter)
+
+            param_dict = {} if file_path_filter is None else {"file_path": file_path_filter}
+
+            # Spy (wrapping the real function) on the internal resolver used by the cache.
+            with mock.patch("fabric_cicd._parameter._utils.process_input_path", wraps=process_input_path) as spy:
+                first = extract_parameter_filters(workspace, param_dict)[2]
+                second = extract_parameter_filters(workspace, param_dict)[2]
+
+            # Two calls for the same filter must trigger exactly one underlying resolution,
+            # proving the second value came from the cache rather than a re-glob.
+            assert spy.call_count == 1, f"{file_path_filter!r}: expected one resolution, got {spy.call_count}"
+
+            if expected is None:
+                # None must stay None so check_replacement still treats it as "no filter".
+                assert first is None, f"{file_path_filter!r}: expected None, got {first!r}"
+                assert second is None, f"{file_path_filter!r}: expected None on cached call, got {second!r}"
+            else:
+                assert isinstance(first, list), f"{file_path_filter!r}: first result is not a list"
+                assert isinstance(second, list), f"{file_path_filter!r}: cached result is not a list"
+                # process_input_path returns list(set(...)); compare order-independently but
+                # keep it duplicate- and length-sensitive so a dedup regression still fails.
+                assert len(first) == len(expected), (
+                    f"{file_path_filter!r}: cached length differs from direct resolution"
+                )
+                assert set(first) == set(expected), f"{file_path_filter!r}: cached value differs from direct resolution"
+                assert second == first, f"{file_path_filter!r}: repeat (cached) call changed the value"
+                assert all(path.is_file() for path in first), f"{file_path_filter!r}: resolved a non-file path"
+                if expected:
+                    saw_non_empty = True
+
+        # Guard against a vacuous pass: at least one filter must resolve to real files.
+        assert saw_non_empty, "No filter produced a non-empty resolution; test did not exercise real matches"
+
+        # Golden pins for the semantically critical branches (stable across platforms now that
+        # repo is resolved), guarding against silent degradation of the whole filter set.
+        assert process_input_path(repo, None) is None
+        assert process_input_path(repo, "**/does_not_exist.xyz") == []
+        assert process_input_path(repo, "missing/file.txt") == []
+        assert set(process_input_path(repo, "**/*.txt")) == {repo / "file1.txt", repo / "folder2" / "file5.txt"}
+
     def test_check_parameter_structure(self):
         """Tests _check_parameter_structure function."""
         # Test with valid list

--- a/tests/test_subfolders.py
+++ b/tests/test_subfolders.py
@@ -626,3 +626,45 @@ def test_large_number_of_folders_and_items(tmp_path, patched_fabric_workspace, v
         last_level_1_index = max(sorted_folders.index(f) for f in level_1_folders)
         first_level_2_index = min(sorted_folders.index(f) for f in level_2_folders)
         assert last_level_1_index < first_level_2_index, "Folder sorting is incorrect with large numbers"
+
+
+def test_refresh_repository_folders_excludes_children_containers(
+    tmp_path, patched_fabric_workspace, valid_workspace_id
+):
+    """Intermediate ancestors are included, but '.children' containers and item folders are excluded."""
+    # Ancestor chain that routes through a ".children" folder (enhanced-metadata style layout).
+    create_platform_file(
+        tmp_path / "Reports" / ".children" / "MyReport.Report",
+        item_type="Report",
+        item_name="My Report",
+    )
+
+    workspace = patched_fabric_workspace(
+        workspace_id=valid_workspace_id,
+        repository_directory=str(tmp_path),
+        item_type_in_scope=["Report"],
+    )
+
+    workspace._refresh_repository_folders()
+
+    # Organizational ancestors are included...
+    assert "/Reports" in workspace.repository_folders
+    # ...even when their path passes through a ".children" folder.
+    assert "/Reports/.children/MyReport.Report" not in workspace.repository_folders
+    # The ".children" container itself is never emitted as a workspace folder.
+    assert "/Reports/.children" not in workspace.repository_folders
+
+
+def test_refresh_repository_folders_platform_at_root(tmp_path, patched_fabric_workspace, valid_workspace_id):
+    """A .platform directly under the repository root yields no folder entries (no out-of-root paths)."""
+    create_platform_file(tmp_path, item_type="Notebook", item_name="Root Item")
+
+    workspace = patched_fabric_workspace(
+        workspace_id=valid_workspace_id,
+        repository_directory=str(tmp_path),
+        item_type_in_scope=["Notebook"],
+    )
+
+    workspace._refresh_repository_folders()
+
+    assert workspace.repository_folders == {}


### PR DESCRIPTION
## Description

Deployments that use parametrization on large repositories slowed down super-linearly (effectively quadratic), to the point where a 58-item repo with enhanced-metadata reports (400+ JSON files each) could run for 2h+ without finishing (#1044). This PR removes the redundant filesystem traversals responsible for that growth.

Two independent problems were confirmed in the current code:

- **Primary hot loop.** During publishing, `_replace_parameters` runs once per definition file, and each run called `extract_parameter_filters` -> `process_input_path` for every `find_replace` / `key_value_replace` entry. For wildcard `file_path` filters, that re-globbed the entire repository every time. Total work scaled as `files x params x full-repo-glob`, which is the "almost exponential growth per report" the issue describes. The resolved filter set only depends on `(repository_directory, file_path filter)`, which is invariant across all files in a single publish, so it is now memoized on an instance-scoped cache (`_parameter_filter_path_cache`, following the existing `_item_attribute_cache` pattern). The repo is now globbed once per unique filter instead of once per file per entry.

- **Folder refresh.** `_refresh_repository_folders` nested `folder.rglob("*")` inside `root_path.rglob("*")`, an independent O(tree^2) traversal. It now walks each `.platform` folder's ancestors a single time (O(tree)) and produces the same set of repository folders.

The memoization helper resolves the path outside the lock (so threads with different filters do not serialize on the expensive glob) and stores under the lock, and it falls back to direct resolution when no real cache is present, preserving existing behavior for callers that pass a mock workspace.

Added tests cover the memoization contract (resolution runs once for many calls, and once per unique filter) and folder-refresh edge cases (`.children` containers excluded, root-level `.platform` produces no out-of-root paths). Full suite: 1039 passed, 6 skipped; ruff format and check clean on the changed files.

## Linked Issue (REQUIRED)

Fixes: #1044