### PR TITLE
fix: Support set hostApp from allowlist 

### DIFF
--- a/src/fabric_cicd/_common/_config_validator.py
+++ b/src/fabric_cicd/_common/_config_validator.py
@@ -1022,12 +1022,6 @@ class ConfigValidator:
                     constants.CONFIG_VALIDATION_MSGS["operation"]["unknown_constant"].format(key, "constants")
                 )
 
-            # Reject protected constants that must not be settable via configuration
-            elif key in constants.PROTECTED_CONSTANTS:
-                self.errors.append(
-                    constants.CONFIG_VALIDATION_MSGS["operation"]["protected_constant"].format(key, "constants")
-                )
-
             if isinstance(value, dict):
                 # Per-key environment mapping: { KEY: { dev: val, prod: val } }
                 for env, env_value in value.items():

--- a/src/fabric_cicd/_common/_config_validator.py
+++ b/src/fabric_cicd/_common/_config_validator.py
@@ -1022,6 +1022,12 @@ class ConfigValidator:
                     constants.CONFIG_VALIDATION_MSGS["operation"]["unknown_constant"].format(key, "constants")
                 )
 
+            # Reject protected constants that must not be settable via configuration
+            elif key in constants.PROTECTED_CONSTANTS:
+                self.errors.append(
+                    constants.CONFIG_VALIDATION_MSGS["operation"]["protected_constant"].format(key, "constants")
+                )
+
             if isinstance(value, dict):
                 # Per-key environment mapping: { KEY: { dev: val, prod: val } }
                 for env, env_value in value.items():

--- a/src/fabric_cicd/_common/_fabric_endpoint.py
+++ b/src/fabric_cicd/_common/_fabric_endpoint.py
@@ -27,7 +27,7 @@ _TOKEN_EXPIRY_BUFFER = datetime.timedelta(seconds=10)
 
 
 def _build_user_agent(host_app: Optional[str]) -> str:
-    """Return the default user-agent, appending a trusted host-app suffix when supported.
+    """Return the default user-agent
 
     Args:
         host_app: The host-app identifier supplied by a trusted caller (e.g. the Fabric CLI).

--- a/src/fabric_cicd/_common/_fabric_endpoint.py
+++ b/src/fabric_cicd/_common/_fabric_endpoint.py
@@ -26,23 +26,24 @@ _RESOURCE_URL = "https://api.fabric.microsoft.com/.default"
 _TOKEN_EXPIRY_BUFFER = datetime.timedelta(seconds=10)
 
 
-def _build_user_agent(user_agent: Optional[str]) -> str:
-    """Return the default user-agent, appending a trusted caller-supplied host-app if exists and supported.
+def _build_user_agent(host_app: Optional[str]) -> str:
+    """Return the default user-agent, appending a trusted host-app suffix when supported.
 
     Args:
-        user_agent: The user-agent supplied by the caller (e.g., the Fabric CLI).
+        host_app: The host-app identifier supplied by a trusted caller (e.g. the Fabric CLI).
+            Only a value matching ``HOST_APP_ALLOWLIST_REGEX`` is appended; anything else is ignored.
     """
-    if not isinstance(user_agent, str) or not user_agent.strip():
+    if not isinstance(host_app, str) or not host_app.strip():
         return constants.USER_AGENT
 
-    candidate = user_agent.strip()
+    candidate = host_app.strip()
 
-    # Never allow CR/LF in a value used as an HTTP header, regardless of the allowlist regex.
+    # Reject CR/LF to prevent HTTP header / log injection.
     if "\r" in candidate or "\n" in candidate:
         return constants.USER_AGENT
 
-    if constants.USER_AGENT_ALLOWLIST_REGEX.match(candidate):
-        return f"{constants.USER_AGENT},(host-app/{candidate})"
+    if constants.HOST_APP_ALLOWLIST_REGEX.match(candidate):
+        return f"{candidate} (deploy; {constants.USER_AGENT})"
 
     return constants.USER_AGENT
 
@@ -55,7 +56,7 @@ class FabricEndpoint:
         token_credential: TokenCredential,
         requests_module: requests = requests,
         http_tracer: Optional[HTTPTracer] = None,
-        user_agent: Optional[str] = None,
+        host_app: Optional[str] = None,
     ) -> None:
         """
         Initializes the FabricEndpoint instance, sets up the authentication token.
@@ -64,12 +65,12 @@ class FabricEndpoint:
             token_credential: The token credential.
             requests_module: The requests module.
             http_tracer: Optional HTTP tracer for debugging. If None, create using factory.
-            user_agent: Optional user-agent supplied by a trusted host application.
+            host_app: Optional host-app identifier supplied by a trusted caller.
         """
         self.token_credential = token_credential
         self.requests = requests_module
         self.http_tracer = http_tracer if http_tracer is not None else HTTPTracerFactory.create()
-        self.user_agent = _build_user_agent(user_agent)
+        self.user_agent = _build_user_agent(host_app)
         self._token: Optional[str] = None
         self._token_expiry: Optional[datetime.datetime] = None
 

--- a/src/fabric_cicd/_common/_fabric_endpoint.py
+++ b/src/fabric_cicd/_common/_fabric_endpoint.py
@@ -27,7 +27,7 @@ _TOKEN_EXPIRY_BUFFER = datetime.timedelta(seconds=10)
 
 
 def _build_user_agent(host_app: Optional[str]) -> str:
-    """Return the default user-agent"""
+    """Return the user-agent"""
     candidate = host_app.strip() if isinstance(host_app, str) else ""
     if candidate and constants.HOST_APP_ALLOWLIST_REGEX.match(candidate):
         return f"{candidate} (deploy; {constants.USER_AGENT})"

--- a/src/fabric_cicd/_common/_fabric_endpoint.py
+++ b/src/fabric_cicd/_common/_fabric_endpoint.py
@@ -32,7 +32,7 @@ _HOST_APP_ALLOWLIST_REGEX = re.compile(r"\Ams-fabric-cli/\d+\.\d+\.\d+(?:-[0-9A-
 
 
 def _build_user_agent(host_app: Optional[str]) -> str:
-    """Return the default user-agent, appending a trusted host-app token when supported."""
+    """Return the user-agent."""
     candidate = host_app.strip() if isinstance(host_app, str) else ""
     if candidate and _HOST_APP_ALLOWLIST_REGEX.match(candidate):
         return f"{candidate} (deploy; {_USER_AGENT})"

--- a/src/fabric_cicd/_common/_fabric_endpoint.py
+++ b/src/fabric_cicd/_common/_fabric_endpoint.py
@@ -36,19 +36,14 @@ def _build_user_agent(user_agent: Optional[str]) -> str:
         return constants.USER_AGENT
 
     candidate = user_agent.strip()
-    # Sanitize CR/LF for any log output so a crafted value cannot forge log lines.
-    sanitized = candidate.replace("\r", "\\r").replace("\n", "\\n")
 
     # Never allow CR/LF in a value used as an HTTP header, regardless of the allowlist regex.
     if "\r" in candidate or "\n" in candidate:
-        logger.debug(f"Ignoring caller-supplied user-agent containing CR/LF: {sanitized}")
         return constants.USER_AGENT
 
     if constants.USER_AGENT_ALLOWLIST_REGEX.match(candidate):
-        logger.debug(f"Using caller-supplied user-agent: {sanitized}")
         return f"{constants.USER_AGENT},(host-app/{candidate})"
 
-    logger.debug(f"Ignoring untrusted caller-supplied user-agent: {sanitized}")
     return constants.USER_AGENT
 
 
@@ -69,12 +64,7 @@ class FabricEndpoint:
             token_credential: The token credential.
             requests_module: The requests module.
             http_tracer: Optional HTTP tracer for debugging. If None, create using factory.
-            user_agent: Optional user-agent supplied by a trusted host application (the Fabric
-                CLI ``deploy`` command), e.g.
-                ``ms-fabric-cicd/1.2.0,ms-fabric-cli/1.6.1 (deploy; Linux/...; Python/3.12.11)``.
-                When it matches ``constants.USER_AGENT_ALLOWLIST_REGEX`` it is appended to the
-                default user-agent as a ``(host-app/...)`` suffix; otherwise only the default
-                ``ms-fabric-cicd/<version>`` is used.
+            user_agent: Optional user-agent supplied by a trusted host application.
         """
         self.token_credential = token_credential
         self.requests = requests_module

