### PR TITLE
v1.3.0

### DIFF
--- a/.changes/unreleased/added-20260625-164942.yaml
+++ b/.changes/unreleased/added-20260625-164942.yaml
@@ -1,8 +1,0 @@
-kind: added
-body: Add `FABRIC_CICD_RETRY_API_MAX_DURATION_SECONDS` environment variable to configure the maximum duration for API request execution, including long-running operation polling and connection retries (default 300 seconds)
-time: 2026-06-25T16:49:42.0887102+03:00
-custom:
-    Author: shirasassoon
-    AuthorLink: https://github.com/shirasassoon
-    Issue: "1022"
-    IssueLink: https://github.com/microsoft/fabric-cicd/issues/1022

--- a/.changes/unreleased/added-20260708-061701.yaml
+++ b/.changes/unreleased/added-20260708-061701.yaml
@@ -1,8 +1,0 @@
-kind: added
-body: Add `$sqlendpoint` and `$sqlendpointid` dynamic replacement variable support for MirroredDatabase items
-time: 2026-07-08T06:17:01Z
-custom:
-    Author: ecgang
-    AuthorLink: https://github.com/ecgang
-    Issue: "1055"
-    IssueLink: https://github.com/microsoft/fabric-cicd/issues/1055

--- a/.changes/unreleased/added-20260712-120217.yaml
+++ b/.changes/unreleased/added-20260712-120217.yaml
@@ -1,8 +1,0 @@
-kind: added
-body: Add `get_supported_feature_flags` function to return all supported feature flags
-time: 2026-07-12T12:02:17.006+03:00
-custom:
-    Author: ayeshurun
-    AuthorLink: https://github.com/ayeshurun
-    Issue: "1059"
-    IssueLink: https://github.com/microsoft/fabric-cicd/issues/1059

--- a/.changes/unreleased/added-20260806-151753.yaml
+++ b/.changes/unreleased/added-20260806-151753.yaml
@@ -1,8 +1,0 @@
-kind: added
-body: Add support for removing globally enabled feature flags via `remove_feature_flag` function
-time: 2026-08-06T15:17:53.0016095+03:00
-custom:
-    Author: shirasassoon
-    AuthorLink: https://github.com/shirasassoon
-    Issue: "1097"
-    IssueLink: https://github.com/microsoft/fabric-cicd/issues/1097

--- a/.changes/unreleased/docs-20260716-115617.yaml
+++ b/.changes/unreleased/docs-20260716-115617.yaml
@@ -1,8 +1,0 @@
-kind: docs
-body: "Extract Git flow guidance into a dedicated page and add a Next Steps section to Getting Started"
-time: 2026-07-16T11:56:17.7134417+03:00
-custom:
-    Author: nkwork9999
-    AuthorLink: https://github.com/nkwork9999
-    Issue: "1019"
-    IssueLink: https://github.com/microsoft/fabric-cicd/issues/1019

--- a/.changes/unreleased/docs-20260716-145101.yaml
+++ b/.changes/unreleased/docs-20260716-145101.yaml
@@ -1,8 +1,0 @@
-kind: docs
-body: Rename Git Flow page to Deployment Overview and add Deployment Philosophy section
-time: 2026-07-16T14:51:01.9305998+03:00
-custom:
-    Author: shirasassoon
-    AuthorLink: https://github.com/shirasassoon
-    Issue: "1018"
-    IssueLink: https://github.com/microsoft/fabric-cicd/issues/1018

--- a/.changes/unreleased/docs-20260809-184341.yaml
+++ b/.changes/unreleased/docs-20260809-184341.yaml
@@ -1,8 +1,0 @@
-kind: docs
-body: Fix broken link to contribution docs in README.md
-time: 2026-08-09T18:43:41.743187+10:00
-custom:
-    Author: isaakchoi
-    AuthorLink: https://github.com/isaakchoi
-    Issue: "1099"
-    IssueLink: https://github.com/microsoft/fabric-cicd/issues/1099

--- a/.changes/unreleased/fixed-20260722-103003.yaml
+++ b/.changes/unreleased/fixed-20260722-103003.yaml
@@ -1,8 +1,0 @@
-kind: fixed
-body: Fix `item_name` list filter in `spark_pool` parameter
-time: 2026-07-22T10:30:03.5378199+03:00
-custom:
-    Author: shirasassoon
-    AuthorLink: https://github.com/shirasassoon
-    Issue: "1071"
-    IssueLink: https://github.com/microsoft/fabric-cicd/issues/1071

