### PR TITLE
Resolves #1099 - Remove erroneous contribution item under docs section in README and add dedicated section for contribution

### DIFF
--- a/.changes/unreleased/docs-20260809-184341.yaml
+++ b/.changes/unreleased/docs-20260809-184341.yaml
@@ -1,0 +1,8 @@
+kind: docs
+body: Fix broken link to contribution docs in README.md
+time: 2026-08-09T18:43:41.743187+10:00
+custom:
+    Author: isaakchoi
+    AuthorLink: https://github.com/isaakchoi
+    Issue: "1099"
+    IssueLink: https://github.com/microsoft/fabric-cicd/issues/1099

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ pip install fabric-cicd
 
 ## Contribution
 
-See the [contribution guide](CONTRIBUTING.md).
+See the [contribution guide](https://github.com/microsoft/fabric-cicd/blob/main/CONTRIBUTING.md).
 
 ## Trademarks
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ To install fabric-cicd, run:
 pip install fabric-cicd
 ```
 
+## Contribution
+
+See the [contribution guide](CONTRIBUTING.md).
+
 ## Trademarks
 
 This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general). Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship. Any use of third-party trademarks or logos are subject to those third-party's policies.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Section Overview:
 -   [Home](https://microsoft.github.io/fabric-cicd/latest/)
 -   [How To](https://microsoft.github.io/fabric-cicd/latest/how_to/)
 -   [Examples](https://microsoft.github.io/fabric-cicd/latest/example/)
--   [Contribution](https://microsoft.github.io/fabric-cicd/latest/contribution/)
 -   [Changelog](https://microsoft.github.io/fabric-cicd/latest/changelog/)
 -   [About](https://microsoft.github.io/fabric-cicd/latest/help/) - Inclusive of Support & Security Policies
 


### PR DESCRIPTION
## Description

README contained a link to the 'Contribution' page in the docs. However, this page does not exist so the hyperlink was pointing to a nonexistent page.

There were three options for resolution:
- Change the link to point to the local CONTRIBUTING.md file.
  - This option was not chosen because the section was explicitly talking about the web docs, not the internal documentation.
- Add the page to the docs.
  - This option was not chosen because the referenced docs are designed for end users, not developers, and developers know to look at CONTRIBUTING.md for this information.
- Delete the erroneous entry.
  - This option was chosen as it provides the cleanest resolution. As mentioned above, developers will easily be able to find CONTRIBUTING.md. A dedicated section was created in the README for contribution information to make it even clearer.

No change log was created as this does not affect any functionality or customer facing documentation.

## Linked Issue (REQUIRED)

#1099 
