### PR TITLE
Resolves #1105 Fix cluster uri replacement in KQL Queryset item

### DIFF
--- a/.changes/unreleased/fixed-20260816-154119.yaml
+++ b/.changes/unreleased/fixed-20260816-154119.yaml
@@ -1,0 +1,8 @@
+kind: fixed
+body: Fix cluster URI resolution for KQL Queryset items
+time: 2026-08-16T15:41:19.7593621+03:00
+custom:
+    Author: shirasassoon
+    AuthorLink: https://github.com/shirasassoon
+    Issue: "1105"
+    IssueLink: https://github.com/microsoft/fabric-cicd/issues/1105

--- a/src/fabric_cicd/_items/_kqlqueryset.py
+++ b/src/fabric_cicd/_items/_kqlqueryset.py
@@ -57,19 +57,24 @@ def replace_cluster_uri(fabric_workspace_obj: FabricWorkspace, file_obj: File) -
     for data_source in data_sources:
         if data_source.get("clusterUri") == "":
             # Get the logical ID of the source KQL database
-            database_id = data_source.get("databaseItemId")
-            logger.debug(f"Found empty cluster URI for database with ID '{database_id}'")
+            database_logical_id = data_source.get("databaseItemId")
+            logger.debug(f"Found empty cluster URI for database with ID '{database_logical_id}'")
 
             database_item = next(
-                (item for item in database_items.values() if item.logical_id == database_id),
+                (item for item in database_items.values() if item.logical_id == database_logical_id),
                 None,
             )
-
-            if not database_item or not database_item.guid:
-                msg = f"Cannot find a deployed KQL Database with logical ID '{database_id}'."
+            if not database_item:
+                msg = f"Cannot find a KQL Database source with logical ID '{database_logical_id}' in the repository."
                 raise ParsingError(msg, logger)
 
+            database_item_name = database_item.name
             database_item_guid = database_item.guid