--- a/.changes/unreleased/fixed-20260726-155751.yaml
+++ b/.changes/unreleased/fixed-20260726-155751.yaml
@@ -1,8 +1,0 @@
-kind: fixed
-body: Fix deployment failure when item attributes are not yet available due to asynchronous provisioning
-time: 2026-07-26T15:57:51.4571413+03:00
-custom:
-    Author: shirasassoon
-    AuthorLink: https://github.com/shirasassoon
-    Issue: "887"
-    IssueLink: https://github.com/microsoft/fabric-cicd/issues/887

--- a/.changes/unreleased/optimization-20260708-143554.yaml
+++ b/.changes/unreleased/optimization-20260708-143554.yaml
@@ -1,8 +1,0 @@
-kind: optimization
-body: Improve performance of the `file_path` parameter filter and repository folder refresh
-time: 2026-07-08T14:35:54.402+03:00
-custom:
-    Author: ayeshurun
-    AuthorLink: https://github.com/ayeshurun
-    Issue: "1044"
-    IssueLink: https://github.com/microsoft/fabric-cicd/issues/1044

--- a/.changes/v1.3.0.md
+++ b/.changes/v1.3.0.md
@@ -1,0 +1,23 @@
+## [v1.3.0](https://pypi.org/project/fabric-cicd/1.3.0) - August 10, 2026
+
+### ✨ New Functionality
+
+- Add `FABRIC_CICD_RETRY_API_MAX_DURATION_SECONDS` environment variable to configure the maximum duration for API request execution, including long-running operation polling and connection retries (default 300 seconds) by [shirasassoon](https://github.com/shirasassoon) ([#1022](https://github.com/microsoft/fabric-cicd/issues/1022))
+- Add `$sqlendpoint` and `$sqlendpointid` dynamic replacement variable support for MirroredDatabase items by [ecgang](https://github.com/ecgang) ([#1055](https://github.com/microsoft/fabric-cicd/issues/1055))
+- Add `get_supported_feature_flags` function to return all supported feature flags by [ayeshurun](https://github.com/ayeshurun) ([#1059](https://github.com/microsoft/fabric-cicd/issues/1059))
+- Add support for removing globally enabled feature flags via `remove_feature_flag` function by [shirasassoon](https://github.com/shirasassoon) ([#1097](https://github.com/microsoft/fabric-cicd/issues/1097))
+
+### 🔧 Bug Fix
+
+- Fix `item_name` list filter in `spark_pool` parameter by [shirasassoon](https://github.com/shirasassoon) ([#1071](https://github.com/microsoft/fabric-cicd/issues/1071))
+- Fix deployment failure when item attributes are not yet available due to asynchronous provisioning by [shirasassoon](https://github.com/shirasassoon) ([#887](https://github.com/microsoft/fabric-cicd/issues/887))
+
+### ⚡ Additional Optimizations
+
+- Improve performance of the `file_path` parameter filter and repository folder refresh by [ayeshurun](https://github.com/ayeshurun) ([#1044](https://github.com/microsoft/fabric-cicd/issues/1044))
+
+### 📝 Documentation Update
+
+- Extract Git flow guidance into a dedicated page and add a Next Steps section to Getting Started by [nkwork9999](https://github.com/nkwork9999) ([#1019](https://github.com/microsoft/fabric-cicd/issues/1019))
+- Rename Git Flow page to Deployment Overview and add Deployment Philosophy section by [shirasassoon](https://github.com/shirasassoon) ([#1018](https://github.com/microsoft/fabric-cicd/issues/1018))
+- Fix broken link to contribution docs in README.md by [isaakchoi](https://github.com/isaakchoi) ([#1099](https://github.com/microsoft/fabric-cicd/issues/1099))

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [v1.3.0](https://pypi.org/project/fabric-cicd/1.3.0) - August 10, 2026
+
+### ✨ New Functionality
+
+- Add `FABRIC_CICD_RETRY_API_MAX_DURATION_SECONDS` environment variable to configure the maximum duration for API request execution, including long-running operation polling and connection retries (default 300 seconds) by [shirasassoon](https://github.com/shirasassoon) ([#1022](https://github.com/microsoft/fabric-cicd/issues/1022))
+- Add `$sqlendpoint` and `$sqlendpointid` dynamic replacement variable support for MirroredDatabase items by [ecgang](https://github.com/ecgang) ([#1055](https://github.com/microsoft/fabric-cicd/issues/1055))
+- Add `get_supported_feature_flags` function to return all supported feature flags by [ayeshurun](https://github.com/ayeshurun) ([#1059](https://github.com/microsoft/fabric-cicd/issues/1059))
+- Add support for removing globally enabled feature flags via `remove_feature_flag` function by [shirasassoon](https://github.com/shirasassoon) ([#1097](https://github.com/microsoft/fabric-cicd/issues/1097))
+
+### 🔧 Bug Fix
+
+- Fix `item_name` list filter in `spark_pool` parameter by [shirasassoon](https://github.com/shirasassoon) ([#1071](https://github.com/microsoft/fabric-cicd/issues/1071))
+- Fix deployment failure when item attributes are not yet available due to asynchronous provisioning by [shirasassoon](https://github.com/shirasassoon) ([#887](https://github.com/microsoft/fabric-cicd/issues/887))
+
+### ⚡ Additional Optimizations
+
+- Improve performance of the `file_path` parameter filter and repository folder refresh by [ayeshurun](https://github.com/ayeshurun) ([#1044](https://github.com/microsoft/fabric-cicd/issues/1044))
+
+### 📝 Documentation Update
+
+- Extract Git flow guidance into a dedicated page and add a Next Steps section to Getting Started by [nkwork9999](https://github.com/nkwork9999) ([#1019](https://github.com/microsoft/fabric-cicd/issues/1019))
+- Rename Git Flow page to Deployment Overview and add Deployment Philosophy section by [shirasassoon](https://github.com/shirasassoon) ([#1018](https://github.com/microsoft/fabric-cicd/issues/1018))
+- Fix broken link to contribution docs in README.md by [isaakchoi](https://github.com/isaakchoi) ([#1099](https://github.com/microsoft/fabric-cicd/issues/1099))
+
 ## [v1.2.0](https://pypi.org/project/fabric-cicd/1.2.0) - June 30, 2026
 
 ### 🆕 New Items Support

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -10,7 +10,7 @@ from fabric_cicd._common._validate_env_vars import VALID_GUID_REGEX as VALID_GUI
 from fabric_cicd._common._validate_env_vars import validate_env_var_api_url
 
 # General
-VERSION = "1.2.0"
+VERSION = "1.3.0"
 DEFAULT_GUID = "00000000-0000-0000-0000-000000000000"
 FEATURE_FLAG = set()
 VALID_ENABLE_FLAGS = ["1", "true", "yes"]


### PR DESCRIPTION

This pull request prepares the project for the v1.3.0 release and introduces several new features, bug fixes, performance improvements, and documentation updates. The most significant changes are the addition of new configuration options and feature flag management functions, important bug fixes for deployment reliability, and enhancements to documentation and performance.

**New Features and Enhancements:**
- Add `FABRIC_CICD_RETRY_API_MAX_DURATION_SECONDS` environment variable to configure the maximum duration for API request execution, including long-running operation polling and connection retries.
- Add `get_supported_feature_flags` function to return all supported feature flags.
- Add support for removing globally enabled feature flags via `remove_feature_flag` function.
- Add `$sqlendpoint` and `$sqlendpointid` dynamic replacement variable support for MirroredDatabase items.

**Bug Fixes:**
- Fix `item_name` list filter in `spark_pool` parameter.
- Fix deployment failure when item attributes are not yet available due to asynchronous provisioning.

**Performance Improvements:**
- Improve performance of the `file_path` parameter filter and repository folder refresh.

**Documentation Updates:**
- Extract Git flow guidance into a dedicated page and add a Next Steps section to Getting Started.
- Rename Git Flow page to Deployment Overview and add Deployment Philosophy section.
- Fix broken link to contribution docs in `README.md`.

**Release and Versioning:**
- Bump version to `1.3.0` and update changelogs and documentation to reflect new features and fixes. [[1]](diffhunk://#diff-91c2d32be351f155f090c4bd57ebe3c10e646edbc1b663e2a72b697f956a949cL13-R13) [[2]](diffhunk://#diff-72453debc960780cf4d136356bfe90dc13021b41822c8bea2729fab8728c2ba2R1-R23) [[3]](diffhunk://#diff-77f023b99d3d58008351d3e82fc06e6d06ba1bc2da9e41be6329b7fa4f419f05R3-R26)

These changes collectively improve configuration flexibility, feature flag management, deployment reliability, performance, and documentation clarity.
