### PR TITLE
Fixes #1072 -Fix PyYAML corrupting unquoted HH:MM:SS values

### DIFF
--- a/.changes/unreleased/fixed-20260802-174244.yaml
+++ b/.changes/unreleased/fixed-20260802-174244.yaml
@@ -1,0 +1,8 @@
+kind: fixed
+body: Fix `instance_pool_id` replacement in `Sparkcompute.yml` corrupting live pool schedule times
+time: 2026-08-02T17:42:44.2669842+03:00
+custom:
+    Author: shirasassoon
+    AuthorLink: https://github.com/shirasassoon
+    Issue: "1072"
+    IssueLink: https://github.com/microsoft/fabric-cicd/issues/1072

--- a/.changes/unreleased/fixed-20260802-174244.yaml
+++ b/.changes/unreleased/fixed-20260802-174244.yaml
@@ -1,5 +1,5 @@
 kind: fixed
-body: Fix `instance_pool_id` replacement in `Sparkcompute.yml` corrupting live pool schedule times
+body: Fix PyYAML corrupting unquoted HH:MM:SS values (e.g. schedule times in `Sparkcompute.yml`)
 time: 2026-08-02T17:42:44.2669842+03:00
 custom:
     Author: shirasassoon

--- a/src/fabric_cicd/_common/_check_utils.py
+++ b/src/fabric_cicd/_common/_check_utils.py
@@ -12,6 +12,7 @@ import filetype
 import yaml
 
 from fabric_cicd._common._exceptions import FileTypeError
+from fabric_cicd._common._yaml_safe import load_yaml
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +81,7 @@ def check_valid_yaml_content(content: str) -> bool:
         bool: True if the content parses as a YAML mapping or sequence, False otherwise.
     """
     try:
-        result = yaml.safe_load(content)
+        result = load_yaml(content)
         return isinstance(result, (dict, list))
     except yaml.YAMLError:
         return False

--- a/src/fabric_cicd/_common/_config_validator.py
+++ b/src/fabric_cicd/_common/_config_validator.py
@@ -13,6 +13,7 @@ import yaml
 from fabric_cicd import constants
 from fabric_cicd._common._exceptions import InputError
 from fabric_cicd._common._validate_env_vars import _URL_CONSTANTS, validate_api_url
+from fabric_cicd._common._yaml_safe import load_yaml
 
 logger = logging.getLogger(__name__)
 
@@ -120,7 +121,7 @@ class ConfigValidator:
 
         try:
             with config_path.open(encoding="utf-8") as f:
-                config = yaml.safe_load(f)
+                config = load_yaml(f)
         except yaml.YAMLError as e:
             self.errors.append(constants.CONFIG_VALIDATION_MSGS["file"]["yaml_syntax"].format(e))
             return None

--- a/src/fabric_cicd/_common/_yaml_safe.py
+++ b/src/fabric_cicd/_common/_yaml_safe.py
@@ -1,0 +1,125 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Centralized, sexagesimal-safe YAML loading and dumping.
+
+PyYAML implements YAML 1.1, whose implicit resolvers parse unquoted ``HH:MM:SS``
+values as base-60 (sexagesimal) integers (for example ``18:00:00`` -> ``64800``).
+When file content is round-tripped through ``load`` / ``dump``, this silently
+corrupts time values such as Environment ``live_pool`` schedules, which the Fabric
+API then rejects as invalid TimeSpans (see issue #1072).
+
+This module is the single place YAML is loaded and dumped across the package.
+:func:`load_yaml` and :func:`dump_yaml` strip only the base-60 branch from the
+int/float implicit resolvers, so time strings are preserved (loaded as strings,
+emitted unquoted) while normal integers, floats, octal, hex, and binary literals
+resolve exactly as before. All other code should call these helpers instead of
+using ``yaml.safe_load`` / ``yaml.dump`` directly, so this behavior stays
+consistent and the corruption class cannot silently reappear.
+"""
+
+import re
+from typing import Union
+
+import yaml
+
+# YAML 1.1 int/float implicit resolvers as used by PyYAML, with the sexagesimal
+# (``(:[0-5]?[0-9])+``) branch removed so ``HH:MM:SS`` values stay strings.
+_INT_RESOLVER = re.compile(
+    r"""^(?:[-+]?0b[0-1_]+
+    |[-+]?0[0-7_]+
+    |[-+]?(?:0|[1-9][0-9_]*)
+    |[-+]?0x[0-9a-fA-F_]+)$""",
+    re.VERBOSE,
+)
+_FLOAT_RESOLVER = re.compile(
+    r"""^(?:[-+]?(?:[0-9][0-9_]*)\.[0-9_]*(?:[eE][-+]?[0-9]+)?
+    |\.[0-9_]+(?:[eE][-+]?[0-9]+)?
+    |[-+]?[0-9][0-9_]*(?:[eE][-+]?[0-9]+)
+    |[-+]?\.(?:inf|Inf|INF)
+    |\.(?:nan|NaN|NAN))$""",
+    re.VERBOSE,
+)
+
+
+def _install_sexagesimal_safe_resolvers(cls: type) -> None:
+    """Replace the int/float implicit resolvers on ``cls`` with sexagesimal-free versions.
+
+    Copies PyYAML's default implicit resolver table onto ``cls`` and swaps the
+    ``int`` and ``float`` regexes for ones that omit the base-60 branch, leaving
+    every other resolver (bool, null, timestamp, etc.) untouched.
+    """
+    replacements = {
+        "tag:yaml.org,2002:int": _INT_RESOLVER,
+        "tag:yaml.org,2002:float": _FLOAT_RESOLVER,
+    }
+    resolvers = {}
+    for first_char, mappings in yaml.SafeLoader.yaml_implicit_resolvers.items():
+        resolvers[first_char] = [(tag, replacements.get(tag, regexp)) for tag, regexp in mappings]
+    cls.yaml_implicit_resolvers = resolvers
+
+
+class SafeYamlLoader(yaml.SafeLoader):
+    """A ``SafeLoader`` that does not apply YAML 1.1 sexagesimal (base-60) parsing.
+
+    Unquoted ``HH:MM:SS`` values are preserved as strings instead of being parsed
+    as base-60 integers, while all other scalar types resolve as usual.
+    """
+
+
+class SafeYamlDumper(yaml.SafeDumper):
+    """A ``SafeDumper`` counterpart to :class:`SafeYamlLoader`.
+
+    With the sexagesimal implicit resolvers removed, string time values are emitted
+    unquoted (for example ``18:00:00``) rather than being force-quoted, matching the
+    representation the Fabric portal writes.
+    """
+
+
+_install_sexagesimal_safe_resolvers(SafeYamlLoader)
+_install_sexagesimal_safe_resolvers(SafeYamlDumper)
+
+
+def load_yaml(stream: Union[str, bytes, any], loader_cls: type = SafeYamlLoader) -> any:
+    """Load YAML content without YAML 1.1 sexagesimal corruption.
+
+    Args:
+        stream: YAML content as a string, bytes, or an open text stream.
+        loader_cls: The loader class to use. Defaults to :class:`SafeYamlLoader`.
+            A sexagesimal-safe subclass (for example one that also detects
+            duplicate keys) may be supplied instead.
+
+    Returns:
+        The parsed Python object (``dict``, ``list``, scalar, or ``None``).
+    """
+    return yaml.load(stream, Loader=loader_cls)
+
+
+def dump_yaml(
+    data: any,
+    *,
+    default_flow_style: bool = False,
+    allow_unicode: bool = True,
+    sort_keys: bool = False,
+) -> str:
+    """Dump a Python object to YAML without corrupting or reordering values.
+
+    Uses :class:`SafeYamlDumper` so string time values round-trip unquoted, and
+    defaults to ``sort_keys=False`` so the original key order is preserved.
+
+    Args:
+        data: The Python object to serialize.
+        default_flow_style: Passed through to ``yaml.dump``.
+        allow_unicode: Passed through to ``yaml.dump``.
+        sort_keys: Passed through to ``yaml.dump``; defaults to ``False``.
+
+    Returns:
+        The serialized YAML string.
+    """
+    return yaml.dump(
+        data,
+        Dumper=SafeYamlDumper,
+        default_flow_style=default_flow_style,
+        allow_unicode=allow_unicode,
+        sort_keys=sort_keys,
+    )

--- a/src/fabric_cicd/_common/_yaml_safe.py
+++ b/src/fabric_cicd/_common/_yaml_safe.py
@@ -6,8 +6,7 @@
 PyYAML implements YAML 1.1, whose implicit resolvers parse unquoted ``HH:MM:SS``
 values as base-60 (sexagesimal) integers (for example ``18:00:00`` -> ``64800``).
 When file content is round-tripped through ``load`` / ``dump``, this silently