--- a/src/fabric_cicd/_common/_fabric_endpoint.py
+++ b/src/fabric_cicd/_common/_fabric_endpoint.py
@@ -26,6 +26,33 @@ _RESOURCE_URL = "https://api.fabric.microsoft.com/.default"
 _TOKEN_EXPIRY_BUFFER = datetime.timedelta(seconds=10)
 
 
+def _build_user_agent(user_agent: Optional[str]) -> str:
+    """Return the default user-agent, appending a trusted caller-supplied host-app.
+
+    The Fabric CLI ``deploy`` command supplies a value such as
+    ``ms-fabric-cicd/1.2.0,ms-fabric-cli/1.6.1 (deploy; Linux/...; Python/3.12.11)``.
+    When it matches ``constants.USER_AGENT_ALLOWLIST_REGEX`` (host app ``ms-fabric-cli``
+    running the ``deploy`` command) it is appended to the default user-agent as a
+    ``(host-app/...)`` suffix, e.g.
+    ``ms-fabric-cicd/<version>,(host-app/ms-fabric-cicd/1.2.0,ms-fabric-cli/1.6.1 (deploy; ...))``.
+    Otherwise only the default ``ms-fabric-cicd/<version>`` is used so arbitrary callers
+    cannot spoof an identity.
+
+    Args:
+        user_agent: The user-agent supplied by the caller (e.g., the Fabric CLI).
+    """
+    if not isinstance(user_agent, str) or not user_agent.strip():
+        return constants.USER_AGENT
+
+    candidate = user_agent.strip()
+    if constants.USER_AGENT_ALLOWLIST_REGEX.match(candidate):
+        logger.debug(f"Using caller-supplied user-agent: {candidate}")
+        return f"{constants.USER_AGENT},(host-app/{candidate})"
+
+    logger.debug(f"Ignoring untrusted caller-supplied user-agent: {candidate}")
+    return constants.USER_AGENT
+
+
 class FabricEndpoint:
     """Handles interactions with the Fabric API, including authentication and request management."""
 
@@ -34,6 +61,7 @@ class FabricEndpoint:
         token_credential: TokenCredential,
         requests_module: requests = requests,
         http_tracer: Optional[HTTPTracer] = None,
+        user_agent: Optional[str] = None,
     ) -> None:
         """
         Initializes the FabricEndpoint instance, sets up the authentication token.
@@ -42,10 +70,17 @@ class FabricEndpoint:
             token_credential: The token credential.
             requests_module: The requests module.
             http_tracer: Optional HTTP tracer for debugging. If None, create using factory.
+            user_agent: Optional user-agent supplied by a trusted host application (the Fabric
+                CLI ``deploy`` command), e.g.
+                ``ms-fabric-cicd/1.2.0,ms-fabric-cli/1.6.1 (deploy; Linux/...; Python/3.12.11)``.
+                When it matches ``constants.USER_AGENT_ALLOWLIST_REGEX`` it is appended to the
+                default user-agent as a ``(host-app/...)`` suffix; otherwise only the default
+                ``ms-fabric-cicd/<version>`` is used.
         """
         self.token_credential = token_credential
         self.requests = requests_module
         self.http_tracer = http_tracer if http_tracer is not None else HTTPTracerFactory.create()
+        self.user_agent = _build_user_agent(user_agent)
         self._token: Optional[str] = None
         self._token_expiry: Optional[datetime.datetime] = None
 
@@ -84,7 +119,7 @@ class FabricEndpoint:
             try:
                 headers = {
                     "Authorization": f"Bearer {self._get_token()}",
-                    "User-Agent": f"{constants.USER_AGENT}",
+                    "User-Agent": self.user_agent,
                 }
                 if files is None:
                     headers["Content-Type"] = "application/json; charset=utf-8"

--- a/src/fabric_cicd/_common/_fabric_endpoint.py
+++ b/src/fabric_cicd/_common/_fabric_endpoint.py
@@ -27,16 +27,7 @@ _TOKEN_EXPIRY_BUFFER = datetime.timedelta(seconds=10)
 
 
 def _build_user_agent(user_agent: Optional[str]) -> str:
-    """Return the default user-agent, appending a trusted caller-supplied host-app.
-
-    The Fabric CLI ``deploy`` command supplies a value such as
-    ``ms-fabric-cicd/1.2.0,ms-fabric-cli/1.6.1 (deploy; Linux/...; Python/3.12.11)``.
-    When it matches ``constants.USER_AGENT_ALLOWLIST_REGEX`` (host app ``ms-fabric-cli``
-    running the ``deploy`` command) it is appended to the default user-agent as a
-    ``(host-app/...)`` suffix, e.g.
-    ``ms-fabric-cicd/<version>,(host-app/ms-fabric-cicd/1.2.0,ms-fabric-cli/1.6.1 (deploy; ...))``.
-    Otherwise only the default ``ms-fabric-cicd/<version>`` is used so arbitrary callers
-    cannot spoof an identity.
+    """Return the default user-agent, appending a trusted caller-supplied host-app if exists and supported.
 
     Args:
         user_agent: The user-agent supplied by the caller (e.g., the Fabric CLI).
@@ -45,11 +36,19 @@ def _build_user_agent(user_agent: Optional[str]) -> str:
         return constants.USER_AGENT
 
     candidate = user_agent.strip()
+    # Sanitize CR/LF for any log output so a crafted value cannot forge log lines.
+    sanitized = candidate.replace("\r", "\\r").replace("\n", "\\n")
+
+    # Never allow CR/LF in a value used as an HTTP header, regardless of the allowlist regex.
+    if "\r" in candidate or "\n" in candidate:
+        logger.debug(f"Ignoring caller-supplied user-agent containing CR/LF: {sanitized}")
+        return constants.USER_AGENT
+
     if constants.USER_AGENT_ALLOWLIST_REGEX.match(candidate):
-        logger.debug(f"Using caller-supplied user-agent: {candidate}")
+        logger.debug(f"Using caller-supplied user-agent: {sanitized}")
         return f"{constants.USER_AGENT},(host-app/{candidate})"
 
-    logger.debug(f"Ignoring untrusted caller-supplied user-agent: {candidate}")
+    logger.debug(f"Ignoring untrusted caller-supplied user-agent: {sanitized}")
     return constants.USER_AGENT
 
 

--- a/src/fabric_cicd/_common/_fabric_endpoint.py
+++ b/src/fabric_cicd/_common/_fabric_endpoint.py
@@ -7,6 +7,7 @@ import datetime
 import json
 import logging
 import os
+import re
 import time
 from typing import Optional
 
@@ -25,14 +26,18 @@ logger = logging.getLogger(__name__)
 _RESOURCE_URL = "https://api.fabric.microsoft.com/.default"
 _TOKEN_EXPIRY_BUFFER = datetime.timedelta(seconds=10)
 
+_USER_AGENT = f"ms-fabric-cicd/{constants.VERSION}"
+
+_HOST_APP_ALLOWLIST_REGEX = re.compile(r"\Ams-fabric-cli/\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?\Z")
+
 
 def _build_user_agent(host_app: Optional[str]) -> str:
-    """Return the user-agent"""
+    """Return the default user-agent, appending a trusted host-app token when supported."""
     candidate = host_app.strip() if isinstance(host_app, str) else ""
-    if candidate and constants.HOST_APP_ALLOWLIST_REGEX.match(candidate):
-        return f"{candidate} (deploy; {constants.USER_AGENT})"
+    if candidate and _HOST_APP_ALLOWLIST_REGEX.match(candidate):
+        return f"{candidate} (deploy; {_USER_AGENT})"
 
-    return constants.USER_AGENT
+    return _USER_AGENT
 
 
 class FabricEndpoint:

--- a/src/fabric_cicd/_common/_fabric_endpoint.py
+++ b/src/fabric_cicd/_common/_fabric_endpoint.py
@@ -27,22 +27,9 @@ _TOKEN_EXPIRY_BUFFER = datetime.timedelta(seconds=10)
 
 
 def _build_user_agent(host_app: Optional[str]) -> str:
