### PR TITLE
Closes #1059 - Expose get_supported_feature_flags

### DIFF
--- a/src/fabric_cicd/__init__.py
+++ b/src/fabric_cicd/__init__.py
@@ -34,6 +34,25 @@ def append_feature_flag(feature: str) -> None:
     constants.FEATURE_FLAG.add(feature)
 
 
+def get_supported_feature_flags() -> list[str]:
+    """
+    Return all feature flags supported by fabric-cicd.
+
+    The returned values are the string identifiers accepted by
+    ``append_feature_flag`` and the ``features`` section of a config file.
+
+    Returns:
+        A sorted list of supported feature flag string values.
+
+    Examples:
+        Basic usage
+        >>> from fabric_cicd import get_supported_feature_flags
+        >>> get_supported_feature_flags()
+        ['continue_on_shortcut_failure', 'disable_workspace_folder_publish', ...]
+    """
+    return sorted(flag.value for flag in FeatureFlag)
+
+
 def change_log_level(level: str = "DEBUG") -> None:
     """
     Sets the log level for all loggers within the fabric_cicd package. Currently only supports DEBUG.
@@ -213,6 +232,7 @@ __all__ = [
     "deploy_with_config",
     "disable_file_logging",
     "get_changed_items",
+    "get_supported_feature_flags",
     "publish_all_items",
     "unpublish_all_orphan_items",
 ]

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -18,6 +18,7 @@ from fabric_cicd import (
     configure_external_file_logging,
     constants,
     disable_file_logging,
+    get_supported_feature_flags,
 )
 from fabric_cicd._common._logging import (
     CustomFormatter,
@@ -656,6 +657,35 @@ class TestWrapperFunctions:
         assert "feature_1" in constants.FEATURE_FLAG
         assert "feature_2" in constants.FEATURE_FLAG
         assert len([f for f in constants.FEATURE_FLAG if f == "feature_1"]) == 1
+
+    def test_get_supported_feature_flags_returns_all_enum_values(self):
+        """Test get_supported_feature_flags returns every FeatureFlag value."""
+        flags = get_supported_feature_flags()
+
+        expected = {flag.value for flag in constants.FeatureFlag}
+        assert set(flags) == expected
+        assert len(flags) == len(expected)
+
+    def test_get_supported_feature_flags_is_sorted_string_list(self):
+        """Test get_supported_feature_flags returns a sorted list of strings."""
+        flags = get_supported_feature_flags()
+
+        assert isinstance(flags, list)
+        assert all(isinstance(flag, str) for flag in flags)
+        assert flags == sorted(flags)
+
+    def test_get_supported_feature_flags_unaffected_by_append(self):
+        """Test get_supported_feature_flags reflects supported flags, not runtime-appended ones."""
+        append_feature_flag("some_unsupported_flag")
+
+        flags = get_supported_feature_flags()
+        assert "some_unsupported_flag" not in flags
+
+    def test_get_supported_feature_flags_values_are_appendable(self):
+        """Test every supported flag is accepted by append_feature_flag."""
+        for flag in get_supported_feature_flags():
+            append_feature_flag(flag)
+            assert flag in constants.FEATURE_FLAG
 
     @pytest.mark.parametrize("level_input", ["DEBUG", "debug"])
     def test_change_log_level(self, level_input, temp_log_dir):


### PR DESCRIPTION
## Description

Adds a public `get_supported_feature_flags()` function to the top-level `fabric_cicd` package so callers can programmatically discover every supported feature flag instead of reading the source or docs. It returns a sorted list of the flag string identifiers, derived directly from the `FeatureFlag` enum, so it stays in sync automatically as flags are added or removed. These are the same values accepted by `append_feature_flag` and the `features` section of a config file.

The function is exported via `__all__`, and tests cover completeness against the enum, sorted string output, independence from runtime-appended (unsupported) flags, and round-trip compatibility with `append_feature_flag`.

```python
from fabric_cicd import get_supported_feature_flags
get_supported_feature_flags()
# ['continue_on_shortcut_failure', 'disable_workspace_folder_publish', ...]
```

## Linked Issue (REQUIRED)

Closes #1059