-corrupts time values such as Environment ``live_pool`` schedules, which the Fabric
-API then rejects as invalid TimeSpans (see issue #1072).
+corrupts time values.
 
 This module is the single place YAML is loaded and dumped across the package.
 :func:`load_yaml` and :func:`dump_yaml` strip only the base-60 branch from the

--- a/src/fabric_cicd/_common/_yaml_safe.py
+++ b/src/fabric_cicd/_common/_yaml_safe.py
@@ -31,8 +31,8 @@ _SEXAGESIMAL_SUBPATTERN = ":[0-5]?[0-9]"
 _NUMERIC_TAGS = ("tag:yaml.org,2002:int", "tag:yaml.org,2002:float")
 
 
-def _strip_sexagesimal_branch(pattern: str) -> str:
-    """Remove only the base-60 alternation branch from a PyYAML numeric resolver pattern.
+def _strip_sexagesimal_branch(rx: re.Pattern) -> re.Pattern:
+    """Return a copy of a PyYAML numeric resolver with only its base-60 branch removed.
 
     PyYAML's int/float implicit resolvers are a top-level ``^(?: A | B | ... )$``
     alternation in which exactly the branches matching sexagesimal (``HH:MM:SS``)
@@ -40,36 +40,56 @@ def _strip_sexagesimal_branch(pattern: str) -> str:
     that is byte-for-byte identical to PyYAML's for every other input, so normal
     ints, floats, exponents, hex, octal, and binary literals resolve exactly as
     before while colon-separated time values fall through to being strings.
+
+    Raises:
+        RuntimeError: If the pattern is not the expected ``^(?:...)$`` wrapper. This
+            makes an unexpected future PyYAML change fail loudly at import instead of
+            silently producing a resolver that could re-corrupt time values.
     """
-    inner = pattern[len("^(?:") : -len(")$")]
+    prefix, suffix = "^(?:", ")$"
+    pattern = rx.pattern
+    if not (pattern.startswith(prefix) and pattern.endswith(suffix)):
+        msg = f"Unexpected PyYAML numeric resolver format; cannot strip sexagesimal branch safely: {pattern!r}"
+        raise RuntimeError(msg)
+
+    inner = pattern[len(prefix) : -len(suffix)]
+    # PyYAML's numeric resolvers are a flat top-level alternation. A couple of the
+    # non-sexagesimal branches contain an inner ``|`` inside a group (for example
+    # ``[-+]?(?:0|[1-9][0-9_]*)``). Splitting naively on ``|`` cuts those into
+    # fragments, but none of those fragments contain _SEXAGESIMAL_SUBPATTERN, so they
+    # are all kept and rejoined with ``|``, exactly reconstructing the original. Only
+    # the whole sexagesimal branches (which have no inner ``|``) are dropped. The
+    # re.compile below reuses the source pattern's own flags and would raise if a
+    # future pattern ever broke this invariant.
     kept = [branch for branch in inner.split("|") if _SEXAGESIMAL_SUBPATTERN not in branch]
-    return "^(?:" + "|".join(kept) + ")$"
+    return re.compile(prefix + "|".join(kept) + suffix, rx.flags)
 
 
-def _sexagesimal_safe_resolvers() -> dict:
-    """Build a copy of PyYAML's implicit resolver table with the base-60 branches removed."""
-    compiled = {}
-    for tag_suffix in _NUMERIC_TAGS:
-        for _, mappings in yaml.SafeLoader.yaml_implicit_resolvers.items():
-            match = next((rx for tag, rx in mappings if tag == tag_suffix), None)
-            if match is not None:
-                compiled[tag_suffix] = re.compile(_strip_sexagesimal_branch(match.pattern), re.VERBOSE)
-                break
+def _sexagesimal_safe_resolvers(source_cls: type) -> dict:
+    """Copy ``source_cls``'s implicit resolver table with the numeric base-60 branches removed.
 
+    The table is derived from the given class's own resolvers (rather than a
+    hard-coded ``SafeLoader``) so a loader is built from ``SafeLoader``'s table and a
+    dumper from ``SafeDumper``'s, keeping each self-consistent even if PyYAML ever
+    diverges the two.
+    """
     resolvers = {}
-    for first_char, mappings in yaml.SafeLoader.yaml_implicit_resolvers.items():
-        resolvers[first_char] = [(tag, compiled.get(tag, regexp)) for tag, regexp in mappings]
+    for first_char, mappings in source_cls.yaml_implicit_resolvers.items():
+        resolvers[first_char] = [
+            (tag, _strip_sexagesimal_branch(regexp) if tag in _NUMERIC_TAGS else regexp) for tag, regexp in mappings
+        ]
     return resolvers
 
 
 def _install_sexagesimal_safe_resolvers(cls: type) -> None:
-    """Install the sexagesimal-free implicit resolver table on ``cls``.
+    """Install a sexagesimal-free implicit resolver table on ``cls``.
 
-    Derives the table from PyYAML's own default resolvers (see
-    :func:`_strip_sexagesimal_branch`), leaving every non-numeric resolver
-    (bool, null, timestamp, etc.) untouched.
+    Derives the table from ``cls``'s own (inherited) PyYAML resolvers via
+    :func:`_strip_sexagesimal_branch`, leaving every non-numeric resolver
+    (bool, null, timestamp, etc.) untouched. Assigning the result shadows the
+    inherited attribute without mutating the PyYAML base class.
     """
-    cls.yaml_implicit_resolvers = _sexagesimal_safe_resolvers()
+    cls.yaml_implicit_resolvers = _sexagesimal_safe_resolvers(cls)
 
 
 class SafeYamlLoader(yaml.SafeLoader):

--- a/src/fabric_cicd/_common/_yaml_safe.py
+++ b/src/fabric_cicd/_common/_yaml_safe.py
@@ -23,40 +23,53 @@ from typing import Union
 
 import yaml
 
-# YAML 1.1 int/float implicit resolvers as used by PyYAML, with the sexagesimal
-# (``(:[0-5]?[0-9])+``) branch removed so ``HH:MM:SS`` values stay strings.
-_INT_RESOLVER = re.compile(
-    r"""^(?:[-+]?0b[0-1_]+
-    |[-+]?0[0-7_]+
-    |[-+]?(?:0|[1-9][0-9_]*)
-    |[-+]?0x[0-9a-fA-F_]+)$""",
-    re.VERBOSE,
-)
-_FLOAT_RESOLVER = re.compile(
-    r"""^(?:[-+]?(?:[0-9][0-9_]*)\.[0-9_]*(?:[eE][-+]?[0-9]+)?
-    |\.[0-9_]+(?:[eE][-+]?[0-9]+)?
-    |[-+]?[0-9][0-9_]*(?:[eE][-+]?[0-9]+)
-    |[-+]?\.(?:inf|Inf|INF)
-    |\.(?:nan|NaN|NAN))$""",
-    re.VERBOSE,
-)
+# The base-60 sub-pattern PyYAML uses inside its int/float implicit resolvers.
+# Any alternation branch containing it is the sexagesimal branch we want to drop.
+_SEXAGESIMAL_SUBPATTERN = ":[0-5]?[0-9]"
+
+# Tags whose implicit resolvers carry the sexagesimal branch.
+_NUMERIC_TAGS = ("tag:yaml.org,2002:int", "tag:yaml.org,2002:float")
+
+
+def _strip_sexagesimal_branch(pattern: str) -> str:
+    """Remove only the base-60 alternation branch from a PyYAML numeric resolver pattern.
+
+    PyYAML's int/float implicit resolvers are a top-level ``^(?: A | B | ... )$``
+    alternation in which exactly the branches matching sexagesimal (``HH:MM:SS``)
+    notation contain ``:[0-5]?[0-9]``. Dropping just those branches yields a resolver
+    that is byte-for-byte identical to PyYAML's for every other input, so normal
+    ints, floats, exponents, hex, octal, and binary literals resolve exactly as
+    before while colon-separated time values fall through to being strings.
+    """
+    inner = pattern[len("^(?:") : -len(")$")]
+    kept = [branch for branch in inner.split("|") if _SEXAGESIMAL_SUBPATTERN not in branch]
+    return "^(?:" + "|".join(kept) + ")$"
+
+
+def _sexagesimal_safe_resolvers() -> dict:
+    """Build a copy of PyYAML's implicit resolver table with the base-60 branches removed."""
+    compiled = {}
+    for tag_suffix in _NUMERIC_TAGS:
+        for _, mappings in yaml.SafeLoader.yaml_implicit_resolvers.items():
+            match = next((rx for tag, rx in mappings if tag == tag_suffix), None)
+            if match is not None:
+                compiled[tag_suffix] = re.compile(_strip_sexagesimal_branch(match.pattern), re.VERBOSE)
+                break
+
+    resolvers = {}
+    for first_char, mappings in yaml.SafeLoader.yaml_implicit_resolvers.items():
+        resolvers[first_char] = [(tag, compiled.get(tag, regexp)) for tag, regexp in mappings]
+    return resolvers
 
 
 def _install_sexagesimal_safe_resolvers(cls: type) -> None:
-    """Replace the int/float implicit resolvers on ``cls`` with sexagesimal-free versions.
+    """Install the sexagesimal-free implicit resolver table on ``cls``.
 
-    Copies PyYAML's default implicit resolver table onto ``cls`` and swaps the
-    ``int`` and ``float`` regexes for ones that omit the base-60 branch, leaving
-    every other resolver (bool, null, timestamp, etc.) untouched.
+    Derives the table from PyYAML's own default resolvers (see
+    :func:`_strip_sexagesimal_branch`), leaving every non-numeric resolver
+    (bool, null, timestamp, etc.) untouched.
     """
-    replacements = {
-        "tag:yaml.org,2002:int": _INT_RESOLVER,
-        "tag:yaml.org,2002:float": _FLOAT_RESOLVER,
-    }
-    resolvers = {}
-    for first_char, mappings in yaml.SafeLoader.yaml_implicit_resolvers.items():
-        resolvers[first_char] = [(tag, replacements.get(tag, regexp)) for tag, regexp in mappings]
-    cls.yaml_implicit_resolvers = resolvers
+    cls.yaml_implicit_resolvers = _sexagesimal_safe_resolvers()
 
 
 class SafeYamlLoader(yaml.SafeLoader):

--- a/src/fabric_cicd/_items/_environment.py
+++ b/src/fabric_cicd/_items/_environment.py
@@ -5,6 +5,7 @@
 
 import logging
 import re
+from typing import Optional
 
 import dpath
 import yaml
@@ -33,6 +34,14 @@ def _process_environment_file(
     using the ``spark_pool`` parameter configuration so that the correct pool
     reference is embedded directly in the YAML sent to the Fabric Items API.
 
+    The YAML is parsed only to look up and match the pool mapping; the resolved
+    pool GUID is then written back with a targeted replacement of the
+    ``instance_pool_id`` line, leaving the rest of the file byte-for-byte
+    unchanged. This avoids a ``yaml.safe_load`` / ``yaml.dump`` round-trip, which
+    (under PyYAML's YAML 1.1 rules) would corrupt other values such as unquoted
+    ``live_pool`` schedule ``HH:MM:SS`` times, which are parsed as sexagesimal
+    integers (see issue #1072).
+
     All other files are returned unchanged.
 
     Args:
@@ -52,18 +61,19 @@ def _process_environment_file(
         return contents
 
     yaml_body = yaml.safe_load(contents)
-    if not isinstance(yaml_body, dict):
+    if not isinstance(yaml_body, dict) or "instance_pool_id" not in yaml_body:
         return contents
 
-    if "instance_pool_id" in yaml_body:
-        yaml_body = _replace_instance_pool_id(fabric_workspace_obj, yaml_body, item.name)
+    resolved_id = _resolve_instance_pool_id(fabric_workspace_obj, yaml_body, item.name)
+    if resolved_id is None or resolved_id == yaml_body["instance_pool_id"]:
+        return contents
 
-    return yaml.dump(yaml_body, default_flow_style=False, sort_keys=False)
+    return _replace_instance_pool_id_line(contents, resolved_id)
 
 
-def _replace_instance_pool_id(fabric_workspace_obj: FabricWorkspace, yaml_body: dict, item_name: str) -> dict:
+def _resolve_instance_pool_id(fabric_workspace_obj: FabricWorkspace, yaml_body: dict, item_name: str) -> Optional[str]:
     """
