### PR TITLE
Closes #1066 - Add MirroredAzureDatabricksCatalog item type support

### DIFF
--- a/docs/reference/item_types.md
+++ b/docs/reference/item_types.md
@@ -113,6 +113,15 @@
     - Referenced items (e.g., Lakehouse, KQL Database, Ontology) that exist in a different workspace will always point to the original item unless parameterized in the `find_replace` section of the `parameter.yml` file.
     - Referenced items within the same workspace are automatically re-pointed to the new item in the target workspace.
 
+## Mirrored Azure Databricks Catalog
+
+- **Parameterization:**
+    - The catalog is created from the `creationPayload` in the `.platform` file's `metadata` (`catalogName`, `mirroringMode`, `databricksWorkspaceConnectionId`, `storageConnectionId`).
+    - **Connections** (`databricksWorkspaceConnectionId` and `storageConnectionId`) are environment-specific and are not source controlled. Parameterize them in the `find_replace` (or `key_value_replace`) section of the `parameter.yml` file, targeting the `.platform` file, when they change between environments.
+- **Only the item shell is deployed** via the `creationPayload`. The item definition is not deployed or updated by `fabric-cicd`.
+- The referenced **connections must exist** in the target environment before deployment, and the executing identity must have access to them.
+- **Known limitation — `autoSync`:** the `autoSync` property is not managed by `fabric-cicd`. The Fabric API only allows it to be set through a separate update request (it is not part of the `creationPayload` or the deployable definition), so it takes the Fabric default on creation and must be configured manually if a non-default value is required.
+
 ## Mirrored Database
 
 - **Parameterization:**

--- a/src/fabric_cicd/_items/_base_publisher.py
+++ b/src/fabric_cicd/_items/_base_publisher.py
@@ -155,6 +155,7 @@ class ItemPublisher(Publisher):
         from fabric_cicd._items._kqlqueryset import KQLQuerysetPublisher
         from fabric_cicd._items._lakehouse import LakehousePublisher
         from fabric_cicd._items._map import MapPublisher
+        from fabric_cicd._items._mirroredazuredatabrickscatalog import MirroredAzureDatabricksCatalogPublisher
         from fabric_cicd._items._mirroreddatabase import MirroredDatabasePublisher
         from fabric_cicd._items._mlexperiment import MLExperimentPublisher
         from fabric_cicd._items._mounteddatafactory import MountedDataFactoryPublisher
@@ -173,6 +174,7 @@ class ItemPublisher(Publisher):
             ItemType.VARIABLE_LIBRARY: VariableLibraryPublisher,
             ItemType.WAREHOUSE: WarehousePublisher,
             ItemType.MIRRORED_DATABASE: MirroredDatabasePublisher,
+            ItemType.MIRRORED_AZURE_DATABRICKS_CATALOG: MirroredAzureDatabricksCatalogPublisher,
             ItemType.LAKEHOUSE: LakehousePublisher,
             ItemType.SQL_DATABASE: SQLDatabasePublisher,
             ItemType.ENVIRONMENT: EnvironmentPublisher,

