### PR TITLE
Fixes #1076 - Publish Ontology before DataAgent

### DIFF
--- a/.changes/unreleased/fixed-20260722-115200.yaml
+++ b/.changes/unreleased/fixed-20260722-115200.yaml
@@ -1,0 +1,8 @@
+kind: fixed
+body: Publish `Ontology` before `DataAgent` so DataAgents that reference an Ontology deploy successfully
+time: 2026-07-22T11:52:00.0000000+03:00
+custom:
+    Author: shirasassoon
+    AuthorLink: https://github.com/shirasassoon
+    Issue: "1076"
+    IssueLink: https://github.com/microsoft/fabric-cicd/issues/1076


### PR DESCRIPTION
## Summary

Fixes #1076. A DataAgent may reference an Ontology, so the Ontology must be published first; otherwise deployment fails.

The ordering fix itself (`SERIAL_ITEM_PUBLISH_ORDER`: `ONTOLOGY` now precedes `DATA_AGENT`) already landed in `main` via #1079's squash-merge, but no dedicated changelog entry was recorded for #1076. This PR adds the missing `.changes` entry so the fix is documented and the issue closes on merge.

## Change

- Add `.changes/unreleased/fixed-20260722-115200.yaml` for #1076.

## Notes

The functional reorder is already present in `main`:
\\\
25: MOUNTED_DATA_FACTORY
26: ONTOLOGY
27: DATA_AGENT
28: ML_EXPERIMENT
29: MAP
\\\
Unpublish uses the reversed order, so DataAgent is still torn down before Ontology.