### PR TITLE
Closes #1097 Add public function to remove feature flags from global set

### DIFF
--- a/.changes/unreleased/added-20260806-151753.yaml
+++ b/.changes/unreleased/added-20260806-151753.yaml
@@ -1,0 +1,8 @@
+kind: added
+body: Add support for removing globally enabled feature flags via `remove_feature_flag` function
+time: 2026-08-06T15:17:53.0016095+03:00
+custom:
+    Author: shirasassoon
+    AuthorLink: https://github.com/shirasassoon
+    Issue: "1097"
+    IssueLink: https://github.com/microsoft/fabric-cicd/issues/1097

--- a/src/fabric_cicd/__init__.py
+++ b/src/fabric_cicd/__init__.py
@@ -34,6 +34,21 @@ def append_feature_flag(feature: str) -> None:
     constants.FEATURE_FLAG.add(feature)
 
 
+def remove_feature_flag(feature: str) -> None:
+    """
+    Remove a feature flag from the global feature_flag set.
+
+    Args:
+        feature: The feature flag to be removed.
+
+    Examples:
+        Basic usage
+        >>> from fabric_cicd import remove_feature_flag
+        >>> remove_feature_flag("enable_lakehouse_unpublish")
+    """
+    constants.FEATURE_FLAG.discard(feature)
+
+
 def get_supported_feature_flags() -> list[str]:
     """
     Return all feature flags supported by fabric-cicd.
@@ -234,5 +249,6 @@ __all__ = [
     "get_changed_items",
     "get_supported_feature_flags",
     "publish_all_items",
+    "remove_feature_flag",
     "unpublish_all_orphan_items",
 ]

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -19,6 +19,7 @@ from fabric_cicd import (
     constants,
     disable_file_logging,
     get_supported_feature_flags,
+    remove_feature_flag,
 )
 from fabric_cicd._common._logging import (
     CustomFormatter,
@@ -657,6 +658,15 @@ class TestWrapperFunctions:
         assert "feature_1" in constants.FEATURE_FLAG
         assert "feature_2" in constants.FEATURE_FLAG
         assert len([f for f in constants.FEATURE_FLAG if f == "feature_1"]) == 1
+
+    def test_remove_feature_flag(self):
+        """Test remove_feature_flag removes only the requested flag."""
+        constants.FEATURE_FLAG.update({"feature_1", "feature_2"})
+
+        remove_feature_flag("feature_1")
+        remove_feature_flag("missing_feature")
+
+        assert {"feature_2"} == constants.FEATURE_FLAG
 
     def test_get_supported_feature_flags_returns_all_enum_values(self):
         """Test get_supported_feature_flags returns every FeatureFlag value."""


### PR DESCRIPTION
This pull request adds support for removing feature flags from the global set and includes corresponding tests and exports. The main focus is on enhancing feature flag management.

**Feature flag management:**

* Added a new function `remove_feature_flag` to remove a feature flag from the global `FEATURE_FLAG` set in `src/fabric_cicd/__init__.py`.
* Exported `remove_feature_flag` in the module's `__all__` list to make it publicly available.

**Testing:**

* Imported `remove_feature_flag` in `tests/test_logging.py` and added a new test `test_remove_feature_flag` to verify correct removal of feature flags, including handling of missing flags. [[1]](diffhunk://#diff-7f5b6b29dd89cb78db1eb94863a0d6f023c3b4f28d7eb3b9b35eab84eec13381R22) [[2]](diffhunk://#diff-7f5b6b29dd89cb78db1eb94863a0d6f023c3b4f28d7eb3b9b35eab84eec13381R662-R670)