### PR TITLE
add back deploy command tip in docs

### DIFF
--- a/docs/how_to/getting_started.md
+++ b/docs/how_to/getting_started.md
@@ -8,6 +8,10 @@ To install fabric-cicd, run:
 pip install fabric-cicd
 ```
 
+!!! tip "Prefer a command-line experience over writing Python?"
+
+    If you'd rather not write Python, the [Microsoft Fabric CLI](https://microsoft.github.io/fabric-cli/) (`fab`) includes a [`deploy` command](https://microsoft.github.io/fabric-cli/commands/fs/deploy/) that runs fabric-cicd under the hood. It deploys Fabric items to a workspace directly from the command line using a shared `config.yml` file. See [Deploying with the Fabric CLI](config_deployment.md#deploying-with-the-fabric-cli) for details.
+
 ## Authentication
 
 > **⚠️ NOTICE**: Due to security best practices, the **Default Credential** (`DefaultAzureCredential` fallback) and **implicit Fabric Notebook authentication** (without a `token_credential` parameter) methods are no longer supported. `token_credential` is now a required parameter.


### PR DESCRIPTION
This pull request improves the onboarding documentation by highlighting an alternative, command-line-based deployment method for users who prefer not to write Python code. The main change is the addition of a tip about using the Microsoft Fabric CLI for deployments.

Documentation improvements:

* Added a tip to `docs/how_to/getting_started.md` explaining that users can use the Microsoft Fabric CLI (`fab`) and its `deploy` command as an alternative to writing Python, with links to relevant documentation and further instructions.