### PR TITLE
Fix Notebook publish ordering so notebook-content is processed before supporting files

### DIFF
--- a/src/fabric_cicd/_items/_notebook.py
+++ b/src/fabric_cicd/_items/_notebook.py
@@ -22,6 +22,9 @@ class NotebookPublisher(ItemPublisher):
         def _sort_key(f: Item) -> tuple[int, str]:
             # .ipynb included for completeness; in practice, .json settings only exist with .py notebooks (git integrated format)
             priority = {".platform": 0, ".py": 1, ".ipynb": 1, ".json": 3}
+            # Process built-in resource files after notebook source and settings files.
+            if "Resources/builtin" in str(f.file_path.as_posix()):
+                return (4, f.file_path.name)
             # Account for other file types that may be added later to the notebook item and assign to priority 2
             return (priority.get(f.file_path.name, priority.get(f.file_path.suffix, 2)), f.file_path.name)
 


### PR DESCRIPTION
## Summary

Fixes Notebook publish failures caused by Fabric processing built-in resource files before Notebook settings/source files.

Notebook items can include files under `Resources/builtin/**`. The existing sort order prioritizes notebook source and settings by file suffix, but built-in resource files can still appear too early in the payload and be interpreted incorrectly during Fabric-side conversion.

This change preserves the existing Notebook payload behavior and only adjusts ordering for `Resources/builtin/**` files so they are processed after notebook source and settings files.

## Root Cause

Fabric Notebook publishing is sensitive to the order of files in the Notebook definition payload.

The existing order was:

```python
priority = {".platform": 0, ".py": 1, ".ipynb": 1, ".json": 3}
```

However, files under `Resources/builtin/**` are supporting resource files and should not be processed before the main Notebook source/settings files.

If a built-in resource file is processed too early, Fabric can attempt to interpret it as part of Notebook conversion, leading to publish failures such as:

```text
PyToIPynbFailure
```

or suffix/conversion errors.

## Changes

- Keeps the existing Notebook sort priority behavior.
- Adds a specific ordering rule for `Resources/builtin/**`.
- Moves built-in resource files after Notebook source and `.json` settings files.
- Does not exclude any files from the payload.
- Limits the change to Notebook item publish ordering.

## Validation

Ran:

```powershell
uv run pytest tests/test_publish.py::TestNotebookPublisher
```

Result:

```text
6 passed
```