-    """Return the default user-agent, appending a trusted host-app suffix when supported.
-
-    Args:
-        host_app: The host-app identifier supplied by a trusted caller (e.g. the Fabric CLI).
-            Only a value matching ``HOST_APP_ALLOWLIST_REGEX`` is appended; anything else is ignored.
-    """
-    if not isinstance(host_app, str) or not host_app.strip():
-        return constants.USER_AGENT
-
-    candidate = host_app.strip()
-
-    # Reject CR/LF to prevent HTTP header / log injection.
-    if "\r" in candidate or "\n" in candidate:
-        return constants.USER_AGENT
-
-    if constants.HOST_APP_ALLOWLIST_REGEX.match(candidate):
+    """Return the default user-agent, appending a trusted host-app suffix when supported."""
+    candidate = host_app.strip() if isinstance(host_app, str) else ""
+    if candidate and constants.HOST_APP_ALLOWLIST_REGEX.match(candidate):
         return f"{candidate} (deploy; {constants.USER_AGENT})"
 
     return constants.USER_AGENT

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -18,14 +18,10 @@ USER_AGENT = f"ms-fabric-cicd/{VERSION}"
 VALID_ENABLE_FLAGS = ["1", "true", "yes"]
 
 # Constants that must never be overridden via the public `constants:` config section.
-# These control security-sensitive or identity-related behavior and are only settable
-# through the internal Python API.
-PROTECTED_CONSTANTS = frozenset({"USER_AGENT", "USER_AGENT_ALLOWLIST_REGEX"})
+PROTECTED_CONSTANTS = frozenset({"USER_AGENT", "HOST_APP_ALLOWLIST_REGEX"})
 
-# Allowlist regex for a caller-supplied user-agent. The pattern uses
-# absolute anchors (\A/\Z) and explicitly excludes CR/LF so a crafted value cannot inject
-# additional HTTP headers or forge log lines via `\r`/`\n`.
-USER_AGENT_ALLOWLIST_REGEX = re.compile(r"\Ams-fabric-cicd/[^,\s]+,ms-fabric-cli/\S+[ \t]+\(deploy;[^\r\n]*\)\Z")
+# Allowlist for the host-app value; matches only a bare `ms-fabric-cli/<version>` token (no whitespace/CRLF).
+HOST_APP_ALLOWLIST_REGEX = re.compile(r"\Ams-fabric-cli/\S+\Z")
 
 
 class EnvVar(str, Enum):

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -4,6 +4,7 @@
 """Constants for the fabric-cicd package."""
 
 import os
+import re
 from enum import Enum
 
 from fabric_cicd._common._validate_env_vars import VALID_GUID_REGEX as VALID_GUID_REGEX
@@ -15,6 +16,16 @@ DEFAULT_GUID = "00000000-0000-0000-0000-000000000000"
 FEATURE_FLAG = set()
 USER_AGENT = f"ms-fabric-cicd/{VERSION}"
 VALID_ENABLE_FLAGS = ["1", "true", "yes"]
+
+# Constants that must never be overridden via the public `constants:` config section.
+# These control security-sensitive or identity-related behavior and are only settable
+# through the internal Python API.
+PROTECTED_CONSTANTS = frozenset({"USER_AGENT"})
+
+# Allowlist regex for a caller-supplied user-agent. Only a user-agent produced by the
+# Fabric CLI `deploy` command is trusted and used verbatim; anything else falls back to
+# the default USER_AGENT so arbitrary callers cannot spoof an identity.
+USER_AGENT_ALLOWLIST_REGEX = re.compile(r"^ms-fabric-cicd/[^,\s]+,ms-fabric-cli/\S+\s+\(deploy;.*\)$")
 
 
 class EnvVar(str, Enum):
