### PR TITLE
Closes #1019 - Focus Getting Started page

### DIFF
--- a/.changes/unreleased/docs-20260716-115617.yaml
+++ b/.changes/unreleased/docs-20260716-115617.yaml
@@ -1,0 +1,8 @@
+kind: docs
+body: "Extract Git flow guidance into a dedicated page and add a Next Steps section to Getting Started"
+time: 2026-07-16T11:56:17.7134417+03:00
+custom:
+    Author: nkwork9999
+    AuthorLink: https://github.com/nkwork9999
+    Issue: "1019"
+    IssueLink: https://github.com/microsoft/fabric-cicd/issues/1019

--- a/docs/how_to/getting_started.md
+++ b/docs/how_to/getting_started.md
@@ -1,9 +1,5 @@
 # Getting Started
 
-!!! tip "Prefer a command-line experience over writing Python?"
-
-    If you'd rather not write Python, the [Microsoft Fabric CLI](https://microsoft.github.io/fabric-cli/) (`fab`) includes a [`deploy` command](https://microsoft.github.io/fabric-cli/commands/fs/deploy/) that runs fabric-cicd under the hood. It deploys Fabric items to a workspace directly from the command line using a shared `config.yml` file. See [Deploying with the Fabric CLI](config_deployment.md#deploying-with-the-fabric-cli) for details.
-
 ## Installation
 
 To install fabric-cicd, run:
@@ -61,14 +57,9 @@ This library deploys from a directory containing files and directories committed
     /parameter.yml
 ```
 
-## GIT Flow
+## Next steps
 
-The flow pictured below is the hero scenario for this library and is the recommendation if you're just starting out.
-
-- `Deployed` branches are not connected to workspaces via [GIT Sync](https://learn.microsoft.com/en-us/fabric/cicd/git-integration/git-get-started?tabs=azure-devops%2CAzure%2Ccommit-to-git#connect-a-workspace-to-a-git-repo)
-- `Feature` branches are connected to workspaces via [GIT Sync](https://learn.microsoft.com/en-us/fabric/cicd/git-integration/git-get-started?tabs=azure-devops%2CAzure%2Ccommit-to-git#connect-a-workspace-to-a-git-repo)
-- `Deployed` workspaces are only updated through script-based deployments, such as through the fabric-cicd library
-- `Feature` branches are created from the default branch, merged back into the default `Deployed` branch, and cherry picked into the upper `Deployed` branches
-- Each deployment is a full deployment and does not consider commit diffs
-
-![GIT Flow](../config/assets/git_flow.png)
+- Review the recommended [Git flow](git_flow.md) for fabric-cicd deployments.
+- Configure deployment behavior with [Configuration Deployment](config_deployment.md).
+- Learn how to manage environment-specific values with [Parameterization](parameterization.md).
+- See [Authentication Examples](../example/authentication.md) for local and pipeline authentication patterns.

--- a/docs/how_to/git_flow.md
+++ b/docs/how_to/git_flow.md
@@ -1,0 +1,11 @@
+# Git Flow
+
+The flow pictured below is the hero scenario for this library and is the recommendation if you're just starting out.
+
+- `Deployed` branches are not connected to workspaces via [Git Sync](https://learn.microsoft.com/en-us/fabric/cicd/git-integration/git-get-started?tabs=azure-devops%2CAzure%2Ccommit-to-git#connect-a-workspace-to-a-git-repo)
+- `Feature` branches are connected to workspaces via [Git Sync](https://learn.microsoft.com/en-us/fabric/cicd/git-integration/git-get-started?tabs=azure-devops%2CAzure%2Ccommit-to-git#connect-a-workspace-to-a-git-repo)
+- `Deployed` workspaces are only updated through script-based deployments, such as through the fabric-cicd library
+- `Feature` branches are created from the default branch, merged back into the default `Deployed` branch, and cherry-picked into the upper `Deployed` branches
+- Each deployment is a full deployment and does not consider commit diffs
+
+![Git Flow](../config/assets/git_flow.png)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
     - How To:
           - How To: how_to/index.md
           - Getting Started: how_to/getting_started.md
+          - Git Flow: how_to/git_flow.md
           - Configuration Deployment: how_to/config_deployment.md
           - Parameterization: how_to/parameterization.md
           - Optional Features: how_to/optional_feature.md


### PR DESCRIPTION
This pull request improves the project documentation by extracting the Git flow guidance into its own dedicated page and enhancing the Getting Started guide with a clearer next steps section. These changes make it easier for new users to follow recommended practices and navigate the documentation.

**Documentation Restructuring and Enhancements:**

* Moved the Git flow section from `getting_started.md` to a new, dedicated page `git_flow.md`, and updated the navigation to include this new page for better discoverability. [[1]](diffhunk://#diff-904f97251ea442726d8f49f4144ae51a882ae8d9e578bb33172cf05d6dad64cdL64-R65) [[2]](diffhunk://#diff-eccdc0b8376d8393117e27ef1f0684dc2345b5d5fe6628575c628c2fdf61c439R1-R11) [[3]](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R14)
* Added a "Next steps" section to `getting_started.md` that links to the new Git flow page and other important topics, providing clearer guidance for users after installation.
* Removed the tip about the Fabric CLI from the top of the Getting Started guide to streamline the introduction.

**Meta and Tracking:**

* Added a changelog entry summarizing these documentation changes, including author and issue references.