+
+            if not database_item_guid:
+                msg = f"Cannot find the KQL Database source with name '{database_item_name}' as it is not yet deployed."
+                raise ParsingError(msg, logger)
+
             # Get the cluster URI of the KQL database
             kqldatabase_data = fabric_workspace_obj.endpoint.invoke(
                 method="GET",
@@ -81,12 +86,12 @@ def replace_cluster_uri(fabric_workspace_obj: FabricWorkspace, file_obj: File) -
                 kqldatabase_cluster_uri = None
 
             if not kqldatabase_cluster_uri:
-                msg = f"Cannot find the cluster URI for KQL Database '{database_item.name}'."
+                msg = f"Cannot find the cluster URI for KQL Database '{database_item_name}'."
                 raise ParsingError(msg, logger)
             # Replace the cluster URI value
             data_source["clusterUri"] = kqldatabase_cluster_uri
             logger.debug(
-                f"Updated the cluster URI for data source '{database_item.name}' with '{kqldatabase_cluster_uri}'"
+                f"Updated the cluster URI for data source '{database_item_name}' with '{kqldatabase_cluster_uri}'"
             )
 
     logger.debug("Successfully updated all empty cluster URIs.")

--- a/src/fabric_cicd/_items/_kqlqueryset.py
+++ b/src/fabric_cicd/_items/_kqlqueryset.py
@@ -50,18 +50,23 @@ def replace_cluster_uri(fabric_workspace_obj: FabricWorkspace, file_obj: File) -
         logger.debug("No data sources found in KQL Queryset.")
         return file_obj.contents
 
-    # Get the KQL Database items from the deployed items
-    database_items = fabric_workspace_obj.deployed_items.get(ItemType.KQL_DATABASE.value, {})
+    # Get the KQL Database items from the repository items
+    database_items = fabric_workspace_obj.repository_items.get(ItemType.KQL_DATABASE.value, {})
 
     # If the cluster URI is empty, replace it with the cluster URI of the KQL database
     for data_source in data_sources:
         if data_source.get("clusterUri") == "":
-            database_item_name = data_source.get("databaseItemName")
-            logger.debug(f"Found empty cluster URI for database '{database_item_name}'")
+            # Get the logical ID of the source KQL database
+            database_id = data_source.get("databaseItemId")
+            logger.debug(f"Found empty cluster URI for database with ID '{database_id}'")
 
-            database_item = database_items.get(database_item_name)
-            if not database_item:
-                msg = f"Cannot find the KQL Database source with name '{database_item_name}' as it is not yet deployed."
+            database_item = next(
+                (item for item in database_items.values() if item.logical_id == database_id),
+                None,
+            )
+
+            if not database_item or not database_item.guid:
+                msg = f"Cannot find a deployed KQL Database with logical ID '{database_id}'."
                 raise ParsingError(msg, logger)
 
             database_item_guid = database_item.guid
@@ -76,12 +81,12 @@ def replace_cluster_uri(fabric_workspace_obj: FabricWorkspace, file_obj: File) -
                 kqldatabase_cluster_uri = None
 
             if not kqldatabase_cluster_uri:
-                msg = f"Cannot find the cluster URI for KQL Database '{database_item_name}'."
+                msg = f"Cannot find the cluster URI for KQL Database '{database_item.name}'."
                 raise ParsingError(msg, logger)
             # Replace the cluster URI value
             data_source["clusterUri"] = kqldatabase_cluster_uri
             logger.debug(
-                f"Updated the cluster URI for data source '{database_item_name}' with '{kqldatabase_cluster_uri}'"
+                f"Updated the cluster URI for data source '{database_item.name}' with '{kqldatabase_cluster_uri}'"
             )
 
     logger.debug("Successfully updated all empty cluster URIs.")

--- a/src/fabric_cicd/_items/_kqlqueryset.py
+++ b/src/fabric_cicd/_items/_kqlqueryset.py
@@ -58,7 +58,7 @@ def replace_cluster_uri(fabric_workspace_obj: FabricWorkspace, file_obj: File) -
         if data_source.get("clusterUri") == "":
             # Get the logical ID of the source KQL database
             database_logical_id = data_source.get("databaseItemId")
-            logger.debug(f"Found empty cluster URI for database with ID '{database_logical_id}'")
+            logger.debug(f"Found empty cluster URI for KQL database with logical ID '{database_logical_id}'")
 
             database_item = next(
                 (item for item in database_items.values() if item.logical_id == database_logical_id),

--- a/tests/test_kqlqueryset_cluster_uri_replacement.py
+++ b/tests/test_kqlqueryset_cluster_uri_replacement.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-"""Tests for KQL Queryset item processing."""
+"""Tests for KQL Queryset cluster URI replacement."""
 
 import json
 from types import SimpleNamespace

--- a/tests/test_kqlqueryset_cluster_uri_replacement.py
+++ b/tests/test_kqlqueryset_cluster_uri_replacement.py
@@ -1,0 +1,109 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for KQL Queryset item processing."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from fabric_cicd._common._exceptions import ParsingError
+from fabric_cicd._common._file import File
+from fabric_cicd._common._item import Item
+from fabric_cicd._items._kqlqueryset import replace_cluster_uri
+from fabric_cicd.constants import ItemType
+
+DATABASE_LOGICAL_ID = "11111111-1111-1111-1111-111111111111"
+DATABASE_GUID = "22222222-2222-2222-2222-222222222222"
+CLUSTER_URI = "https://example.kusto.fabric.microsoft.com"
+
+
+def create_queryset_file(tmp_path, cluster_uri="", database_item_id=DATABASE_LOGICAL_ID):
+    """Create a KQL Queryset definition file for testing."""
+    queryset_path = tmp_path / "RealTimeQueryset.json"
+    queryset_path.write_text(
+        json.dumps({
+            "queryset": {
+                "dataSources": [
+                    {
+                        "clusterUri": cluster_uri,
+                        "databaseItemId": database_item_id,
+                    }
+                ]
+            }
+        }),
+        encoding="utf-8",
+    )
+    return File(tmp_path, queryset_path)
+
+
+def create_workspace(database_guid=DATABASE_GUID, query_service_uri=CLUSTER_URI):
+    """Create a minimal workspace containing a repository KQL Database."""
+    endpoint = MagicMock()
+    endpoint.invoke.return_value = {"body": {"properties": {"queryServiceUri": query_service_uri}}}
+    database_item = Item(
+        type=ItemType.KQL_DATABASE.value,
+        name="TestDatabase",
+        description="",
+        guid=database_guid,
+        logical_id=DATABASE_LOGICAL_ID,
+    )
+    return SimpleNamespace(
+        repository_items={ItemType.KQL_DATABASE.value: {database_item.name: database_item}},
+        endpoint=endpoint,
+        base_api_url="https://api.fabric.microsoft.com/v1/workspaces/workspace-id",
+    )
+
+
+def test_replace_cluster_uri_resolves_database_logical_id(tmp_path):
+    """An empty cluster URI is resolved using the database logical ID and deployed GUID."""
+    workspace = create_workspace()
+
+    result = json.loads(replace_cluster_uri(workspace, create_queryset_file(tmp_path)))
+
+    assert result["queryset"]["dataSources"][0]["clusterUri"] == CLUSTER_URI
+    workspace.endpoint.invoke.assert_called_once_with(
+        method="GET",
+        url=f"{workspace.base_api_url}/kqlDatabases/{DATABASE_GUID}",
+    )
+
+
+def test_replace_cluster_uri_raises_for_unknown_logical_id(tmp_path):
+    """An unknown database logical ID produces a parsing error."""
+    workspace = create_workspace()
+
+    with pytest.raises(ParsingError, match="Cannot find a KQL Database source with logical ID"):
+        replace_cluster_uri(workspace, create_queryset_file(tmp_path, database_item_id="unknown-id"))
+
+    workspace.endpoint.invoke.assert_not_called()
+
+
+def test_replace_cluster_uri_raises_for_undeployed_database(tmp_path):
+    """A repository database without a deployed GUID cannot supply a cluster URI."""
+    workspace = create_workspace(database_guid="")
+
+    with pytest.raises(ParsingError, match="as it is not yet deployed"):
+        replace_cluster_uri(workspace, create_queryset_file(tmp_path))
+
+    workspace.endpoint.invoke.assert_not_called()
+
+
+def test_replace_cluster_uri_raises_when_query_service_uri_is_missing(tmp_path):
+    """A deployed database without a query service URI produces a parsing error."""
+    workspace = create_workspace(query_service_uri=None)
+
+    with pytest.raises(ParsingError, match="Cannot find the cluster URI for KQL Database 'TestDatabase'"):
+        replace_cluster_uri(workspace, create_queryset_file(tmp_path))
+
+
+def test_replace_cluster_uri_preserves_existing_uri(tmp_path):
+    """A populated cluster URI is returned unchanged without calling Fabric."""
+    workspace = create_workspace()
+    existing_uri = "https://existing.kusto.fabric.microsoft.com"
+
+    result = json.loads(replace_cluster_uri(workspace, create_queryset_file(tmp_path, cluster_uri=existing_uri)))
+
+    assert result["queryset"]["dataSources"][0]["clusterUri"] == existing_uri
+    workspace.endpoint.invoke.assert_not_called()


### PR DESCRIPTION
This pull request updates the logic for replacing empty cluster URIs in KQL Queryset files, improving the accuracy and robustness of how KQL Database items are matched and referenced. The changes ensure that the system uses repository items and logical IDs instead of deployed items and names, resulting in more reliable behavior during parsing and error handling.

**Improvements to KQL Database item lookup and error handling:**

* The function now retrieves KQL Database items from `fabric_workspace_obj.repository_items` instead of `deployed_items`, ensuring it works with repository state rather than deployment state.
* When resolving empty cluster URIs, the code matches KQL Database items by their logical ID (`databaseItemId`) instead of by name, making the lookup more robust and less error-prone.
* Improved error messages and log statements to reference the database's logical ID and name, providing clearer diagnostics when a database or its cluster URI cannot be found. [[1]](diffhunk://#diff-996cee517cea88bd9e7c873c7bb485859c629fd192a348d4ac41456264669864L53-R69) [[2]](diffhunk://#diff-996cee517cea88bd9e7c873c7bb485859c629fd192a348d4ac41456264669864L79-R89)