@@ -465,6 +476,7 @@ CONFIG_VALIDATION_MSGS = {
         "empty_section_env": "'{}.{}' cannot be empty if specified",
         "invalid_constant_key": "Constant key in '{}' must be a non-empty string, got: {}",
         "unknown_constant": "Unknown constant '{}' in '{}' - this constant does not exist in fabric_cicd.constants",
+        "protected_constant": "Constant '{}' in '{}' is protected and cannot be overridden via configuration",
         "folders_list_prefix": "'{}[{}]' entry must start with '/' (got '{}')",
         "mutually_exclusive": "Cannot specify both '{}' and '{}'. Choose one filtering strategy.",
         "mutually_exclusive_env": "Cannot specify both '{}' and '{}' for the same environment(s): {}. Choose one filtering strategy per environment.",

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -20,12 +20,12 @@ VALID_ENABLE_FLAGS = ["1", "true", "yes"]
 # Constants that must never be overridden via the public `constants:` config section.
 # These control security-sensitive or identity-related behavior and are only settable
 # through the internal Python API.
-PROTECTED_CONSTANTS = frozenset({"USER_AGENT"})
+PROTECTED_CONSTANTS = frozenset({"USER_AGENT", "USER_AGENT_ALLOWLIST_REGEX"})
 
-# Allowlist regex for a caller-supplied user-agent. Only a user-agent produced by the
-# Fabric CLI `deploy` command is trusted and used verbatim; anything else falls back to
-# the default USER_AGENT so arbitrary callers cannot spoof an identity.
-USER_AGENT_ALLOWLIST_REGEX = re.compile(r"^ms-fabric-cicd/[^,\s]+,ms-fabric-cli/\S+\s+\(deploy;.*\)$")
+# Allowlist regex for a caller-supplied user-agent. The pattern uses
+# absolute anchors (\A/\Z) and explicitly excludes CR/LF so a crafted value cannot inject
+# additional HTTP headers or forge log lines via `\r`/`\n`.
+USER_AGENT_ALLOWLIST_REGEX = re.compile(r"\Ams-fabric-cicd/[^,\s]+,ms-fabric-cli/\S+[ \t]+\(deploy;[^\r\n]*\)\Z")
 
 
 class EnvVar(str, Enum):

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -4,7 +4,6 @@
 """Constants for the fabric-cicd package."""
 
 import os
-import re
 from enum import Enum
 
 from fabric_cicd._common._validate_env_vars import VALID_GUID_REGEX as VALID_GUID_REGEX
@@ -14,14 +13,7 @@ from fabric_cicd._common._validate_env_vars import validate_env_var_api_url
 VERSION = "1.2.0"
 DEFAULT_GUID = "00000000-0000-0000-0000-000000000000"
 FEATURE_FLAG = set()
-USER_AGENT = f"ms-fabric-cicd/{VERSION}"
 VALID_ENABLE_FLAGS = ["1", "true", "yes"]
-
-# Constants that must never be overridden via the public `constants:` config section.
-PROTECTED_CONSTANTS = frozenset({"USER_AGENT", "HOST_APP_ALLOWLIST_REGEX"})
-
-# Allowlist for the host-app value;
-HOST_APP_ALLOWLIST_REGEX = re.compile(r"\Ams-fabric-cli/\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?\Z")
 
 
 class EnvVar(str, Enum):
@@ -472,7 +464,6 @@ CONFIG_VALIDATION_MSGS = {
         "empty_section_env": "'{}.{}' cannot be empty if specified",
         "invalid_constant_key": "Constant key in '{}' must be a non-empty string, got: {}",
         "unknown_constant": "Unknown constant '{}' in '{}' - this constant does not exist in fabric_cicd.constants",
-        "protected_constant": "Constant '{}' in '{}' is protected and cannot be overridden via configuration",
         "folders_list_prefix": "'{}[{}]' entry must start with '/' (got '{}')",
         "mutually_exclusive": "Cannot specify both '{}' and '{}'. Choose one filtering strategy.",
         "mutually_exclusive_env": "Cannot specify both '{}' and '{}' for the same environment(s): {}. Choose one filtering strategy per environment.",

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -20,8 +20,8 @@ VALID_ENABLE_FLAGS = ["1", "true", "yes"]
 # Constants that must never be overridden via the public `constants:` config section.
 PROTECTED_CONSTANTS = frozenset({"USER_AGENT", "HOST_APP_ALLOWLIST_REGEX"})
 
-# Allowlist for the host-app value; matches only a bare `ms-fabric-cli/<version>` token (no whitespace/CRLF).
-HOST_APP_ALLOWLIST_REGEX = re.compile(r"\Ams-fabric-cli/\S+\Z")
+# Allowlist for the host-app value;
+HOST_APP_ALLOWLIST_REGEX = re.compile(r"\Ams-fabric-cli/\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?\Z")
 
 
 class EnvVar(str, Enum):

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -111,7 +111,7 @@ class FabricWorkspace:
         token_credential = validate_token_credential(token_credential)
 
         # Initialize endpoint
-        self.endpoint = FabricEndpoint(token_credential=token_credential)
+        self.endpoint = FabricEndpoint(token_credential=token_credential, user_agent=kwargs.get("user_agent"))
 
         # Snapshot at construction so subsequent configure_fabric_fqdn calls for a
         # different workspace don't retarget this instance.

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -111,7 +111,7 @@ class FabricWorkspace:
         token_credential = validate_token_credential(token_credential)
 
         # Initialize endpoint
-        self.endpoint = FabricEndpoint(token_credential=token_credential, user_agent=kwargs.get("user_agent"))
+        self.endpoint = FabricEndpoint(token_credential=token_credential, host_app=kwargs.get("host_app"))
 
         # Snapshot at construction so subsequent configure_fabric_fqdn calls for a
         # different workspace don't retarget this instance.

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -529,7 +529,6 @@ def deploy_with_config(  # noqa: D417
         ...     print(e.deployment_result.message)   # Original error message
         ...     print(e.deployment_result.responses) # Partial API responses or None
     """
-    # Trusted first-party callers (e.g. the Fabric CLI) may pass ``host_app`` via kwargs to
     # Trusted first-party callers may pass ``host_app`` via kwargs to
     host_app = kwargs.get("host_app")
 

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -530,7 +530,6 @@ def deploy_with_config(  # noqa: D417
         ...     print(e.deployment_result.message)   # Original error message
         ...     print(e.deployment_result.responses) # Partial API responses or None
     """
-    # Trusted first-party callers may pass ``host_app`` via kwargs to
     host_app = kwargs.get("host_app")
 
     log_header(logger, "Config-Based Deployment")

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -192,7 +192,7 @@ def publish_all_items(
         ...     publish_all_items(workspace, items_to_include=changed)
     """
     fabric_workspace_obj = validate_fabric_workspace_obj(fabric_workspace_obj)
-    
+
     # Initialize response collection if feature flag is enabled
     responses_enabled = FeatureFlag.ENABLE_RESPONSE_COLLECTION.value in constants.FEATURE_FLAG
     if responses_enabled:
@@ -217,14 +217,14 @@ def publish_all_items(
         if FeatureFlag.ENABLE_EXPERIMENTAL_FEATURES.value not in constants.FEATURE_FLAG:
             msg = "The 'enable_bulk_publish' feature flag requires 'enable_experimental_features' to be enabled."
             raise InputError(msg, logger)
-        
+
         reasons = []
         unsupported = set(fabric_workspace_obj.item_type_in_scope) - set(constants.BULK_ACCEPTED_ITEM_TYPES)
         # Fall back to standard deployment if unsupported item types or dynamic parameter variables are detected, otherwise enable bulk publish
         if unsupported or fabric_workspace_obj.contains_param_vars:
             if unsupported:
                 reasons.append(f"unsupported item types: {', '.join(sorted(unsupported))}")
-                
+
             if fabric_workspace_obj.contains_param_vars:
                 reasons.append(
                     "parameter file contains dynamic variables ($workspace/$items) requiring runtime resolution"
@@ -427,13 +427,13 @@ def unpublish_all_orphan_items(
     )
 
 
-def deploy_with_config(
+def deploy_with_config(  # noqa: D417
     config_file_path: str,
     *,
     token_credential: TokenCredential,
     environment: str = "N/A",
     config_override: Optional[dict] = None,
-    user_agent: Optional[str] = None,
+    **kwargs,
 ) -> DeploymentResult:
     """
     Deploy items using YAML configuration file with environment-specific settings.
@@ -447,7 +447,6 @@ def deploy_with_config(
         token_credential: Azure token credential for authentication (e.g., AzureCliCredential, ClientSecretCredential) - required.
         environment: Environment name to use for deployment (e.g., 'dev', 'test', 'prod'), if missing defaults to 'N/A'.
         config_override: Optional dictionary to override specific configuration values.
-        user_agent: Optional user-agent supplied by a trusted host application.
 
     Returns:
         DeploymentResult: A result object containing the deployment status, message, and
@@ -530,6 +529,10 @@ def deploy_with_config(
         ...     print(e.deployment_result.message)   # Original error message
         ...     print(e.deployment_result.responses) # Partial API responses or None
     """
+    # Trusted first-party callers (e.g. the Fabric CLI) may pass ``host_app`` via kwargs to
+    # Trusted first-party callers may pass ``host_app`` via kwargs to
+    host_app = kwargs.get("host_app")
+
     log_header(logger, "Config-Based Deployment")
     logger.info(f"Loading configuration from {config_file_path} for environment '{environment}'")
 
@@ -569,7 +572,7 @@ def deploy_with_config(
                 token_credential=token_credential,
                 parameter_file_path=workspace_settings.get("parameter_file_path"),
                 skip_parameterization=skip_parameterization,
-                user_agent=user_agent,
+                host_app=host_app,
             )
             # Execute deployment operations based on skip settings
             if not publish_settings.get("skip", False):

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -230,7 +230,6 @@ def publish_all_items(
                     "parameter file contains dynamic variables ($workspace/$items) requiring runtime resolution"
                 )
             logger.warning(f"Falling back to standard deployment. Reason: {'; '.join(reasons)}.")
-       
         else:
             fabric_workspace_obj.bulk_publish_enabled = True
 
@@ -434,6 +433,7 @@ def deploy_with_config(
     token_credential: TokenCredential,
     environment: str = "N/A",
     config_override: Optional[dict] = None,
+    user_agent: Optional[str] = None,
 ) -> DeploymentResult:
     """
     Deploy items using YAML configuration file with environment-specific settings.
@@ -447,6 +447,13 @@ def deploy_with_config(
         token_credential: Azure token credential for authentication (e.g., AzureCliCredential, ClientSecretCredential) - required.
         environment: Environment name to use for deployment (e.g., 'dev', 'test', 'prod'), if missing defaults to 'N/A'.
         config_override: Optional dictionary to override specific configuration values.
+        user_agent: Optional user-agent supplied by a trusted host application (the Fabric CLI
+            ``deploy`` command), e.g.
+            ``ms-fabric-cicd/1.2.0,ms-fabric-cli/1.6.1 (deploy; Linux/...; Python/3.12.11)``. When
+            it matches ``constants.USER_AGENT_ALLOWLIST_REGEX`` it is appended to the default
+            user-agent as a ``(host-app/...)`` suffix; otherwise only the default
+            ``ms-fabric-cicd/<version>`` is used. This is a Python API argument only and cannot be
+            set through the config file or ``config_override``.
 
     Returns:
         DeploymentResult: A result object containing the deployment status, message, and
@@ -568,6 +575,7 @@ def deploy_with_config(
                 token_credential=token_credential,
                 parameter_file_path=workspace_settings.get("parameter_file_path"),
                 skip_parameterization=skip_parameterization,
+                user_agent=user_agent,
             )
             # Execute deployment operations based on skip settings
             if not publish_settings.get("skip", False):

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -447,13 +447,7 @@ def deploy_with_config(
         token_credential: Azure token credential for authentication (e.g., AzureCliCredential, ClientSecretCredential) - required.
         environment: Environment name to use for deployment (e.g., 'dev', 'test', 'prod'), if missing defaults to 'N/A'.
         config_override: Optional dictionary to override specific configuration values.
-        user_agent: Optional user-agent supplied by a trusted host application (the Fabric CLI
-            ``deploy`` command), e.g.
-            ``ms-fabric-cicd/1.2.0,ms-fabric-cli/1.6.1 (deploy; Linux/...; Python/3.12.11)``. When
-            it matches ``constants.USER_AGENT_ALLOWLIST_REGEX`` it is appended to the default
-            user-agent as a ``(host-app/...)`` suffix; otherwise only the default
-            ``ms-fabric-cicd/<version>`` is used. This is a Python API argument only and cannot be
-            set through the config file or ``config_override``.
+        user_agent: Optional user-agent supplied by a trusted host application.
 
     Returns:
         DeploymentResult: A result object containing the deployment status, message, and

--- a/tests/test__fabric_endpoint.py
+++ b/tests/test__fabric_endpoint.py
@@ -361,6 +361,10 @@ _VALID_CLI_USER_AGENT_COMPOSED = f"{constants.USER_AGENT},(host-app/{_VALID_CLI_
         # Arbitrary spoofed identity is rejected.
         ("malicious-app/9.9.9 (deploy; Linux/6.6; Python/3.12)", constants.USER_AGENT),
         ("not-a-user-agent", constants.USER_AGENT),
+        # CR/LF injection attempts are rejected (header/log injection guard).
+        ("ms-fabric-cicd/1.2.0,ms-fabric-cli/1.6.1 (deploy; x\rInjected: 1)", constants.USER_AGENT),
+        ("ms-fabric-cicd/1.2.0,ms-fabric-cli/1.6.1 (deploy; x\nInjected: 1)", constants.USER_AGENT),
+        ("ms-fabric-cicd/1.2.0,ms-fabric-cli/1.6.1 (deploy; ok)\r\nX-Injected: 1", constants.USER_AGENT),
     ],
     ids=[
         "none",
@@ -372,6 +376,9 @@ _VALID_CLI_USER_AGENT_COMPOSED = f"{constants.USER_AGENT},(host-app/{_VALID_CLI_
         "missing_cli_rejected",
         "spoofed_identity_rejected",
         "junk_rejected",
+        "cr_injection_rejected",
+        "lf_injection_rejected",
+        "trailing_crlf_injection_rejected",
     ],
 )
 def test_build_user_agent(user_agent, expected):
@@ -415,6 +422,18 @@ def test_build_user_agent_logs_supplied_host(setup_mocks):
     dl.messages.clear()
     _build_user_agent("spoofed-app/1.0.0 (deploy)")
     assert any("spoofed-app/1.0.0 (deploy)" in message for message in dl.messages)
+
+
+def test_build_user_agent_sanitizes_crlf_in_log(setup_mocks):
+    """Test a CR/LF-bearing user-agent is rejected and its logged form is sanitized (no raw CR/LF)."""
+    dl, _ = setup_mocks
+
+    result = _build_user_agent("ms-fabric-cicd/1.2.0,ms-fabric-cli/1.6.1 (deploy; ok)\r\nX-Injected: 1")
+
+    assert result == constants.USER_AGENT
+    # The raw CR/LF must never reach the log; the escaped form should appear instead.
+    assert all("\r" not in message and "\n" not in message for message in dl.messages)
+    assert any("\\r\\nX-Injected: 1" in message for message in dl.messages)
 
 
 @pytest.mark.parametrize(

--- a/tests/test__fabric_endpoint.py
+++ b/tests/test__fabric_endpoint.py
@@ -354,8 +354,13 @@ _VALID_HOST_APP_COMPOSED = f"{_VALID_HOST_APP} (deploy; {constants.USER_AGENT})"
         ("   ", constants.USER_AGENT),
         (_VALID_HOST_APP, _VALID_HOST_APP_COMPOSED),
         (f"  {_VALID_HOST_APP}  ", _VALID_HOST_APP_COMPOSED),
+        # Pre-release and build-metadata semver tokens are accepted.
+        ("ms-fabric-cli/1.0.0-beta", f"ms-fabric-cli/1.0.0-beta (deploy; {constants.USER_AGENT})"),
+        ("ms-fabric-cli/1.0.0+build.123", f"ms-fabric-cli/1.0.0+build.123 (deploy; {constants.USER_AGENT})"),
         # Missing version is rejected.
         ("ms-fabric-cli", constants.USER_AGENT),
+        # Incomplete semver (missing patch) is rejected.
+        ("ms-fabric-cli/1.6", constants.USER_AGENT),
         # A full user-agent string (with spaces) is rejected; only the bare product token is allowed.
         ("ms-fabric-cli/1.6.1 (deploy; Linux/6.6; Python/3.12)", constants.USER_AGENT),
         # Arbitrary spoofed identity is rejected.
@@ -372,7 +377,10 @@ _VALID_HOST_APP_COMPOSED = f"{_VALID_HOST_APP} (deploy; {constants.USER_AGENT})"
         "whitespace",
         "valid_host_app",
         "valid_surrounding_whitespace",
+        "valid_prerelease",
+        "valid_build_metadata",
         "missing_version_rejected",
+        "incomplete_semver_rejected",
         "full_user_agent_rejected",
         "spoofed_identity_rejected",
         "junk_rejected",

--- a/tests/test__fabric_endpoint.py
+++ b/tests/test__fabric_endpoint.py
@@ -11,6 +11,7 @@ from azure.core.exceptions import ClientAuthenticationError
 from fabric_cicd import constants
 from fabric_cicd._common._exceptions import InvokeError, TokenError
 from fabric_cicd._common._fabric_endpoint import (
+    _USER_AGENT,
     FabricEndpoint,
     _build_user_agent,
     _format_invoke_log,
@@ -340,36 +341,28 @@ def test_get_token(setup_mocks):
     mock_token_credential.get_token.assert_called_once_with("https://api.fabric.microsoft.com/.default")
 
 
-# A host-app value that matches the allowlist regex (bare ms-fabric-cli product token).
 _VALID_HOST_APP = "ms-fabric-cli/1.6.1"
-# The composed User-Agent header when the host-app value is trusted (host-app token + default UA).
-_VALID_HOST_APP_COMPOSED = f"{_VALID_HOST_APP} (deploy; {constants.USER_AGENT})"
+_VALID_HOST_APP_COMPOSED = f"{_VALID_HOST_APP} (deploy; {_USER_AGENT})"
 
 
 @pytest.mark.parametrize(
     ("host_app", "expected"),
     [
-        (None, constants.USER_AGENT),
-        ("", constants.USER_AGENT),
-        ("   ", constants.USER_AGENT),
+        (None, _USER_AGENT),
+        ("", _USER_AGENT),
+        ("   ", _USER_AGENT),
         (_VALID_HOST_APP, _VALID_HOST_APP_COMPOSED),
         (f"  {_VALID_HOST_APP}  ", _VALID_HOST_APP_COMPOSED),
-        # Pre-release and build-metadata semver tokens are accepted.
-        ("ms-fabric-cli/1.0.0-beta", f"ms-fabric-cli/1.0.0-beta (deploy; {constants.USER_AGENT})"),
-        ("ms-fabric-cli/1.0.0+build.123", f"ms-fabric-cli/1.0.0+build.123 (deploy; {constants.USER_AGENT})"),
-        # Missing version is rejected.
-        ("ms-fabric-cli", constants.USER_AGENT),
-        # Incomplete semver (missing patch) is rejected.
-        ("ms-fabric-cli/1.6", constants.USER_AGENT),
-        # A full user-agent string (with spaces) is rejected; only the bare product token is allowed.
-        ("ms-fabric-cli/1.6.1 (deploy; Linux/6.6; Python/3.12)", constants.USER_AGENT),
-        # Arbitrary spoofed identity is rejected.
-        ("malicious-app/9.9.9", constants.USER_AGENT),
-        ("not-a-host-app", constants.USER_AGENT),
-        # CR/LF injection attempts are rejected (header/log injection guard).
-        ("ms-fabric-cli/1.6.1\rInjected: 1", constants.USER_AGENT),
-        ("ms-fabric-cli/1.6.1\nInjected: 1", constants.USER_AGENT),
-        ("ms-fabric-cli/1.6.1\r\nX-Injected: 1", constants.USER_AGENT),
+        ("ms-fabric-cli/1.0.0-beta", f"ms-fabric-cli/1.0.0-beta (deploy; {_USER_AGENT})"),
+        ("ms-fabric-cli/1.0.0+build.123", f"ms-fabric-cli/1.0.0+build.123 (deploy; {_USER_AGENT})"),
+        ("ms-fabric-cli", _USER_AGENT),
+        ("ms-fabric-cli/1.6", _USER_AGENT),
+        ("ms-fabric-cli/1.6.1 (deploy; Linux/6.6; Python/3.12)", _USER_AGENT),
+        ("malicious-app/9.9.9", _USER_AGENT),
+        ("not-a-host-app", _USER_AGENT),
+        ("ms-fabric-cli/1.6.1\rInjected: 1", _USER_AGENT),
+        ("ms-fabric-cli/1.6.1\nInjected: 1", _USER_AGENT),
+        ("ms-fabric-cli/1.6.1\r\nX-Injected: 1", _USER_AGENT),
     ],
     ids=[
         "none",
@@ -397,11 +390,11 @@ def test_build_user_agent(host_app, expected):
 @pytest.mark.parametrize(
     ("host_app", "expected_user_agent"),
     [
-        (None, constants.USER_AGENT),
-        ("", constants.USER_AGENT),
-        ("   ", constants.USER_AGENT),
+        (None, _USER_AGENT),
+        ("", _USER_AGENT),
+        ("   ", _USER_AGENT),
         (_VALID_HOST_APP, _VALID_HOST_APP_COMPOSED),
-        ("bogus-app/1.0.0", constants.USER_AGENT),
+        ("bogus-app/1.0.0", _USER_AGENT),
     ],
     ids=["none", "empty", "whitespace", "valid_host_app", "untrusted_ignored"],
 )
@@ -426,7 +419,7 @@ def test_build_user_agent_ignores_untrusted_value(setup_mocks):
 
     result = _build_user_agent("spoofed-app/1.0.0")
 
-    assert result == constants.USER_AGENT
+    assert result == _USER_AGENT
     assert all("spoofed-app/1.0.0" not in message for message in dl.messages)
 
 
@@ -436,8 +429,7 @@ def test_build_user_agent_rejects_crlf(setup_mocks):
 
     result = _build_user_agent("ms-fabric-cli/1.6.1\r\nX-Injected: 1")
 
-    assert result == constants.USER_AGENT
-    # The raw CR/LF must never reach the log.
+    assert result == _USER_AGENT
     assert all("\r" not in message and "\n" not in message for message in dl.messages)
 
 

--- a/tests/test__fabric_endpoint.py
+++ b/tests/test__fabric_endpoint.py
@@ -340,40 +340,40 @@ def test_get_token(setup_mocks):
     mock_token_credential.get_token.assert_called_once_with("https://api.fabric.microsoft.com/.default")
 
 
-# A user-agent that matches the CLI deploy allowlist regex.
-_VALID_CLI_USER_AGENT = "ms-fabric-cicd/1.2.0,ms-fabric-cli/1.6.1 (deploy; Linux/6.6.87-WSL2; Python/3.12.11)"
-# The composed User-Agent header when the CLI value is trusted (default UA + host-app suffix).
-_VALID_CLI_USER_AGENT_COMPOSED = f"{constants.USER_AGENT},(host-app/{_VALID_CLI_USER_AGENT})"
+# A host-app value that matches the allowlist regex (bare ms-fabric-cli product token).
+_VALID_HOST_APP = "ms-fabric-cli/1.6.1"
+# The composed User-Agent header when the host-app value is trusted (host-app token + default UA).
+_VALID_HOST_APP_COMPOSED = f"{_VALID_HOST_APP} (deploy; {constants.USER_AGENT})"
 
 
 @pytest.mark.parametrize(
-    ("user_agent", "expected"),
+    ("host_app", "expected"),
     [
         (None, constants.USER_AGENT),
         ("", constants.USER_AGENT),
         ("   ", constants.USER_AGENT),
-        (_VALID_CLI_USER_AGENT, _VALID_CLI_USER_AGENT_COMPOSED),
-        (f"  {_VALID_CLI_USER_AGENT}  ", _VALID_CLI_USER_AGENT_COMPOSED),
-        # Wrong command (not deploy) is rejected.
-        ("ms-fabric-cicd/1.2.0,ms-fabric-cli/1.6.1 (publish; Linux/6.6; Python/3.12)", constants.USER_AGENT),
-        # Missing ms-fabric-cli host app is rejected.
-        ("ms-fabric-cicd/1.2.0 (deploy; Linux/6.6; Python/3.12)", constants.USER_AGENT),
+        (_VALID_HOST_APP, _VALID_HOST_APP_COMPOSED),
+        (f"  {_VALID_HOST_APP}  ", _VALID_HOST_APP_COMPOSED),
+        # Missing version is rejected.
+        ("ms-fabric-cli", constants.USER_AGENT),
+        # A full user-agent string (with spaces) is rejected; only the bare product token is allowed.
+        ("ms-fabric-cli/1.6.1 (deploy; Linux/6.6; Python/3.12)", constants.USER_AGENT),
         # Arbitrary spoofed identity is rejected.
-        ("malicious-app/9.9.9 (deploy; Linux/6.6; Python/3.12)", constants.USER_AGENT),
-        ("not-a-user-agent", constants.USER_AGENT),
+        ("malicious-app/9.9.9", constants.USER_AGENT),
+        ("not-a-host-app", constants.USER_AGENT),
         # CR/LF injection attempts are rejected (header/log injection guard).
-        ("ms-fabric-cicd/1.2.0,ms-fabric-cli/1.6.1 (deploy; x\rInjected: 1)", constants.USER_AGENT),
-        ("ms-fabric-cicd/1.2.0,ms-fabric-cli/1.6.1 (deploy; x\nInjected: 1)", constants.USER_AGENT),
-        ("ms-fabric-cicd/1.2.0,ms-fabric-cli/1.6.1 (deploy; ok)\r\nX-Injected: 1", constants.USER_AGENT),
+        ("ms-fabric-cli/1.6.1\rInjected: 1", constants.USER_AGENT),
+        ("ms-fabric-cli/1.6.1\nInjected: 1", constants.USER_AGENT),
+        ("ms-fabric-cli/1.6.1\r\nX-Injected: 1", constants.USER_AGENT),
     ],
     ids=[
         "none",
         "empty",
         "whitespace",
-        "valid_cli_deploy",
+        "valid_host_app",
         "valid_surrounding_whitespace",
-        "wrong_command_rejected",
-        "missing_cli_rejected",
+        "missing_version_rejected",
+        "full_user_agent_rejected",
         "spoofed_identity_rejected",
         "junk_rejected",
         "cr_injection_rejected",
@@ -381,31 +381,31 @@ _VALID_CLI_USER_AGENT_COMPOSED = f"{constants.USER_AGENT},(host-app/{_VALID_CLI_
         "trailing_crlf_injection_rejected",
     ],
 )
-def test_build_user_agent(user_agent, expected):
-    """Test a trusted CLI deploy user-agent is appended as a host-app, else the default is used."""
-    assert _build_user_agent(user_agent) == expected
+def test_build_user_agent(host_app, expected):
+    """Test a trusted host-app is appended as a host-app suffix, else the default is used."""
+    assert _build_user_agent(host_app) == expected
 
 
 @pytest.mark.parametrize(
-    ("user_agent", "expected_user_agent"),
+    ("host_app", "expected_user_agent"),
     [
         (None, constants.USER_AGENT),
         ("", constants.USER_AGENT),
         ("   ", constants.USER_AGENT),
-        (_VALID_CLI_USER_AGENT, _VALID_CLI_USER_AGENT_COMPOSED),
-        ("bogus-app/1.0.0 (deploy)", constants.USER_AGENT),
+        (_VALID_HOST_APP, _VALID_HOST_APP_COMPOSED),
+        ("bogus-app/1.0.0", constants.USER_AGENT),
     ],
-    ids=["none", "empty", "whitespace", "valid_cli_deploy", "untrusted_ignored"],
+    ids=["none", "empty", "whitespace", "valid_host_app", "untrusted_ignored"],
 )
-def test_invoke_sets_user_agent_header(setup_mocks, user_agent, expected_user_agent):
-    """Test invoke sends the trusted CLI user-agent verbatim, else the default."""
+def test_invoke_sets_user_agent_header(setup_mocks, host_app, expected_user_agent):
+    """Test invoke sends the composed host-app user-agent when trusted, else the default."""
     _, mock_requests = setup_mocks
     mock_requests.return_value = Mock(
         status_code=200, headers={"Content-Type": "application/json"}, json=Mock(return_value={})
     )
     mock_token_credential = Mock()
     mock_token_credential.get_token.return_value = Mock(token=generate_mock_token(), expires_on=9999999999)
-    endpoint = FabricEndpoint(token_credential=mock_token_credential, user_agent=user_agent)
+    endpoint = FabricEndpoint(token_credential=mock_token_credential, host_app=host_app)
     endpoint.invoke("GET", "http://example.com")
 
     sent_headers = mock_requests.call_args.kwargs["headers"]
@@ -413,20 +413,20 @@ def test_invoke_sets_user_agent_header(setup_mocks, user_agent, expected_user_ag
 
 
 def test_build_user_agent_ignores_untrusted_value(setup_mocks):
-    """Test an untrusted (non-allowlisted) user-agent is ignored and never written to the log."""
+    """Test an untrusted (non-allowlisted) host-app is ignored and never written to the log."""
     dl, _ = setup_mocks
 
-    result = _build_user_agent("spoofed-app/1.0.0 (deploy)")
+    result = _build_user_agent("spoofed-app/1.0.0")
 
     assert result == constants.USER_AGENT
-    assert all("spoofed-app/1.0.0 (deploy)" not in message for message in dl.messages)
+    assert all("spoofed-app/1.0.0" not in message for message in dl.messages)
 
 
 def test_build_user_agent_rejects_crlf(setup_mocks):
-    """Test a CR/LF-bearing user-agent is rejected and never written to the log."""
+    """Test a CR/LF-bearing host-app is rejected and never written to the log."""
     dl, _ = setup_mocks
 
-    result = _build_user_agent("ms-fabric-cicd/1.2.0,ms-fabric-cli/1.6.1 (deploy; ok)\r\nX-Injected: 1")
+    result = _build_user_agent("ms-fabric-cli/1.6.1\r\nX-Injected: 1")
 
     assert result == constants.USER_AGENT
     # The raw CR/LF must never reach the log.

--- a/tests/test__fabric_endpoint.py
+++ b/tests/test__fabric_endpoint.py
@@ -10,7 +10,13 @@ from azure.core.exceptions import ClientAuthenticationError
 
 from fabric_cicd import constants
 from fabric_cicd._common._exceptions import InvokeError, TokenError
-from fabric_cicd._common._fabric_endpoint import FabricEndpoint, _format_invoke_log, _handle_response, handle_retry
+from fabric_cicd._common._fabric_endpoint import (
+    FabricEndpoint,
+    _build_user_agent,
+    _format_invoke_log,
+    _handle_response,
+    handle_retry,
+)
 
 
 class DummyLogger:
@@ -332,6 +338,83 @@ def test_get_token(setup_mocks):
     assert endpoint._get_token() == "test_token"  # Second call uses cache
     # Only called once at init — subsequent calls return cached
     mock_token_credential.get_token.assert_called_once_with("https://api.fabric.microsoft.com/.default")
+
+
+# A user-agent that matches the CLI deploy allowlist regex.
+_VALID_CLI_USER_AGENT = "ms-fabric-cicd/1.2.0,ms-fabric-cli/1.6.1 (deploy; Linux/6.6.87-WSL2; Python/3.12.11)"
+# The composed User-Agent header when the CLI value is trusted (default UA + host-app suffix).
+_VALID_CLI_USER_AGENT_COMPOSED = f"{constants.USER_AGENT},(host-app/{_VALID_CLI_USER_AGENT})"
+
+
+@pytest.mark.parametrize(
+    ("user_agent", "expected"),
+    [
+        (None, constants.USER_AGENT),
+        ("", constants.USER_AGENT),
+        ("   ", constants.USER_AGENT),
+        (_VALID_CLI_USER_AGENT, _VALID_CLI_USER_AGENT_COMPOSED),
+        (f"  {_VALID_CLI_USER_AGENT}  ", _VALID_CLI_USER_AGENT_COMPOSED),
+        # Wrong command (not deploy) is rejected.
+        ("ms-fabric-cicd/1.2.0,ms-fabric-cli/1.6.1 (publish; Linux/6.6; Python/3.12)", constants.USER_AGENT),
+        # Missing ms-fabric-cli host app is rejected.
+        ("ms-fabric-cicd/1.2.0 (deploy; Linux/6.6; Python/3.12)", constants.USER_AGENT),
+        # Arbitrary spoofed identity is rejected.
+        ("malicious-app/9.9.9 (deploy; Linux/6.6; Python/3.12)", constants.USER_AGENT),
+        ("not-a-user-agent", constants.USER_AGENT),
+    ],
+    ids=[
+        "none",
+        "empty",
+        "whitespace",
+        "valid_cli_deploy",
+        "valid_surrounding_whitespace",
+        "wrong_command_rejected",
+        "missing_cli_rejected",
+        "spoofed_identity_rejected",
+        "junk_rejected",
+    ],
+)
+def test_build_user_agent(user_agent, expected):
+    """Test a trusted CLI deploy user-agent is appended as a host-app, else the default is used."""
+    assert _build_user_agent(user_agent) == expected
+
+
+@pytest.mark.parametrize(
+    ("user_agent", "expected_user_agent"),
+    [
+        (None, constants.USER_AGENT),
+        ("", constants.USER_AGENT),
+        ("   ", constants.USER_AGENT),
+        (_VALID_CLI_USER_AGENT, _VALID_CLI_USER_AGENT_COMPOSED),
+        ("bogus-app/1.0.0 (deploy)", constants.USER_AGENT),
+    ],
+    ids=["none", "empty", "whitespace", "valid_cli_deploy", "untrusted_ignored"],
+)
+def test_invoke_sets_user_agent_header(setup_mocks, user_agent, expected_user_agent):
+    """Test invoke sends the trusted CLI user-agent verbatim, else the default."""
+    _, mock_requests = setup_mocks
+    mock_requests.return_value = Mock(
+        status_code=200, headers={"Content-Type": "application/json"}, json=Mock(return_value={})
+    )
+    mock_token_credential = Mock()
+    mock_token_credential.get_token.return_value = Mock(token=generate_mock_token(), expires_on=9999999999)
+    endpoint = FabricEndpoint(token_credential=mock_token_credential, user_agent=user_agent)
+    endpoint.invoke("GET", "http://example.com")
+
+    sent_headers = mock_requests.call_args.kwargs["headers"]
+    assert sent_headers["User-Agent"] == expected_user_agent
+
+
+def test_build_user_agent_logs_supplied_host(setup_mocks):
+    """Test the supplied user-agent is written to the log for both accepted and rejected values."""
+    dl, _ = setup_mocks
+
+    _build_user_agent(_VALID_CLI_USER_AGENT)
+    assert any(_VALID_CLI_USER_AGENT in message for message in dl.messages)
+
+    dl.messages.clear()
+    _build_user_agent("spoofed-app/1.0.0 (deploy)")
+    assert any("spoofed-app/1.0.0 (deploy)" in message for message in dl.messages)
 
 
 @pytest.mark.parametrize(

--- a/tests/test__fabric_endpoint.py
+++ b/tests/test__fabric_endpoint.py
@@ -412,28 +412,25 @@ def test_invoke_sets_user_agent_header(setup_mocks, user_agent, expected_user_ag
     assert sent_headers["User-Agent"] == expected_user_agent
 
 
-def test_build_user_agent_logs_supplied_host(setup_mocks):
-    """Test the supplied user-agent is written to the log for both accepted and rejected values."""
+def test_build_user_agent_ignores_untrusted_value(setup_mocks):
+    """Test an untrusted (non-allowlisted) user-agent is ignored and never written to the log."""
     dl, _ = setup_mocks
 
-    _build_user_agent(_VALID_CLI_USER_AGENT)
-    assert any(_VALID_CLI_USER_AGENT in message for message in dl.messages)
+    result = _build_user_agent("spoofed-app/1.0.0 (deploy)")
 
-    dl.messages.clear()
-    _build_user_agent("spoofed-app/1.0.0 (deploy)")
-    assert any("spoofed-app/1.0.0 (deploy)" in message for message in dl.messages)
+    assert result == constants.USER_AGENT
+    assert all("spoofed-app/1.0.0 (deploy)" not in message for message in dl.messages)
 
 
-def test_build_user_agent_sanitizes_crlf_in_log(setup_mocks):
-    """Test a CR/LF-bearing user-agent is rejected and its logged form is sanitized (no raw CR/LF)."""
+def test_build_user_agent_rejects_crlf(setup_mocks):
+    """Test a CR/LF-bearing user-agent is rejected and never written to the log."""
     dl, _ = setup_mocks
 
     result = _build_user_agent("ms-fabric-cicd/1.2.0,ms-fabric-cli/1.6.1 (deploy; ok)\r\nX-Injected: 1")
 
     assert result == constants.USER_AGENT
-    # The raw CR/LF must never reach the log; the escaped form should appear instead.
+    # The raw CR/LF must never reach the log.
     assert all("\r" not in message and "\n" not in message for message in dl.messages)
-    assert any("\\r\\nX-Injected: 1" in message for message in dl.messages)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config_validator.py
+++ b/tests/test_config_validator.py
@@ -576,16 +576,16 @@ class TestConfigValidator:
             in self.validator.errors[0]
         )
 
-    def test_validate_constants_dict_protected_user_agent_allowlist_regex(self):
-        """Test _validate_constants_section rejects overriding the user-agent allowlist regex."""
-        constants_dict = {"USER_AGENT_ALLOWLIST_REGEX": ".*"}
+    def test_validate_constants_dict_protected_host_app_allowlist_regex(self):
+        """Test _validate_constants_section rejects overriding the host-app allowlist regex."""
+        constants_dict = {"HOST_APP_ALLOWLIST_REGEX": ".*"}
 
         self.validator._validate_constants_section(constants_dict)
 
         assert len(self.validator.errors) == 1
         assert (
             constants.CONFIG_VALIDATION_MSGS["operation"]["protected_constant"].format(
-                "USER_AGENT_ALLOWLIST_REGEX", "constants"
+                "HOST_APP_ALLOWLIST_REGEX", "constants"
             )
             in self.validator.errors[0]
         )

--- a/tests/test_config_validator.py
+++ b/tests/test_config_validator.py
@@ -564,6 +564,18 @@ class TestConfigValidator:
         assert len(self.validator.errors) == 1
         assert "Unknown constant 'UNKNOWN_CONSTANT'" in self.validator.errors[0]
 
+    def test_validate_constants_dict_protected_constant(self):
+        """Test _validate_constants_section rejects protected constants like USER_AGENT."""
+        constants_dict = {"USER_AGENT": "spoofed-agent/1.0"}
+
+        self.validator._validate_constants_section(constants_dict)
+
+        assert len(self.validator.errors) == 1
+        assert (
+            constants.CONFIG_VALIDATION_MSGS["operation"]["protected_constant"].format("USER_AGENT", "constants")
+            in self.validator.errors[0]
+        )
+
     def test_validate_constants_dict_valid_various_types(self):
         """Test _validate_constants_section with valid constants of various types."""
         constants_dict = {

--- a/tests/test_config_validator.py
+++ b/tests/test_config_validator.py
@@ -576,6 +576,20 @@ class TestConfigValidator:
             in self.validator.errors[0]
         )
 
+    def test_validate_constants_dict_protected_user_agent_allowlist_regex(self):
+        """Test _validate_constants_section rejects overriding the user-agent allowlist regex."""
+        constants_dict = {"USER_AGENT_ALLOWLIST_REGEX": ".*"}
+
+        self.validator._validate_constants_section(constants_dict)
+
+        assert len(self.validator.errors) == 1
+        assert (
+            constants.CONFIG_VALIDATION_MSGS["operation"]["protected_constant"].format(
+                "USER_AGENT_ALLOWLIST_REGEX", "constants"
+            )
+            in self.validator.errors[0]
+        )
+
     def test_validate_constants_dict_valid_various_types(self):
         """Test _validate_constants_section with valid constants of various types."""
         constants_dict = {

--- a/tests/test_config_validator.py
+++ b/tests/test_config_validator.py
@@ -564,31 +564,23 @@ class TestConfigValidator:
         assert len(self.validator.errors) == 1
         assert "Unknown constant 'UNKNOWN_CONSTANT'" in self.validator.errors[0]
 
-    def test_validate_constants_dict_protected_constant(self):
-        """Test _validate_constants_section rejects protected constants like USER_AGENT."""
+    def test_validate_constants_dict_user_agent_not_overridable(self):
+        """Test USER_AGENT is not an overridable constant (moved out of the constants module)."""
         constants_dict = {"USER_AGENT": "spoofed-agent/1.0"}
 
         self.validator._validate_constants_section(constants_dict)
 
         assert len(self.validator.errors) == 1
-        assert (
-            constants.CONFIG_VALIDATION_MSGS["operation"]["protected_constant"].format("USER_AGENT", "constants")
-            in self.validator.errors[0]
-        )
+        assert "Unknown constant 'USER_AGENT'" in self.validator.errors[0]
 
-    def test_validate_constants_dict_protected_host_app_allowlist_regex(self):
-        """Test _validate_constants_section rejects overriding the host-app allowlist regex."""
+    def test_validate_constants_dict_host_app_allowlist_not_overridable(self):
+        """Test HOST_APP_ALLOWLIST_REGEX is not an overridable constant (moved out of the constants module)."""
         constants_dict = {"HOST_APP_ALLOWLIST_REGEX": ".*"}
 
         self.validator._validate_constants_section(constants_dict)
 
         assert len(self.validator.errors) == 1
-        assert (
-            constants.CONFIG_VALIDATION_MSGS["operation"]["protected_constant"].format(
-                "HOST_APP_ALLOWLIST_REGEX", "constants"
-            )
-            in self.validator.errors[0]
-        )
+        assert "Unknown constant 'HOST_APP_ALLOWLIST_REGEX'" in self.validator.errors[0]
 
     def test_validate_constants_dict_valid_various_types(self):
         """Test _validate_constants_section with valid constants of various types."""


### PR DESCRIPTION
## Description
This pull request introduces a more secure and flexible approach to handling the `User-Agent` header in API requests, with a focus on supporting trusted host application identification and preventing header injection attacks. The changes include a new allowlist-based user agent builder, updates to propagate the host app through the deployment pipeline, and comprehensive tests to ensure correct and secure behavior. Additionally, constants related to user agent construction are now internal and cannot be overridden in configuration files.

**User-Agent Handling and Security Improvements:**

* Introduced `_build_user_agent` and `_HOST_APP_ALLOWLIST_REGEX` in `_fabric_endpoint.py` to construct the `User-Agent` header, allowing only trusted, strictly validated host-app identifiers to be appended and preventing injection attacks. (`src/fabric_cicd/_common/_fabric_endpoint.py` [[1]](diffhunk://#diff-df48b77e163b4a13c97f80408ad6640fca48ffdc60c19e085b4c73589933178cR10) [[2]](diffhunk://#diff-df48b77e163b4a13c97f80408ad6640fca48ffdc60c19e085b4c73589933178cR29-R41)
* Removed `USER_AGENT` from `constants.py` so it cannot be overridden by configuration, and ensured related allowlist regex is also internal-only. (`src/fabric_cicd/constants.py` [[1]](diffhunk://#diff-91c2d32be351f155f090c4bd57ebe3c10e646edbc1b663e2a72b697f956a949cL16) `tests/test_config_validator.py` [[2]](diffhunk://#diff-efac1c6e9cdafa9c863857db8cc8243226477d6e659d8b1c9012752e7f5e45d0R567-R584)
* Updated `FabricEndpoint` to accept an optional `host_app` parameter and use the new user agent builder, propagating this through the deployment flow (`deploy_with_config`, `fabric_workspace.py`). (`src/fabric_cicd/_common/_fabric_endpoint.py` [[1]](diffhunk://#diff-df48b77e163b4a13c97f80408ad6640fca48ffdc60c19e085b4c73589933178cR51) [[2]](diffhunk://#diff-df48b77e163b4a13c97f80408ad6640fca48ffdc60c19e085b4c73589933178cR60-R65) [[3]](diffhunk://#diff-df48b77e163b4a13c97f80408ad6640fca48ffdc60c19e085b4c73589933178cL87-R104) `src/fabric_cicd/fabric_workspace.py` [[4]](diffhunk://#diff-3bd0f70ed06c7fc7a0f77378aecc6fb108eeb5263161db3b22270f3de4df99c0L114-R114) `src/fabric_cicd/publish.py` [[5]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704L431-R436) [[6]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R532-R534) [[7]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R574)

**Testing and Validation:**

* Added extensive tests for `_build_user_agent` and header propagation, verifying correct handling of trusted and untrusted host-app values, and ensuring no injection or spoofing is possible. (`tests/test__fabric_endpoint.py` [[1]](diffhunk://#diff-d5975d64f0adde0e560b6984da9e6c82903b4d6c09da96d60e3051c37465497aL13-R20) [[2]](diffhunk://#diff-d5975d64f0adde0e560b6984da9e6c82903b4d6c09da96d60e3051c37465497aR344-R435)
* Updated configuration validation tests to ensure internal constants cannot be overridden. (`tests/test_config_validator.py` [tests/test_config_validator.pyR567-R584](diffhunk://#diff-efac1c6e9cdafa9c863857db8cc8243226477d6e659d8b1c9012752e7f5e45d0R567-R584))

These changes collectively improve security, traceability, and maintainability of the deployment pipeline’s API interactions.

## Linked Issue (REQUIRED)
#1086
<!-- 
REQUIRED: This PR must be linked to an issue via the PR title format.
PR Title MUST follow this exact format: "Fixes #123 - Short Description"

Use the appropriate action word:
- Fixes #123 (for bug fixes)
- Closes #456 (for features)  
- Resolves #789 (for other changes)

Example: "Fixes #520 - Add Python version requirements to documentation"
-->