--- a/src/fabric_cicd/_items/_mirroredazuredatabrickscatalog.py
+++ b/src/fabric_cicd/_items/_mirroredazuredatabrickscatalog.py
@@ -1,0 +1,59 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Functions to process and deploy Mirrored Azure Databricks Catalog item."""
+
+import json
+import logging
+from typing import Optional
+
+from fabric_cicd import constants
+from fabric_cicd._common._item import Item
+from fabric_cicd._items._base_publisher import ItemPublisher
+from fabric_cicd.constants import ItemType
+
+logger = logging.getLogger(__name__)
+
+
+class MirroredAzureDatabricksCatalogPublisher(ItemPublisher):
+    """Publisher for Mirrored Azure Databricks Catalog items."""
+
+    item_type = ItemType.MIRRORED_AZURE_DATABRICKS_CATALOG.value
+
+    def publish_one(self, item_name: str, item: Item) -> None:
+        """Publish a single Mirrored Azure Databricks Catalog item."""
+        creation_payload = self._get_creation_payload(item)
+
+        self.fabric_workspace_obj._publish_item(
+            item_name=item_name,
+            item_type=self.item_type,
+            creation_payload=creation_payload,
+            skip_publish_logging=True,
+        )
+
+        # Check if the item is published to avoid any post publish actions
+        if item.skip_publish:
+            return
+
+        logger.info(f"{constants.INDENT}Published Mirrored Azure Databricks Catalog '{item_name}'")
+
+    def _get_creation_payload(self, item: Item) -> Optional[dict]:
+        """
+        Extract the creationPayload from the item's .platform metadata.
+
+        The Mirrored Azure Databricks Catalog is created via the creationPayload
+        (catalogName, mirroringMode, databricksWorkspaceConnectionId, storageConnectionId).
+        Environment-specific values in the creationPayload (e.g., connection IDs) are
+        resolved via parameterization before extraction.
+
+        Args:
+            item: The item object to extract the creationPayload from.
+        """
+        platform_file = next((file for file in item.item_files if file.name == ".platform"), None)
+        if platform_file is None or "creationPayload" not in platform_file.contents:
+            return None
+
+        # Resolve environment-specific values (e.g., connection IDs) via parameterization
+        contents = self.fabric_workspace_obj._replace_parameters(platform_file, item)
+
+        return json.loads(contents)["metadata"]["creationPayload"]

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -60,6 +60,7 @@ class ItemType(str, Enum):
     KQL_QUERYSET = "KQLQueryset"
     LAKEHOUSE = "Lakehouse"
     MAP = "Map"
+    MIRRORED_AZURE_DATABRICKS_CATALOG = "MirroredAzureDatabricksCatalog"
     MIRRORED_DATABASE = "MirroredDatabase"
     ML_EXPERIMENT = "MLExperiment"
     MOUNTED_DATA_FACTORY = "MountedDataFactory"
@@ -82,32 +83,33 @@ SERIAL_ITEM_PUBLISH_ORDER: dict[int, ItemType] = {
     1: ItemType.VARIABLE_LIBRARY,
     2: ItemType.WAREHOUSE,
     3: ItemType.MIRRORED_DATABASE,
-    4: ItemType.LAKEHOUSE,
-    5: ItemType.SQL_DATABASE,
-    6: ItemType.ENVIRONMENT,
-    7: ItemType.USER_DATA_FUNCTION,
-    8: ItemType.EVENTHOUSE,
-    9: ItemType.SPARK_JOB_DEFINITION,
-    10: ItemType.NOTEBOOK,
-    11: ItemType.SEMANTIC_MODEL,
-    12: ItemType.REPORT,
-    13: ItemType.PAGINATED_REPORT,
-    14: ItemType.COPY_JOB,
-    15: ItemType.DATA_BUILD_TOOL_JOB,
-    16: ItemType.KQL_DATABASE,
-    17: ItemType.KQL_QUERYSET,
-    18: ItemType.DATAFLOW,
-    19: ItemType.DATA_PIPELINE,
-    20: ItemType.REFLEX,
-    21: ItemType.EVENTSTREAM,
-    22: ItemType.KQL_DASHBOARD,
-    23: ItemType.GRAPHQL_API,
-    24: ItemType.APACHE_AIRFLOW_JOB,
-    25: ItemType.MOUNTED_DATA_FACTORY,
-    26: ItemType.DATA_AGENT,
-    27: ItemType.ML_EXPERIMENT,
-    28: ItemType.ONTOLOGY,
-    29: ItemType.MAP,
+    4: ItemType.MIRRORED_AZURE_DATABRICKS_CATALOG,
+    5: ItemType.LAKEHOUSE,
+    6: ItemType.SQL_DATABASE,
+    7: ItemType.ENVIRONMENT,
+    8: ItemType.USER_DATA_FUNCTION,
+    9: ItemType.EVENTHOUSE,
+    10: ItemType.SPARK_JOB_DEFINITION,
+    11: ItemType.NOTEBOOK,
+    12: ItemType.SEMANTIC_MODEL,
+    13: ItemType.REPORT,
+    14: ItemType.PAGINATED_REPORT,
+    15: ItemType.COPY_JOB,
+    16: ItemType.DATA_BUILD_TOOL_JOB,
+    17: ItemType.KQL_DATABASE,
+    18: ItemType.KQL_QUERYSET,
+    19: ItemType.DATAFLOW,
+    20: ItemType.DATA_PIPELINE,
+    21: ItemType.REFLEX,
+    22: ItemType.EVENTSTREAM,
+    23: ItemType.KQL_DASHBOARD,
+    24: ItemType.GRAPHQL_API,
+    25: ItemType.APACHE_AIRFLOW_JOB,
+    26: ItemType.MOUNTED_DATA_FACTORY,
+    27: ItemType.DATA_AGENT,
+    28: ItemType.ML_EXPERIMENT,
+    29: ItemType.ONTOLOGY,
+    30: ItemType.MAP,
 }
 
 
@@ -212,6 +214,7 @@ SHELL_ONLY_PUBLISH = [
     ItemType.WAREHOUSE.value,
     ItemType.SQL_DATABASE.value,
     ItemType.ML_EXPERIMENT.value,
+    ItemType.MIRRORED_AZURE_DATABRICKS_CATALOG.value,
 ]
 
 # Item count limit for bulk publish API (as per current API documentation)

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -657,6 +657,117 @@ def test_mirrored_database_published_before_lakehouse(mock_endpoint, temp_worksp
 
 
 # =============================================================================
+# Mirrored Azure Databricks Catalog Tests
+# =============================================================================
+
+
+def _create_mirrored_adb_catalog_item(
+    base_path: Path, name: str, logical_id: str, creation_payload: Optional[dict]
+) -> Path:
+    """Create a MirroredAzureDatabricksCatalog test item with an optional creationPayload."""
+    item_dir = base_path / f"{name}.MirroredAzureDatabricksCatalog"
+    item_dir.mkdir(parents=True, exist_ok=True)
+
+    metadata = {
+        "type": "MirroredAzureDatabricksCatalog",
+        "displayName": name,
+        "description": "Test MirroredAzureDatabricksCatalog",
+    }
+    if creation_payload is not None:
+        metadata["creationPayload"] = creation_payload
+
+    platform = {
+        "metadata": metadata,
+        "config": {"version": "2.0", "logicalId": logical_id},
+    }
+    with (item_dir / ".platform").open("w", encoding="utf-8") as f:
+        json.dump(platform, f)
+
+    return item_dir
+
+
+def _get_create_item_body(mock_endpoint) -> dict:
+    """Return the body of the POST /items create call captured by the mock endpoint."""
+    for call in mock_endpoint.invoke.call_args_list:
+        kwargs = call.kwargs
+        if kwargs.get("method") == "POST" and kwargs.get("url", "").endswith("/items"):
+            return kwargs.get("body", {})
+    msg = "No POST /items create call was captured"
+    raise AssertionError(msg)
+
+
+def test_mirrored_adb_catalog_publishes_with_creation_payload(mock_endpoint, temp_workspace_dir):
+    """Test that a Mirrored Azure Databricks Catalog is created via its creationPayload."""
+    creation_payload = {
+        "catalogName": "catalog_1",
+        "databricksWorkspaceConnectionId": "11111111-1111-1111-1111-111111111111",
+        "mirroringMode": "Full",
+        "storageConnectionId": "22222222-2222-2222-2222-222222222222",
+    }
+    _create_mirrored_adb_catalog_item(temp_workspace_dir, "TestCatalog", "test-adb-catalog-id", creation_payload)
+
+    with (
+        patch("fabric_cicd.fabric_workspace.FabricEndpoint", return_value=mock_endpoint),
+        patch.object(FabricWorkspace, "_refresh_deployed_items", new=lambda self: setattr(self, "deployed_items", {})),
+        patch.object(
+            FabricWorkspace, "_refresh_deployed_folders", new=lambda self: setattr(self, "deployed_folders", {})
+        ),
+    ):
+        workspace = FabricWorkspace(
+            workspace_id="12345678-1234-5678-abcd-1234567890ab",
+            repository_directory=str(temp_workspace_dir),
+            item_type_in_scope=["MirroredAzureDatabricksCatalog"],
+            token_credential=DummyTokenCredential(),
+        )
+
+        publish.publish_all_items(workspace)
+
+    body = _get_create_item_body(mock_endpoint)
+    assert body["type"] == "MirroredAzureDatabricksCatalog"
+    assert body["creationPayload"] == creation_payload
+    # Shell-only publish: no definition parts are sent
+    assert "definition" not in body
+
+
+def test_mirrored_adb_catalog_publishes_without_creation_payload(mock_endpoint, temp_workspace_dir):
+    """Test that a Mirrored Azure Databricks Catalog without a creationPayload creates a shell item."""
+    _create_mirrored_adb_catalog_item(temp_workspace_dir, "ShellCatalog", "shell-adb-catalog-id", None)
+
+    with (
+        patch("fabric_cicd.fabric_workspace.FabricEndpoint", return_value=mock_endpoint),
+        patch.object(FabricWorkspace, "_refresh_deployed_items", new=lambda self: setattr(self, "deployed_items", {})),
+        patch.object(
+            FabricWorkspace, "_refresh_deployed_folders", new=lambda self: setattr(self, "deployed_folders", {})
+        ),
+    ):
+        workspace = FabricWorkspace(
+            workspace_id="12345678-1234-5678-abcd-1234567890ab",
+            repository_directory=str(temp_workspace_dir),
+            item_type_in_scope=["MirroredAzureDatabricksCatalog"],
+            token_credential=DummyTokenCredential(),
+        )
+
+        publish.publish_all_items(workspace)
+
+    body = _get_create_item_body(mock_endpoint)
+    assert body["type"] == "MirroredAzureDatabricksCatalog"
+    assert "creationPayload" not in body
+    assert "definition" not in body
+
+
+def test_mirrored_adb_catalog_is_shell_only_and_ordered():
+    """Test that the item type is registered as shell-only and placed among the source item types."""
+    assert ItemType.MIRRORED_AZURE_DATABRICKS_CATALOG.value in constants.SHELL_ONLY_PUBLISH
+
+    order = constants.SERIAL_ITEM_PUBLISH_ORDER
+    positions = {item_type: position for position, item_type in order.items()}
+    # Deploys after MirroredDatabase and before downstream consumers such as Lakehouse/Notebook
+    assert positions[ItemType.MIRRORED_DATABASE] < positions[ItemType.MIRRORED_AZURE_DATABRICKS_CATALOG]
+    assert positions[ItemType.MIRRORED_AZURE_DATABRICKS_CATALOG] < positions[ItemType.LAKEHOUSE]
+    assert positions[ItemType.MIRRORED_AZURE_DATABRICKS_CATALOG] < positions[ItemType.NOTEBOOK]
+
+
+# =============================================================================
 # Folder Exclusion Tests
 # =============================================================================
 


### PR DESCRIPTION
## Summary

Closes #1066. Adds support for the **`MirroredAzureDatabricksCatalog`** item type.

Eligibility gates verified against the Fabric REST API docs:
- **Git/source-control support** — listed in the item definition overview ✅
- **API deployment support** — Create + Get/Update Definition operations ✅
- **Service principal auth** — supported on the Create endpoint ✅

## Design decisions

- **Dependency order:** The item references only external **Connections** (`databricksWorkspaceConnectionId`, `storageConnectionId`), not Fabric-managed items. It is placed at position **4** in `SERIAL_ITEM_PUBLISH_ORDER`, right after `MirroredDatabase` and ahead of downstream consumers (Lakehouse, Notebook, SemanticModel, etc.).
- **Deployment:** Shell-only + `creationPayload` (same mechanism as Warehouse). The publisher extracts `creationPayload` (`catalogName`, `mirroringMode`, connection IDs) from the `.platform` metadata and applies parameterization so environment-specific connection IDs can be re-pointed via `find_replace` / `key_value_replace`.
- **`autoSync` deferred:** `autoSync` can only be set through a separate update request (not part of `creationPayload` or the deployable definition), so it is not managed by fabric-cicd and is documented as a known limitation.

## Changes

- `constants.py`: new `ItemType` enum member, inserted into `SERIAL_ITEM_PUBLISH_ORDER` (pos 4), added to `SHELL_ONLY_PUBLISH`.
- `_items/_mirroredazuredatabrickscatalog.py`: new `MirroredAzureDatabricksCatalogPublisher`.
- `_items/_base_publisher.py`: registered publisher import + factory mapping.
- `tests/test_publish.py`: unit tests for create-with-payload, shell-only create, and publish ordering.
- `docs/reference/item_types.md`: new section incl. `autoSync` known limitation.

## Validation

- `from fabric_cicd import FabricWorkspace` import check ✅
- `uv run pytest` — 1043 passed, 11 skipped ✅
- `uv run ruff format --check` ✅ · `uv run ruff check` ✅

## Remaining manual steps (require a real workspace)

- [ ] Add an exported sample item to `sample/workspace/`.
- [ ] Add the type to `item_types_to_deploy` in `tests/test_integration_publish.py` and regenerate `tests/fixtures/http_trace.json.gz`.
- [ ] Validate end-to-end via `devtools/debug_local.py`.