-    Replace ``instance_pool_id`` in parsed Sparkcompute YAML with a resolved pool GUID.
+    Resolve the target ``instance_pool_id`` GUID for Sparkcompute YAML.
 
     This function reads ``spark_pool`` parameter mappings from
     ``fabric_workspace_obj.environment_parameter`` and finds the entry whose
@@ -72,8 +82,7 @@ def _replace_instance_pool_id(fabric_workspace_obj: FabricWorkspace, yaml_body: 
     otherwise, the mapping applies globally.
 
     The mapped target pool ``name`` and ``type`` are then resolved against the
-    workspace custom pool list returned by the Fabric API, and the resolved pool
-    ``id`` is written back to ``yaml_body["instance_pool_id"]``.
+    workspace custom pool list returned by the Fabric API.
 
     Args:
         fabric_workspace_obj: Workspace context containing environment, parameters,
@@ -82,7 +91,7 @@ def _replace_instance_pool_id(fabric_workspace_obj: FabricWorkspace, yaml_body: 
         item_name: Environment item name used for optional per-item mapping filters.
 
     Returns:
-        The YAML dictionary, updated if a matching mapping is found; otherwise unchanged.
+        The resolved pool GUID if a matching mapping is found; otherwise ``None``.
     """
     from fabric_cicd._parameter._utils import _find_match, process_environment_key
 
@@ -96,15 +105,37 @@ def _replace_instance_pool_id(fabric_workspace_obj: FabricWorkspace, yaml_body: 
             input_name = key.get("item_name")
             if instance_pool_id == pool_id and _find_match(input_name or None, item_name):
                 pool_config = replace_value[fabric_workspace_obj.environment]
-                resolved_id = _resolve_pool_id(
+                return _resolve_pool_id(
                     pools,
                     pool_name=pool_config["name"],
                     pool_type=pool_config["type"],
                 )
-                yaml_body["instance_pool_id"] = resolved_id
-                break
 
-    return yaml_body
+    return None
+
+
+def _replace_instance_pool_id_line(contents: str, resolved_id: str) -> str:
+    """
+    Replace the value of the top-level ``instance_pool_id`` key in raw YAML text.
+
+    Only the ``instance_pool_id`` line is modified; all other lines (including
+    unquoted ``live_pool`` schedule times) are preserved exactly, avoiding the
+    sexagesimal corruption caused by a full YAML round-trip.
+
+    Args:
+        contents: The original ``Sparkcompute.yml`` contents.
+        resolved_id: The pool GUID to write as the new ``instance_pool_id`` value.
+
+    Returns:
+        The contents with the ``instance_pool_id`` value replaced.
+    """
+    return re.sub(
+        r"^(?P<prefix>instance_pool_id[ \t]*:[ \t]*).*$",
+        lambda m: f"{m.group('prefix')}{resolved_id}",
+        contents,
+        count=1,
+        flags=re.MULTILINE,
+    )
 
 
 def _resolve_pool_id(pools: list[dict], pool_name: str, pool_type: str) -> str:

--- a/src/fabric_cicd/_items/_environment.py
+++ b/src/fabric_cicd/_items/_environment.py
@@ -8,7 +8,6 @@ import re
 from typing import Optional
 
 import dpath
-import yaml
 
 from fabric_cicd import FabricWorkspace, constants
 from fabric_cicd._common._exceptions import InputError
@@ -16,6 +15,7 @@ from fabric_cicd._common._fabric_endpoint import handle_retry
 from fabric_cicd._common._file import File
 from fabric_cicd._common._item import Item
 from fabric_cicd._common._logging import log_header
+from fabric_cicd._common._yaml_safe import load_yaml
 from fabric_cicd._items._base_publisher import ItemPublisher
 from fabric_cicd.constants import ItemType
 
@@ -54,7 +54,7 @@ def _process_environment_file(
     if "instance_pool_id" not in contents:
         return contents
 
-    yaml_body = yaml.safe_load(contents)
+    yaml_body = load_yaml(contents)
     if not isinstance(yaml_body, dict) or "instance_pool_id" not in yaml_body:
         return contents
 

--- a/src/fabric_cicd/_items/_environment.py
+++ b/src/fabric_cicd/_items/_environment.py
@@ -62,7 +62,13 @@ def _process_environment_file(
     if resolved_id is None or resolved_id == yaml_body["instance_pool_id"]:
         return contents
 
-    return _replace_instance_pool_id_line(contents, resolved_id)
+    return re.sub(
+        r"^(?P<prefix>instance_pool_id[ \t]*:[ \t]*).*$",
+        lambda match: f"{match.group('prefix')}{resolved_id}",
+        contents,
+        count=1,
+        flags=re.MULTILINE,
+    )
 
 
 def _resolve_instance_pool_id(fabric_workspace_obj: FabricWorkspace, yaml_body: dict, item_name: str) -> Optional[str]:
@@ -106,28 +112,6 @@ def _resolve_instance_pool_id(fabric_workspace_obj: FabricWorkspace, yaml_body: 
                 )
 
     return None
-
-
-def _replace_instance_pool_id_line(contents: str, resolved_id: str) -> str:
-    """
-    Replace the value of the top-level ``instance_pool_id`` key in raw YAML text.
-
-    Only the ``instance_pool_id`` line is modified; all other content is preserved unchanged.
-
-    Args:
-        contents: The original ``Sparkcompute.yml`` contents.
-        resolved_id: The pool GUID to write as the new ``instance_pool_id`` value.
-
-    Returns:
-        The contents with the ``instance_pool_id`` value replaced.
-    """
-    return re.sub(
-        r"^(?P<prefix>instance_pool_id[ \t]*:[ \t]*).*$",
-        lambda m: f"{m.group('prefix')}{resolved_id}",
-        contents,
-        count=1,
-        flags=re.MULTILINE,
-    )
 
 
 def _resolve_pool_id(pools: list[dict], pool_name: str, pool_type: str) -> str:

--- a/src/fabric_cicd/_items/_environment.py
+++ b/src/fabric_cicd/_items/_environment.py
@@ -34,13 +34,7 @@ def _process_environment_file(
     using the ``spark_pool`` parameter configuration so that the correct pool
     reference is embedded directly in the YAML sent to the Fabric Items API.
 
-    The YAML is parsed only to look up and match the pool mapping; the resolved
-    pool GUID is then written back with a targeted replacement of the
-    ``instance_pool_id`` line, leaving the rest of the file byte-for-byte
-    unchanged. This avoids a ``yaml.safe_load`` / ``yaml.dump`` round-trip, which
-    (under PyYAML's YAML 1.1 rules) would corrupt other values such as unquoted
-    ``live_pool`` schedule ``HH:MM:SS`` times, which are parsed as sexagesimal
-    integers (see issue #1072).
+    Only the ``instance_pool_id`` line is replaced; all other content is preserved unchanged.
 
     All other files are returned unchanged.
 
@@ -118,9 +112,7 @@ def _replace_instance_pool_id_line(contents: str, resolved_id: str) -> str:
     """
     Replace the value of the top-level ``instance_pool_id`` key in raw YAML text.
 
-    Only the ``instance_pool_id`` line is modified; all other lines (including
-    unquoted ``live_pool`` schedule times) are preserved exactly, avoiding the
-    sexagesimal corruption caused by a full YAML round-trip.
+    Only the ``instance_pool_id`` line is modified; all other content is preserved unchanged.
 
     Args:
         contents: The original ``Sparkcompute.yml`` contents.

--- a/src/fabric_cicd/_parameter/_parameter.py
+++ b/src/fabric_cicd/_parameter/_parameter.py
@@ -168,6 +168,7 @@ class Parameter:
 
                 # Use custom loader that detects duplicate keys
                 parameter_dict = yaml.load(yaml_content, Loader=_DuplicateKeyLoader) or {}
+                _warn_on_sexagesimal_values(yaml_content)
                 logger.debug(constants.PARAMETER_MSGS["passed"].format("YAML content is valid"))
 
                 if parameter_dict.get("extend"):
@@ -273,7 +274,9 @@ class Parameter:
                     return {}
 
             # Use custom loader that detects duplicate keys
-            return yaml.load(param_content, Loader=_DuplicateKeyLoader) or {}
+            template_dict = yaml.load(param_content, Loader=_DuplicateKeyLoader) or {}
+            _warn_on_sexagesimal_values(param_content)
+            return template_dict
 
         except (UnicodeDecodeError, yaml.YAMLError) as e:
             logger.error(constants.PARAMETER_MSGS["template_file_error"].format(file_path, e))
@@ -1071,6 +1074,58 @@ class _DuplicateKeyLoader(yaml.SafeLoader):
     """Custom YAML loader that raises an error on duplicate keys."""
 
     pass
+
+
+_SEXAGESIMAL_NUMERIC_TAGS = frozenset({"tag:yaml.org,2002:int", "tag:yaml.org,2002:float"})
+
+
+def _find_sexagesimal_scalars(yaml_content: str) -> list[str]:
+    """Find unquoted YAML 1.1 sexagesimal (base-60) time values in raw parameter content.
+
+    PyYAML implements YAML 1.1, whose implicit resolvers parse unquoted ``HH:MM:SS``
+    values as base-60 integers (for example ``18:00:00`` -> ``64800``). When such a
+    value is used as a replacement in the parameter file, the corrupted integer is
+    injected into the deployed item and rejected by the Fabric API (see issue #1072).
+
+    This inspects the composed node tree and returns the original text of each scalar
+    the resolver would treat as an int or float whose raw form is sexagesimal
+    (colon-separated). Quoted values resolve to strings and are not flagged.
+
+    Args:
+        yaml_content: The raw parameter file contents.
+
+    Returns:
+        A sorted list of unique ``"value (line N)"`` descriptors, empty if none found.
+    """
+    try:
+        root = yaml.compose(yaml_content, Loader=yaml.SafeLoader)
+    except yaml.YAMLError:
+        return []
+    if root is None:
+        return []
+
+    findings: set[str] = set()
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        if isinstance(node, yaml.ScalarNode):
+            if node.tag in _SEXAGESIMAL_NUMERIC_TAGS and ":" in node.value:
+                findings.add(f"'{node.value}' (line {node.start_mark.line + 1})")
+        elif isinstance(node, yaml.MappingNode):
+            for key_node, value_node in node.value:
+                stack.append(key_node)
+                stack.append(value_node)
+        elif isinstance(node, yaml.SequenceNode):
+            stack.extend(node.value)
+
+    return sorted(findings)
+
+
+def _warn_on_sexagesimal_values(yaml_content: str) -> None:
+    """Log a warning if the parameter content contains unquoted sexagesimal time values."""
+    findings = _find_sexagesimal_scalars(yaml_content)
+    if findings:
+        logger.warning(constants.PARAMETER_MSGS["sexagesimal time"].format(", ".join(findings)))
 
 
 def _collect_duplicate_key_errors(root_node: yaml.MappingNode, loader: _DuplicateKeyLoader) -> list[str]:

--- a/src/fabric_cicd/_parameter/_parameter.py
+++ b/src/fabric_cicd/_parameter/_parameter.py
@@ -13,6 +13,7 @@ from typing import ClassVar, Optional
 import yaml
 
 import fabric_cicd.constants as constants
+from fabric_cicd._common._yaml_safe import SafeYamlLoader
 from fabric_cicd._parameter._utils import (
     is_valid_structure,
     process_input_path,
@@ -168,7 +169,6 @@ class Parameter:
 
                 # Use custom loader that detects duplicate keys
                 parameter_dict = yaml.load(yaml_content, Loader=_DuplicateKeyLoader) or {}
-                _warn_on_sexagesimal_values(yaml_content)
                 logger.debug(constants.PARAMETER_MSGS["passed"].format("YAML content is valid"))
 
                 if parameter_dict.get("extend"):
@@ -274,9 +274,7 @@ class Parameter:
                     return {}
 
             # Use custom loader that detects duplicate keys
-            template_dict = yaml.load(param_content, Loader=_DuplicateKeyLoader) or {}
-            _warn_on_sexagesimal_values(param_content)
-            return template_dict
+            return yaml.load(param_content, Loader=_DuplicateKeyLoader) or {}
 
         except (UnicodeDecodeError, yaml.YAMLError) as e:
             logger.error(constants.PARAMETER_MSGS["template_file_error"].format(file_path, e))
@@ -1070,62 +1068,14 @@ class Parameter:
         return True, "Valid file path"
 
 
-class _DuplicateKeyLoader(yaml.SafeLoader):
-    """Custom YAML loader that raises an error on duplicate keys."""
+class _DuplicateKeyLoader(SafeYamlLoader):
+    """Custom YAML loader that raises an error on duplicate keys.
+
+    Inherits sexagesimal-safe scalar resolution from :class:`SafeYamlLoader` so
+    unquoted ``HH:MM:SS`` values in parameter files are preserved as strings.
+    """
 
     pass
-
-
-_SEXAGESIMAL_NUMERIC_TAGS = frozenset({"tag:yaml.org,2002:int", "tag:yaml.org,2002:float"})
-
-
-def _find_sexagesimal_scalars(yaml_content: str) -> list[str]:
-    """Find unquoted YAML 1.1 sexagesimal (base-60) time values in raw parameter content.
-
-    PyYAML implements YAML 1.1, whose implicit resolvers parse unquoted ``HH:MM:SS``
-    values as base-60 integers (for example ``18:00:00`` -> ``64800``). When such a
-    value is used as a replacement in the parameter file, the corrupted integer is
-    injected into the deployed item and rejected by the Fabric API (see issue #1072).
-
-    This inspects the composed node tree and returns the original text of each scalar
-    the resolver would treat as an int or float whose raw form is sexagesimal
-    (colon-separated). Quoted values resolve to strings and are not flagged.
-
-    Args:
-        yaml_content: The raw parameter file contents.
-
-    Returns:
-        A sorted list of unique ``"value (line N)"`` descriptors, empty if none found.
-    """
-    try:
-        root = yaml.compose(yaml_content, Loader=yaml.SafeLoader)
-    except yaml.YAMLError:
-        return []
-    if root is None:
-        return []
-
-    findings: set[str] = set()
-    stack = [root]
-    while stack:
-        node = stack.pop()
-        if isinstance(node, yaml.ScalarNode):
-            if node.tag in _SEXAGESIMAL_NUMERIC_TAGS and ":" in node.value:
-                findings.add(f"'{node.value}' (line {node.start_mark.line + 1})")
-        elif isinstance(node, yaml.MappingNode):
-            for key_node, value_node in node.value:
-                stack.append(key_node)
-                stack.append(value_node)
-        elif isinstance(node, yaml.SequenceNode):
-            stack.extend(node.value)
-
-    return sorted(findings)
-
-
-def _warn_on_sexagesimal_values(yaml_content: str) -> None:
-    """Log a warning if the parameter content contains unquoted sexagesimal time values."""
-    findings = _find_sexagesimal_scalars(yaml_content)
-    if findings:
-        logger.warning(constants.PARAMETER_MSGS["sexagesimal time"].format(", ".join(findings)))
 
 
 def _collect_duplicate_key_errors(root_node: yaml.MappingNode, loader: _DuplicateKeyLoader) -> list[str]:

--- a/src/fabric_cicd/_parameter/_utils.py
+++ b/src/fabric_cicd/_parameter/_utils.py
@@ -22,6 +22,7 @@ from jsonpath_ng.ext import parse
 import fabric_cicd.constants as constants
 from fabric_cicd import FabricWorkspace
 from fabric_cicd._common._exceptions import InputError, ParsingError
+from fabric_cicd._common._yaml_safe import dump_yaml, load_yaml
 from fabric_cicd.constants import ItemType
 
 logger = logging.getLogger(__name__)
@@ -467,69 +468,6 @@ def process_environment_key(environment: str, replace_value_dict: dict) -> dict:
 """Functions to replace key values in JSON or YAML"""
 
 
-class _TimeSafeLoader(yaml.SafeLoader):
-    """A ``SafeLoader`` that does not apply YAML 1.1 sexagesimal (base-60) parsing.
-
-    PyYAML implements YAML 1.1, whose implicit resolvers treat unquoted
-    ``HH:MM:SS`` values as base-60 integers (for example ``18:00:00`` -> ``64800``).
-    When a document is round-tripped through ``safe_load`` / ``dump`` during
-    ``key_value_replace`` parameterization, this silently corrupts time values
-    such as Environment ``live_pool`` schedules (see issue #1072). This loader
-    strips the sexagesimal branch from the int/float implicit resolvers so those
-    values are preserved as strings, while normal integers, floats, octal, hex,
-    and binary literals continue to resolve as before.
-    """
-
-
-class _TimeSafeDumper(yaml.SafeDumper):
-    """A ``SafeDumper`` counterpart to :class:`_TimeSafeLoader`.
-
-    With the sexagesimal implicit resolvers removed, string time values are
-    emitted unquoted (for example ``18:00:00``) instead of being force-quoted,
-    matching the representation the Fabric portal writes.
-    """
-
-
-# YAML 1.1 int/float implicit resolvers as used by PyYAML, with the sexagesimal
-# (``(:[0-5]?[0-9])+``) branch removed so ``HH:MM:SS`` values stay strings.
-_INT_RESOLVER = re.compile(
-    r"""^(?:[-+]?0b[0-1_]+
-    |[-+]?0[0-7_]+
-    |[-+]?(?:0|[1-9][0-9_]*)
-    |[-+]?0x[0-9a-fA-F_]+)$""",
-    re.VERBOSE,
-)
-_FLOAT_RESOLVER = re.compile(
-    r"""^(?:[-+]?(?:[0-9][0-9_]*)\.[0-9_]*(?:[eE][-+]?[0-9]+)?
-    |\.[0-9_]+(?:[eE][-+]?[0-9]+)?
-    |[-+]?[0-9][0-9_]*(?:[eE][-+]?[0-9]+)
-    |[-+]?\.(?:inf|Inf|INF)
-    |\.(?:nan|NaN|NAN))$""",
-    re.VERBOSE,
-)
-
-
-def _install_sexagesimal_safe_resolvers(cls: type) -> None:
-    """Replace the int/float implicit resolvers on ``cls`` with sexagesimal-free versions.
-
-    Copies PyYAML's default implicit resolver table onto ``cls`` and swaps the
-    ``int`` and ``float`` regexes for ones that omit the base-60 branch, leaving
-    every other resolver (bool, null, timestamp, etc.) untouched.
-    """
-    replacements = {
-        "tag:yaml.org,2002:int": _INT_RESOLVER,
-        "tag:yaml.org,2002:float": _FLOAT_RESOLVER,
-    }
-    resolvers = {}
-    for first_char, mappings in yaml.SafeLoader.yaml_implicit_resolvers.items():
-        resolvers[first_char] = [(tag, replacements.get(tag, regexp)) for tag, regexp in mappings]
-    cls.yaml_implicit_resolvers = resolvers
-
-
-_install_sexagesimal_safe_resolvers(_TimeSafeLoader)
-_install_sexagesimal_safe_resolvers(_TimeSafeDumper)
-
-
 def replace_key_value(
     workspace_obj: FabricWorkspace, param_dict: dict, content: str, env: str, is_yaml: bool = False
 ) -> str:
@@ -545,7 +483,7 @@ def replace_key_value(
     # Parse content to a dictionary based on format (YAML or JSON)
     if is_yaml:
         try:
-            data = yaml.load(content, Loader=_TimeSafeLoader)
+            data = load_yaml(content)
         except yaml.YAMLError as ye:
             raise ValueError(ye) from ye
 
@@ -576,11 +514,7 @@ def replace_key_value(
             except Exception as match_e:
                 raise ValueError(match_e) from match_e
 
-    return (
-        yaml.dump(data, Dumper=_TimeSafeDumper, default_flow_style=False, allow_unicode=True, sort_keys=False)
-        if is_yaml
-        else json.dumps(data)
-    )
+    return dump_yaml(data) if is_yaml else json.dumps(data)
 
 
 def replace_variables_in_parameter_file(raw_file: str) -> str:

--- a/src/fabric_cicd/_parameter/_utils.py
+++ b/src/fabric_cicd/_parameter/_utils.py
@@ -467,6 +467,69 @@ def process_environment_key(environment: str, replace_value_dict: dict) -> dict:
 """Functions to replace key values in JSON or YAML"""
 
 
+class _TimeSafeLoader(yaml.SafeLoader):
+    """A ``SafeLoader`` that does not apply YAML 1.1 sexagesimal (base-60) parsing.
+
+    PyYAML implements YAML 1.1, whose implicit resolvers treat unquoted
+    ``HH:MM:SS`` values as base-60 integers (for example ``18:00:00`` -> ``64800``).
+    When a document is round-tripped through ``safe_load`` / ``dump`` during
+    ``key_value_replace`` parameterization, this silently corrupts time values
+    such as Environment ``live_pool`` schedules (see issue #1072). This loader
+    strips the sexagesimal branch from the int/float implicit resolvers so those
+    values are preserved as strings, while normal integers, floats, octal, hex,
+    and binary literals continue to resolve as before.
+    """
+
+
+class _TimeSafeDumper(yaml.SafeDumper):
+    """A ``SafeDumper`` counterpart to :class:`_TimeSafeLoader`.
+
+    With the sexagesimal implicit resolvers removed, string time values are
+    emitted unquoted (for example ``18:00:00``) instead of being force-quoted,
+    matching the representation the Fabric portal writes.
+    """
+
+
+# YAML 1.1 int/float implicit resolvers as used by PyYAML, with the sexagesimal
+# (``(:[0-5]?[0-9])+``) branch removed so ``HH:MM:SS`` values stay strings.
+_INT_RESOLVER = re.compile(
+    r"""^(?:[-+]?0b[0-1_]+
+    |[-+]?0[0-7_]+
+    |[-+]?(?:0|[1-9][0-9_]*)
+    |[-+]?0x[0-9a-fA-F_]+)$""",
+    re.VERBOSE,
+)
+_FLOAT_RESOLVER = re.compile(
+    r"""^(?:[-+]?(?:[0-9][0-9_]*)\.[0-9_]*(?:[eE][-+]?[0-9]+)?
+    |\.[0-9_]+(?:[eE][-+]?[0-9]+)?
+    |[-+]?[0-9][0-9_]*(?:[eE][-+]?[0-9]+)
+    |[-+]?\.(?:inf|Inf|INF)
+    |\.(?:nan|NaN|NAN))$""",
+    re.VERBOSE,
+)
+
+
+def _install_sexagesimal_safe_resolvers(cls: type) -> None:
+    """Replace the int/float implicit resolvers on ``cls`` with sexagesimal-free versions.
+
+    Copies PyYAML's default implicit resolver table onto ``cls`` and swaps the
+    ``int`` and ``float`` regexes for ones that omit the base-60 branch, leaving
+    every other resolver (bool, null, timestamp, etc.) untouched.
+    """
+    replacements = {
+        "tag:yaml.org,2002:int": _INT_RESOLVER,
+        "tag:yaml.org,2002:float": _FLOAT_RESOLVER,
+    }
+    resolvers = {}
+    for first_char, mappings in yaml.SafeLoader.yaml_implicit_resolvers.items():
+        resolvers[first_char] = [(tag, replacements.get(tag, regexp)) for tag, regexp in mappings]
+    cls.yaml_implicit_resolvers = resolvers
+
+
+_install_sexagesimal_safe_resolvers(_TimeSafeLoader)
+_install_sexagesimal_safe_resolvers(_TimeSafeDumper)
+
+
 def replace_key_value(
     workspace_obj: FabricWorkspace, param_dict: dict, content: str, env: str, is_yaml: bool = False
 ) -> str:
@@ -482,7 +545,7 @@ def replace_key_value(
     # Parse content to a dictionary based on format (YAML or JSON)
     if is_yaml:
         try:
-            data = yaml.safe_load(content)
+            data = yaml.load(content, Loader=_TimeSafeLoader)
         except yaml.YAMLError as ye:
             raise ValueError(ye) from ye
 
@@ -513,7 +576,11 @@ def replace_key_value(
             except Exception as match_e:
                 raise ValueError(match_e) from match_e
 
-    return yaml.dump(data, default_flow_style=False, allow_unicode=True) if is_yaml else json.dumps(data)
+    return (
+        yaml.dump(data, Dumper=_TimeSafeDumper, default_flow_style=False, allow_unicode=True, sort_keys=False)
+        if is_yaml
+        else json.dumps(data)
+    )
 
 
 def replace_variables_in_parameter_file(raw_file: str) -> str:

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -300,6 +300,11 @@ PARAMETER_MSGS = {
     "not set": "Parameter file path is not set",
     "empty yaml": "YAML content is empty",
     "duplicate key": "duplicate key(s) found: {}",
+    "sexagesimal time": (
+        "Unquoted time value(s) {} were parsed as base-60 integers by YAML "
+        "(e.g. 18:00:00 becomes 64800), which will corrupt the deployed value. "
+        "Quote these value(s) in your parameter file (e.g. '18:00:00') to preserve them as strings."
+    ),
     "valid load": f"Successfully loaded {PARAMETER_FILE_NAME}",
     "invalid load": f"Error loading {PARAMETER_FILE_NAME} " + "'{}'",
     "invalid structure": "Invalid parameter file structure",

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -300,11 +300,6 @@ PARAMETER_MSGS = {
     "not set": "Parameter file path is not set",
     "empty yaml": "YAML content is empty",
     "duplicate key": "duplicate key(s) found: {}",
-    "sexagesimal time": (
-        "Unquoted time value(s) {} were parsed as base-60 integers by YAML "
-        "(e.g. 18:00:00 becomes 64800), which will corrupt the deployed value. "
-        "Quote these value(s) in your parameter file (e.g. '18:00:00') to preserve them as strings."
-    ),
     "valid load": f"Successfully loaded {PARAMETER_FILE_NAME}",
     "invalid load": f"Error loading {PARAMETER_FILE_NAME} " + "'{}'",
     "invalid structure": "Invalid parameter file structure",

--- a/tests/test_environment_publish.py
+++ b/tests/test_environment_publish.py
@@ -289,6 +289,93 @@ def test_resolve_pool_id_not_found():
         env_module._resolve_pool_id(pools, pool_name="MissingPool", pool_type="Workspace")
 
 
+def test_process_environment_file_preserves_live_pool_schedule_times(tmp_path):
+    """Regression for #1072: unquoted live_pool HH:MM:SS times survive processing.
+
+    A full yaml.safe_load / yaml.dump round-trip corrupts unquoted times under
+    PyYAML's YAML 1.1 sexagesimal parsing (18:00:00 -> 64800). The targeted line
+    replacement must leave these values untouched.
+    """
+    env_dir = tmp_path / "EnvSchedule"
+    setting_dir = env_dir / "Setting"
+    setting_dir.mkdir(parents=True, exist_ok=True)
+    sc = setting_dir / "Sparkcompute.yml"
+    original = (
+        "instance_pool_id: pool-123\n"
+        "live_pool:\n"
+        "  state: Enabled\n"
+        "  schedule_state: Enabled\n"
+        "  schedule:\n"
+        "    recurrence_type: Daily\n"
+        "    start_time: 08:00:00\n"
+        "    end_time: 18:00:00\n"
+        "    time_zone: Pacific Standard Time\n"
+    )
+    sc.write_text(original, encoding="utf-8")
+
+    class FakeWS:
+        environment = "DEV"
+        environment_parameter: ClassVar[dict] = {
+            "spark_pool": [
+                {
+                    "instance_pool_id": "pool-123",
+                    "replace_value": {"DEV": {"type": "Capacity", "name": "MyPool"}},
+                }
+            ]
+        }
+        base_api_url = "https://api.example/v1/workspaces/ws-id"
+
+        def _get_workspace_pools(self):
+            return [{"id": "resolved-guid-abc", "name": "MyPool", "type": "Capacity"}]
+
+    dummy = DummyFile(sc)
+    result = env_module._process_environment_file(FakeWS(), DummyItem("EnvSchedule", [sc]), dummy)
+
+    # instance_pool_id was replaced
+    assert "instance_pool_id: resolved-guid-abc" in result
+    # time values remain intact as unquoted strings, not sexagesimal integers
+    assert "start_time: 08:00:00" in result
+    assert "end_time: 18:00:00" in result
+    assert "28800" not in result
+    assert "64800" not in result
+    # everything except the instance_pool_id line is byte-for-byte identical
+    expected = original.replace("instance_pool_id: pool-123", "instance_pool_id: resolved-guid-abc")
+    assert result == expected
+
+
+def test_process_environment_file_no_replacement_returns_original_unchanged(tmp_path):
+    """When no pool replacement occurs, the file is returned byte-for-byte unchanged.
+
+    Previously the round-trip ran unconditionally whenever instance_pool_id was
+    present, corrupting live_pool times even when no spark_pool mapping applied.
+    """
+    env_dir = tmp_path / "EnvNoReplace"
+    setting_dir = env_dir / "Setting"
+    setting_dir.mkdir(parents=True, exist_ok=True)
+    sc = setting_dir / "Sparkcompute.yml"
+    original = "instance_pool_id: pool-123\nlive_pool:\n  schedule:\n    start_time: 08:00:00\n    end_time: 18:00:00\n"
+    sc.write_text(original, encoding="utf-8")
+
+    class FakeWS:
+        environment = "DEV"
+        environment_parameter: ClassVar[dict] = {}
+        base_api_url = "https://api.example/v1/workspaces/ws-id"
+
+        def _get_workspace_pools(self):
+            return []
+
+    dummy = DummyFile(sc)
+    result = env_module._process_environment_file(FakeWS(), DummyItem("EnvNoReplace", [sc]), dummy)
+    assert result == original
+
+
+def test_replace_instance_pool_id_line_replaces_only_the_value():
+    """_replace_instance_pool_id_line rewrites only the instance_pool_id value."""
+    contents = "instance_pool_id: old-guid\ndriver_cores: 8\nlive_pool:\n  schedule:\n    end_time: 18:00:00\n"
+    result = env_module._replace_instance_pool_id_line(contents, "new-guid")
+    assert result == ("instance_pool_id: new-guid\ndriver_cores: 8\nlive_pool:\n  schedule:\n    end_time: 18:00:00\n")
+
+
 def test_environment_publisher_exposes_func_process_file_for_bulk():
     """EnvironmentPublisher class attribute ensures bulk path discovers the file processor."""
     assert hasattr(env_module.EnvironmentPublisher, "func_process_file")

--- a/tests/test_environment_publish.py
+++ b/tests/test_environment_publish.py
@@ -290,7 +290,7 @@ def test_resolve_pool_id_not_found():
 
 
 def test_process_environment_file_preserves_live_pool_schedule_times(tmp_path):
-    """Regression for #1072: unquoted live_pool HH:MM:SS times survive processing.
+    """Tests unquoted live_pool HH:MM:SS times survive processing.
 
     A full yaml.safe_load / yaml.dump round-trip corrupts unquoted times under
     PyYAML's YAML 1.1 sexagesimal parsing (18:00:00 -> 64800). The targeted line

--- a/tests/test_environment_publish.py
+++ b/tests/test_environment_publish.py
@@ -369,13 +369,6 @@ def test_process_environment_file_no_replacement_returns_original_unchanged(tmp_
     assert result == original
 
 
-def test_replace_instance_pool_id_line_replaces_only_the_value():
-    """_replace_instance_pool_id_line rewrites only the instance_pool_id value."""
-    contents = "instance_pool_id: old-guid\ndriver_cores: 8\nlive_pool:\n  schedule:\n    end_time: 18:00:00\n"
-    result = env_module._replace_instance_pool_id_line(contents, "new-guid")
-    assert result == ("instance_pool_id: new-guid\ndriver_cores: 8\nlive_pool:\n  schedule:\n    end_time: 18:00:00\n")
-
-
 def test_environment_publisher_exposes_func_process_file_for_bulk():
     """EnvironmentPublisher class attribute ensures bulk path discovers the file processor."""
     assert hasattr(env_module.EnvironmentPublisher, "func_process_file")

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -836,42 +836,8 @@ find_replace:
         Path(temp_file_path).unlink()
 
 
-def test_find_sexagesimal_scalars_detects_unquoted_time():
-    """_find_sexagesimal_scalars flags only unquoted YAML 1.1 base-60 time values."""
-    from fabric_cicd._parameter._parameter import _find_sexagesimal_scalars
-
-    content = """key_value_replace:
-  - find_key: $.end_time
-    replace_value:
-      DEV: 18:00:00
-      PROD: '18:00:00'
-      QA: 64800
-      RATIO: 1.3
-      LABEL: not_a_time
-"""
-    findings = _find_sexagesimal_scalars(content)
-    # Only the unquoted 18:00:00 is flagged; quoted string, plain int, float, and
-    # non-numeric string are all ignored.
-    assert findings == ["'18:00:00' (line 4)"]
-
-
-def test_find_sexagesimal_scalars_none_when_all_safe():
-    """_find_sexagesimal_scalars returns nothing when times are quoted or absent."""
-    from fabric_cicd._parameter._parameter import _find_sexagesimal_scalars
-
-    content = """key_value_replace:
-  - find_key: $.end_time
-    replace_value:
-      DEV: '18:00:00'
-      PROD: plain-string
-      COUNT: 42
-"""
-    assert _find_sexagesimal_scalars(content) == []
-
-
-def test_load_parameter_file_warns_on_unquoted_time(caplog):
-    """Loading a parameter file with an unquoted time logs a sexagesimal warning (#1072)."""
-    import logging
+def test_parameter_loader_preserves_unquoted_time():
+    """The parameter file loader keeps unquoted YAML 1.1 time values as strings (#1072)."""
     import tempfile
 
     with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as temp_file:
@@ -883,43 +849,15 @@ def test_load_parameter_file_warns_on_unquoted_time(caplog):
         temp_file_path = temp_file.name
 
     try:
-        with caplog.at_level(logging.WARNING):
-            Parameter(
-                repository_directory=Path(temp_file_path).parent,
-                item_type_in_scope=["Notebook"],
-                environment="TEST",
-                parameter_file_name=Path(temp_file_path).name,
-            )
-        warning_prefix = constants.PARAMETER_MSGS["sexagesimal time"].split("{}")[0]
-        assert any(warning_prefix in record.message for record in caplog.records)
-        assert any("18:00:00" in record.message for record in caplog.records)
-    finally:
-        Path(temp_file_path).unlink()
-
-
-def test_load_parameter_file_no_warning_when_time_quoted(caplog):
-    """A quoted time value in the parameter file does not trigger the sexagesimal warning."""
-    import logging
-    import tempfile
-
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as temp_file:
-        temp_file.write("""key_value_replace:
-  - find_key: $.live_pool.schedule.end_time
-    replace_value:
-      TEST: '18:00:00'
-""")
-        temp_file_path = temp_file.name
-
-    try:
-        with caplog.at_level(logging.WARNING):
-            Parameter(
-                repository_directory=Path(temp_file_path).parent,
-                item_type_in_scope=["Notebook"],
-                environment="TEST",
-                parameter_file_name=Path(temp_file_path).name,
-            )
-        warning_prefix = constants.PARAMETER_MSGS["sexagesimal time"].split("{}")[0]
-        assert not any(warning_prefix in record.message for record in caplog.records)
+        param = Parameter(
+            repository_directory=Path(temp_file_path).parent,
+            item_type_in_scope=["Notebook"],
+            environment="TEST",
+            parameter_file_name=Path(temp_file_path).name,
+        )
+        replace_value = param.environment_parameter["key_value_replace"][0]["replace_value"]
+        # Without sexagesimal-safe loading this would be the integer 64800.
+        assert replace_value["TEST"] == "18:00:00"
     finally:
         Path(temp_file_path).unlink()
 

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -836,6 +836,94 @@ find_replace:
         Path(temp_file_path).unlink()
 
 
+def test_find_sexagesimal_scalars_detects_unquoted_time():
+    """_find_sexagesimal_scalars flags only unquoted YAML 1.1 base-60 time values."""
+    from fabric_cicd._parameter._parameter import _find_sexagesimal_scalars
+
+    content = """key_value_replace:
+  - find_key: $.end_time
+    replace_value:
+      DEV: 18:00:00
+      PROD: '18:00:00'
+      QA: 64800
+      RATIO: 1.3
+      LABEL: not_a_time
+"""
+    findings = _find_sexagesimal_scalars(content)
+    # Only the unquoted 18:00:00 is flagged; quoted string, plain int, float, and
+    # non-numeric string are all ignored.
+    assert findings == ["'18:00:00' (line 4)"]
+
+
+def test_find_sexagesimal_scalars_none_when_all_safe():
+    """_find_sexagesimal_scalars returns nothing when times are quoted or absent."""
+    from fabric_cicd._parameter._parameter import _find_sexagesimal_scalars
+
+    content = """key_value_replace:
+  - find_key: $.end_time
+    replace_value:
+      DEV: '18:00:00'
+      PROD: plain-string
+      COUNT: 42
+"""
+    assert _find_sexagesimal_scalars(content) == []
+
+
+def test_load_parameter_file_warns_on_unquoted_time(caplog):
+    """Loading a parameter file with an unquoted time logs a sexagesimal warning (#1072)."""
+    import logging
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as temp_file:
+        temp_file.write("""key_value_replace:
+  - find_key: $.live_pool.schedule.end_time
+    replace_value:
+      TEST: 18:00:00
+""")
+        temp_file_path = temp_file.name
+
+    try:
+        with caplog.at_level(logging.WARNING):
+            Parameter(
+                repository_directory=Path(temp_file_path).parent,
+                item_type_in_scope=["Notebook"],
+                environment="TEST",
+                parameter_file_name=Path(temp_file_path).name,
+            )
+        warning_prefix = constants.PARAMETER_MSGS["sexagesimal time"].split("{}")[0]
+        assert any(warning_prefix in record.message for record in caplog.records)
+        assert any("18:00:00" in record.message for record in caplog.records)
+    finally:
+        Path(temp_file_path).unlink()
+
+
+def test_load_parameter_file_no_warning_when_time_quoted(caplog):
+    """A quoted time value in the parameter file does not trigger the sexagesimal warning."""
+    import logging
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as temp_file:
+        temp_file.write("""key_value_replace:
+  - find_key: $.live_pool.schedule.end_time
+    replace_value:
+      TEST: '18:00:00'
+""")
+        temp_file_path = temp_file.name
+
+    try:
+        with caplog.at_level(logging.WARNING):
+            Parameter(
+                repository_directory=Path(temp_file_path).parent,
+                item_type_in_scope=["Notebook"],
+                environment="TEST",
+                parameter_file_name=Path(temp_file_path).name,
+            )
+        warning_prefix = constants.PARAMETER_MSGS["sexagesimal time"].split("{}")[0]
+        assert not any(warning_prefix in record.message for record in caplog.records)
+    finally:
+        Path(temp_file_path).unlink()
+
+
 def test_duplicate_keys_single_duplicate(repository_directory, item_type_in_scope, target_environment):
     """Test detection of a single duplicate root-level key via _DuplicateKeyLoader."""
     param_obj = Parameter(

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -837,7 +837,7 @@ find_replace:
 
 
 def test_parameter_loader_preserves_unquoted_time():
-    """The parameter file loader keeps unquoted YAML 1.1 time values as strings (#1072)."""
+    """The parameter file loader keeps unquoted YAML 1.1 time values as strings."""
     import tempfile
 
     with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as temp_file:

--- a/tests/test_parameter_utils.py
+++ b/tests/test_parameter_utils.py
@@ -1474,6 +1474,78 @@ runtime_version: "1.2"
         result_data = yaml.safe_load(result)
         assert result_data["config"]["threshold"] == 0.8
 
+    def test_replace_key_value_yaml_preserves_schedule_times(self, mock_workspace):
+        """Regression for #1072: unquoted HH:MM:SS times survive key_value_replace on YAML.
+
+        A yaml.safe_load / yaml.dump round-trip under PyYAML's YAML 1.1 rules parses
+        unquoted times as sexagesimal integers (18:00:00 -> 64800), corrupting
+        live_pool schedules even when the replacement targets an unrelated key.
+        """
+        test_yaml = """instance_pool_id: pool-123
+live_pool:
+  state: Enabled
+  schedule_state: Enabled
+  schedule:
+    recurrence_type: Daily
+    start_time: 08:00:00
+    end_time: 18:00:00
+    time_zone: Pacific Standard Time
+"""
+        # Replacement targets only instance_pool_id; times must be untouched.
+        param_dict = {
+            "find_key": "$.instance_pool_id",
+            "replace_value": {"dev": "new-guid", "prod": "prod-guid"},
+        }
+
+        result = replace_key_value(mock_workspace, param_dict, test_yaml, "dev", is_yaml=True)
+
+        assert "instance_pool_id: new-guid" in result
+        # Times remain intact, not corrupted to sexagesimal integers.
+        assert "start_time: 08:00:00" in result
+        assert "end_time: 18:00:00" in result
+        assert "28800" not in result
+        assert "64800" not in result
+
+        result_data = yaml.safe_load(result.replace("08:00:00", "'08:00:00'").replace("18:00:00", "'18:00:00'"))
+        assert result_data["live_pool"]["schedule"]["start_time"] == "08:00:00"
+        assert result_data["live_pool"]["schedule"]["end_time"] == "18:00:00"
+
+    def test_replace_key_value_yaml_preserves_key_order(self, mock_workspace):
+        """key_value_replace on YAML must not reorder keys alphabetically (sort_keys=False)."""
+        test_yaml = """zeta: 1
+alpha: 2
+schedule:
+  start_time: 08:00:00
+  end_time: 18:00:00
+"""
+        param_dict = {"find_key": "$.alpha", "replace_value": {"dev": 9}}
+
+        result = replace_key_value(mock_workspace, param_dict, test_yaml, "dev", is_yaml=True)
+
+        # Original order preserved: zeta before alpha, start_time before end_time.
+        assert result.index("zeta:") < result.index("alpha:")
+        assert result.index("start_time:") < result.index("end_time:")
+        assert "alpha: 9" in result
+
+    def test_replace_key_value_yaml_time_safe_loader_keeps_numeric_types(self, mock_workspace):
+        """The sexagesimal-safe loader still resolves normal ints, floats, and bools."""
+        test_yaml = """count: 8
+ratio: 1.3
+enabled: true
+end_time: 18:00:00
+"""
+        param_dict = {"find_key": "$.count", "replace_value": {"dev": 10}}
+
+        result = replace_key_value(mock_workspace, param_dict, test_yaml, "dev", is_yaml=True)
+        result_data = yaml.safe_load(result.replace("18:00:00", "'18:00:00'"))
+
+        assert result_data["count"] == 10
+        assert isinstance(result_data["count"], int)
+        assert result_data["ratio"] == 1.3
+        assert isinstance(result_data["ratio"], float)
+        assert result_data["enabled"] is True
+        assert result_data["end_time"] == "18:00:00"
+
     def test_replace_variables_in_parameter_file(self, monkeypatch):
         """Test replace_variables_in_parameter_file with feature flag enabled."""
         # Set up test environment variables

--- a/tests/test_parameter_utils.py
+++ b/tests/test_parameter_utils.py
@@ -1475,7 +1475,7 @@ runtime_version: "1.2"
         assert result_data["config"]["threshold"] == 0.8
 
     def test_replace_key_value_yaml_preserves_schedule_times(self, mock_workspace):
-        """Regression for #1072: unquoted HH:MM:SS times survive key_value_replace on YAML.
+        """Test unquoted HH:MM:SS times survive key_value_replace on YAML.
 
         A yaml.safe_load / yaml.dump round-trip under PyYAML's YAML 1.1 rules parses
         unquoted times as sexagesimal integers (18:00:00 -> 64800), corrupting

--- a/tests/test_yaml_safe.py
+++ b/tests/test_yaml_safe.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-"""Tests for the centralized sexagesimal-safe YAML helpers (#1072)."""
+"""Tests for the centralized sexagesimal-safe YAML helpers."""
 
 import io
 from pathlib import Path
@@ -132,7 +132,7 @@ def test_no_raw_yaml_round_trip_in_src():
     """Guardrail: no source module bypasses the shared helpers with raw load/dump.
 
     Raw ``yaml.safe_load`` / ``yaml.dump`` (and bare ``yaml.load(x)``) re-introduce
-    the YAML 1.1 sexagesimal corruption fixed in #1072. All loading and dumping must
+    the YAML 1.1 sexagesimal corruption. All loading and dumping must
     go through ``_yaml_safe`` (or ``yaml.load`` with an explicit sexagesimal-safe
     ``Loader=``), so this test fails if a raw round-trip call reappears.
     """

--- a/tests/test_yaml_safe.py
+++ b/tests/test_yaml_safe.py
@@ -6,6 +6,8 @@
 import io
 from pathlib import Path
 
+import yaml
+
 from fabric_cicd._common._yaml_safe import dump_yaml, load_yaml
 
 SRC_DIR = Path(__file__).resolve().parents[1] / "src" / "fabric_cicd"
@@ -43,7 +45,69 @@ def test_dump_yaml_preserves_key_order():
     assert dumped.index("z:") < dumped.index("a:")
 
 
-def test_no_raw_yaml_round_trip_in_src():
+def test_load_yaml_matches_pyyaml_except_sexagesimal():
+    """Our loader is byte-identical to yaml.safe_load for every non-sexagesimal scalar.
+
+    This locks in the guarantee that stripping the base-60 branch did not change
+    resolution of any other literal. The edge cases below (unsigned exponent stays a
+    string, signed exponent is a float, ``0o17`` stays a string) are ones a naive
+    hand-written resolver gets wrong, so they are asserted explicitly.
+    """
+    non_sexagesimal = [
+        "42",
+        "-7",
+        "+9",
+        "0o17",
+        "0x1F",
+        "0b1010",
+        "1.5",
+        "-3.2e4",
+        "3.2e+4",
+        "1_000",
+        ".inf",
+        "-.inf",
+        "true",
+        "false",
+        "null",
+        "~",
+        "hello",
+        "'18:00:00'",
+        "2001-12-15",
+        "2001-12-15T02:59:43Z",
+        "[1, 2, 3]",
+        "{a: 1}",
+        "3723",
+        "64800",
+    ]
+    for raw in non_sexagesimal:
+        expected = yaml.safe_load(raw)
+        actual = load_yaml(raw)
+        assert type(actual) is type(expected), f"type differs for {raw!r}"
+        assert actual == expected, f"value differs for {raw!r}"
+
+
+def test_load_yaml_only_sexagesimal_differs():
+    """Colon-separated time literals are the only inputs that diverge from PyYAML.
+
+    Note PyYAML's sexagesimal-int branch requires a leading 1-9, so ``08:30:00``
+    already survives as a string in stock PyYAML; only non-zero-leading hours such
+    as ``18:00:00`` are corrupted. Our loader keeps all of them as strings.
+    """
+    corrupted_by_pyyaml = ["18:00:00", "1:2:3"]
+    for raw in corrupted_by_pyyaml:
+        assert isinstance(yaml.safe_load(raw), int)
+        assert load_yaml(raw) == raw
+
+    for raw in ["18:00:00", "08:30:00", "1:2:3", "23:59:59"]:
+        assert load_yaml(raw) == raw
+
+
+def test_dump_yaml_matches_pyyaml_for_normal_data():
+    """dump_yaml output matches stock yaml.dump (same options) for non-time data."""
+    data = {"count": 42, "ratio": 1.5, "flag": True, "name": "hello", "items": [1, 2, 3]}
+    expected = yaml.dump(data, default_flow_style=False, allow_unicode=True, sort_keys=False)
+    assert dump_yaml(data) == expected
+
     """Guardrail: no source module bypasses the shared helpers with raw load/dump.
 
     Raw ``yaml.safe_load`` / ``yaml.dump`` (and bare ``yaml.load(x)``) re-introduce

--- a/tests/test_yaml_safe.py
+++ b/tests/test_yaml_safe.py
@@ -108,6 +108,27 @@ def test_dump_yaml_matches_pyyaml_for_normal_data():
     expected = yaml.dump(data, default_flow_style=False, allow_unicode=True, sort_keys=False)
     assert dump_yaml(data) == expected
 
+
+def test_strip_sexagesimal_branch_rejects_unexpected_format():
+    """The resolver strip guards against a PyYAML wrapper-format change instead of corrupting silently."""
+    import re
+
+    import pytest
+
+    from fabric_cicd._common._yaml_safe import _strip_sexagesimal_branch
+
+    with pytest.raises(RuntimeError):
+        _strip_sexagesimal_branch(re.compile(r"^[0-9]+$"))
+
+
+def test_dumper_resolvers_derived_from_safedumper():
+    """SafeYamlDumper's resolvers derive from SafeDumper's own table, not SafeLoader's."""
+    from fabric_cicd._common._yaml_safe import SafeYamlDumper
+
+    assert set(SafeYamlDumper.yaml_implicit_resolvers) == set(yaml.SafeDumper.yaml_implicit_resolvers)
+
+
+def test_no_raw_yaml_round_trip_in_src():
     """Guardrail: no source module bypasses the shared helpers with raw load/dump.
 
     Raw ``yaml.safe_load`` / ``yaml.dump`` (and bare ``yaml.load(x)``) re-introduce

--- a/tests/test_yaml_safe.py
+++ b/tests/test_yaml_safe.py
@@ -1,0 +1,69 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for the centralized sexagesimal-safe YAML helpers (#1072)."""
+
+import io
+from pathlib import Path
+
+from fabric_cicd._common._yaml_safe import dump_yaml, load_yaml
+
+SRC_DIR = Path(__file__).resolve().parents[1] / "src" / "fabric_cicd"
+
+
+def test_load_yaml_preserves_unquoted_time():
+    """Unquoted HH:MM:SS values load as strings instead of base-60 integers."""
+    data = load_yaml("start: 08:00:00\nend: 18:00:00\n")
+    assert data == {"start": "08:00:00", "end": "18:00:00"}
+
+
+def test_load_yaml_still_parses_normal_scalars():
+    """Ordinary ints, floats, and booleans keep resolving as usual."""
+    data = load_yaml("count: 42\nratio: 1.5\nflag: true\nname: hello\n")
+    assert data == {"count": 42, "ratio": 1.5, "flag": True, "name": "hello"}
+
+
+def test_load_yaml_accepts_stream():
+    """load_yaml works with an open text stream, not just a string."""
+    stream = io.StringIO("end: 18:00:00\n")
+    assert load_yaml(stream) == {"end": "18:00:00"}
+
+
+def test_dump_yaml_emits_unquoted_time():
+    """A string time round-trips through dump/load unchanged and stays unquoted."""
+    dumped = dump_yaml({"end": "18:00:00"})
+    assert "18:00:00" in dumped
+    assert "'18:00:00'" not in dumped
+    assert load_yaml(dumped) == {"end": "18:00:00"}
+
+
+def test_dump_yaml_preserves_key_order():
+    """dump_yaml defaults to sort_keys=False so original ordering is kept."""
+    dumped = dump_yaml({"z": 1, "a": 2})
+    assert dumped.index("z:") < dumped.index("a:")
+
+
+def test_no_raw_yaml_round_trip_in_src():
+    """Guardrail: no source module bypasses the shared helpers with raw load/dump.
+
+    Raw ``yaml.safe_load`` / ``yaml.dump`` (and bare ``yaml.load(x)``) re-introduce
+    the YAML 1.1 sexagesimal corruption fixed in #1072. All loading and dumping must
+    go through ``_yaml_safe`` (or ``yaml.load`` with an explicit sexagesimal-safe
+    ``Loader=``), so this test fails if a raw round-trip call reappears.
+    """
+    forbidden = ("yaml.safe_load(", "yaml.safe_dump(", "yaml.dump(", "yaml.full_load(")
+    offenders = []
+    for path in SRC_DIR.rglob("*.py"):
+        if path.name == "_yaml_safe.py":
+            continue
+        text = path.read_text(encoding="utf-8")
+        for line in text.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("#") or '"""' in stripped:
+                continue
+            if any(token in line for token in forbidden):
+                offenders.append(f"{path.name}: {stripped}")
+            # bare yaml.load without an explicit safe Loader= is also forbidden
+            if "yaml.load(" in line and "Loader=" not in line:
+                offenders.append(f"{path.name}: {stripped}")
+    assert not offenders, "Raw YAML round-trip calls found; route them through _yaml_safe:\n" + "\n".join(offenders)


### PR DESCRIPTION
## Why

Deploying an Environment item whose `Setting/Sparkcompute.yml` contains a `live_pool` schedule fails with `SparkSettingsInvalidClpSchedule` (for example `Invalid custom live pool schedule EndTime: 64800.00:00:00`). The root cause is PyYAML's YAML 1.1 behavior: unquoted `HH:MM:SS` values are parsed as base-60 (sexagesimal) integers, so `end_time: 18:00:00` becomes `64800` and is re-emitted as a bare integer that the Fabric API interprets as a 64800-day .NET TimeSpan.

This corruption occurs on any code path that round-trips YAML through `yaml.safe_load` / `yaml.dump`. An audit of every YAML call site in `src/` found two such deployment paths. Rather than patch each site independently, this PR centralizes all YAML handling so the whole bug class is fixed in one place and cannot silently reappear.

## Centralized handling (`_common/_yaml_safe.py`)

A new shared module is now the single place YAML is loaded and dumped across the package. `load_yaml` / `dump_yaml` use a sexagesimal-safe `SafeYamlLoader` / `SafeYamlDumper` pair that strips only the base-60 branch from the int/float implicit resolvers. Time strings are preserved end to end (loaded as strings, emitted unquoted to match the Fabric portal format) while normal ints, floats, octal, hex, and binary literals still resolve exactly as before. `dump_yaml` defaults to `sort_keys=False` so key order is preserved. `load_yaml` accepts a string, bytes, or an open stream.

Every YAML call site is routed through these helpers:

- **Environment publisher (`_items/_environment.py`)** - `_process_environment_file` no longer re-serializes `Sparkcompute.yml` at all. Since this path only mutates one known key, the YAML is parsed (via `load_yaml`) solely to look up the `spark_pool` mapping, and the resolved GUID is written back with a targeted single-line replacement of `instance_pool_id`. Every other line (comments, formatting, schedule times) is preserved byte-for-byte, and the file is returned unchanged when no mapping matches.
- **`key_value_replace` parameterization (`_parameter/_utils.py`)** - applies replacements to an arbitrary user-supplied JSONPath, so it genuinely needs to parse and re-dump. It now uses `load_yaml` / `dump_yaml`, preserving times and key order. JSON targets were never affected.
- **Parameter file loading (`_parameter/_parameter.py`)** - `_DuplicateKeyLoader` now inherits from `SafeYamlLoader`, so duplicate-key detection and time-safe loading are combined. This means an unquoted `HH:MM:SS` used as a `replace_value` is now preserved correctly (`18:00:00` stays a string) instead of being corrupted to `64800`.
- **`_common/_check_utils.py` and `_common/_config_validator.py`** - YAML validation reads are routed through `load_yaml` for consistency.

Because consistent time-safe loading now fixes the parameter-file value at parse time, the interim "unquoted time" warning added earlier in this PR's history is removed - it would have been redundant and its message (telling users to quote the value) would have been misleading now that the value is handled correctly automatically.

## Guardrail

A test greps `src/` and fails if a raw `yaml.safe_load` / `yaml.dump` (or a bare `yaml.load` without an explicit safe `Loader=`) is reintroduced outside the shared module, so this class of corruption cannot creep back in.

## Tests

- `tests/test_yaml_safe.py`: `load_yaml` preserves unquoted times, still parses normal scalars, accepts a stream; `dump_yaml` emits times unquoted and preserves key order; plus the guardrail test.
- `tests/test_environment_publish.py`: unquoted `live_pool` times survive while `instance_pool_id` is replaced; files unchanged when no replacement applies.
- `tests/test_parameter_utils.py`: `key_value_replace` on YAML preserves schedule times and key order and still resolves normal int/float/bool types.
- `tests/test_parameter.py`: the parameter loader preserves an unquoted time value as a string.

Full suite passes (1083 passed, 11 skipped); ruff format and lint are clean. No new dependency added.
