### PR TITLE
Closes #1117 Support dynamic replacement variables in bulk publish mode

### DIFF
--- a/.changes/unreleased/added-20260831-225839.yaml
+++ b/.changes/unreleased/added-20260831-225839.yaml
@@ -1,0 +1,8 @@
+kind: added
+body: Add support for dynamic replacement variables in bulk publish mode
+time: 2026-08-31T22:58:39.1302168+03:00
+custom:
+    Author: shirasassoon
+    AuthorLink: https://github.com/shirasassoon
+    Issue: "1117"
+    IssueLink: https://github.com/microsoft/fabric-cicd/issues/1117

--- a/.github/workflows/ai-issue-triage.yml
+++ b/.github/workflows/ai-issue-triage.yml
@@ -30,11 +30,11 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Resolve issue details
               id: issue
-              uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
               with:
                   script: |
                       const issueNumber = context.payload.issue?.number || ${{ inputs.issue_number || 0 }};
@@ -105,7 +105,7 @@ jobs:
 
             - name: Post-process triage results
               if: steps.ai-assessment.outputs.ai_assessments != ''
-              uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
               env:
                   ASSESSMENT_OUTPUT: ${{ steps.ai-assessment.outputs.ai_assessments }}
                   SUPPRESS_LABELS: ${{ env.SUPPRESS_LABELS }}
@@ -219,7 +219,7 @@ jobs:
 
             - name: Generate triage summary
               if: always() && steps.ai-assessment.outputs.ai_assessments != ''
-              uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
               env:
                   ASSESSMENT_OUTPUT: ${{ steps.ai-assessment.outputs.ai_assessments }}
                   LABEL_DECISIONS: ${{ env.LABEL_DECISIONS }}
@@ -272,7 +272,7 @@ jobs:
 
             - name: Upload triage report
               if: always() && steps.ai-assessment.outputs.ai_assessments != ''
-              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: triage-report-issue-${{ steps.issue.outputs.number }}
                   path: triage-reports/

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -27,7 +27,7 @@ jobs:
         steps:
             - name: Get PR Information
               id: pr-info
-              uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
               with:
                   script: |
                       const prNumber = parseInt('${{ github.event.inputs.pr_number }}');
@@ -53,7 +53,7 @@ jobs:
             is_version_bump: ${{ steps.version_bump_check.outputs.is_version_bump }}
         steps:
             - name: Checkout code
-              uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   fetch-depth: 0
 
@@ -83,13 +83,13 @@ jobs:
         steps:
             - name: Generate GitHub App Token
               id: app-token
-              uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
               with:
                   app-id: ${{ secrets.APP_ID }}
                   private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
             - name: Checkout repository
-              uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   fetch-depth: 0
                   token: ${{ steps.app-token.outputs.token }}
@@ -151,7 +151,7 @@ jobs:
 
             - name: Create GitHub Release
               if: needs.validate-version-bump.outputs.is_version_bump == 'true'
-              uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
               with:
                   github-token: ${{ steps.app-token.outputs.token }}
                   script: |

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -31,13 +31,13 @@ jobs:
             HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         steps:
             - name: ⤵️ Checkout
-              uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   fetch-depth: 0 # Required to access full commit history
 
             - name: ✔️ Check for changelog changes
               id: changelog_check
-              uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
               with:
                   script: |
                       const { execSync } = require('child_process');
@@ -51,7 +51,7 @@ jobs:
 
             - name: 🚧 Setup Node
               if: steps.changelog_check.outputs.exists == 'true'
-              uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
                   node-version: "20"
 

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -17,13 +17,13 @@ jobs:
         steps:
             - name: Generate GitHub App Token
               id: app-token
-              uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
               with:
                   app-id: ${{ secrets.APP_ID }}
                   private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
             - name: Checkout repository
-              uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   fetch-depth: 0
                   token: ${{ steps.app-token.outputs.token }}
@@ -42,7 +42,7 @@ jobs:
                   echo "version_number=$CONSTANTS_VERSION" >> $GITHUB_OUTPUT
 
             - name: Install Python
-              uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+              uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
               with:
                   python-version: "3.9"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,10 @@ jobs:
                 python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         steps:
             - name: Checkout code
-              uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+              uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
               with:
                   python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,10 +19,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Set up Python
-              uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
+              uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
               with:
                   python-version: "3.x"
 
@@ -45,10 +45,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Set up Python
-              uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
+              uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
               with:
                   python-version: "3.x"
 
@@ -73,7 +73,7 @@ jobs:
             is_version_bump: ${{ steps.version_bump_check.outputs.is_version_bump }}
         steps:
             - name: Checkout code
-              uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   fetch-depth: 0
 
@@ -150,7 +150,7 @@ jobs:
         steps:
             - name: Check PR Author Collaborator Role
               id: check_permissions
-              uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
               with:
                   script: |
                       const prAuthor = context.payload.pull_request.user.login;
@@ -201,7 +201,7 @@ jobs:
             issues: read
         steps:
             - name: Validate Linked Issue
-              uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
               with:
                   script: |
                       const prNumber = context.issue.number;

--- a/docs/how_to/optional_feature.md
+++ b/docs/how_to/optional_feature.md
@@ -157,25 +157,17 @@ Since this feature is experimental, it is recommended for non-production environ
 
 !!! tip "Items using item IDs instead of logical IDs"
 
-    Item definitions in the same workspace that reference other items by item ID (rather than logical ID) can still be published via bulk publish. However, parameterization is required to ensure references are correctly re-pointed in the target workspace. The recommended approach is to use a `find_replace` parameter where the `find_value` is the referenced item's ID and the `replace_value` is its logical ID. For example, a Dataflow Gen2 item that references a Lakehouse by item ID — use `find_replace` to swap the Lakehouse's item ID with its logical ID so the bulk publish API can resolve the dependency.
-
-    Note that logical ID replacement may not be a valid solution for all item types. In such cases, you can either use standard publish, or use a multi-phased bulk publish deployment by applying [selective deployment](#selective-deployment-features) to separate the affected items across phases.
+    Item definitions that reference other items in the same workspace by item ID rather than logical ID can still be published in bulk. However, parameterization is required to re-point those references to the corresponding items in the target workspace. Use a `find_replace` parameter with the referenced item's ID as the `find_value` and the target item's ID as the `replace_value`. Alternatively, use a [dynamic replacement variable](#dynamic-replacement-variable-support) to avoid hard-coded values.
 
     For more details on logical IDs, see [Resolve Logical ID Conflicts in Microsoft Fabric](https://learn.microsoft.com/en-us/fabric/cicd/git-integration/logical-id-conflict-resolution).
-
-### Dynamic Replacement Variables
-
-Dynamic replacement variables (`$workspace` and `$items`) are supported in bulk publish. Because these variables are resolved at runtime, bulk publish orders items into dependency **tiers**: when an `$items.*` variable references another item in the same workspace, the referenced item is published in an earlier tier so its resolved value is available to its dependents. Each tier is published in its own bulk call, and deployed items are refreshed between tiers so later tiers resolve against real item IDs.
-
-Asynchronously provisioned attributes are handled automatically. When a downstream item references a SQL endpoint (`$sqlendpoint`, `$sqlendpointid`) or an Eventhouse query URI (`$queryserviceuri`), bulk publish waits for the source item's endpoint to finish provisioning before publishing the next tier, so the variable never resolves to an empty value.
-
-!!! warning "Unfiltered current-workspace `$items.*` replace values"
-
-    A current-workspace `$items.*` **`replace_value`** with no `item_type`, `item_name`, or `file_path` filter causes bulk publish to fall back to standard publish. Without a filter the dependency scope cannot be narrowed, so every item would be treated as a dependent of the referenced item. Add at least one filter to each such parameter entry to keep the deployment on the bulk path. Cross-workspace item variables (`$workspace.<name>.$items.*`), `$workspace.*` variables, and dynamic `find_value`s do not trigger this fallback.
 
 ### Authentication Requirements
 
 When authenticating with a service principal or managed identity, all item types in a bulk call must support non-interactive authentication. If any item type in the batch does not, the entire call fails. Ensure your `item_type_in_scope` only includes item types with matching auth support.
+
+### Dynamic Replacement Variable Support
+
+Dynamic replacement variables (`$workspace` and `$items`) are supported in bulk publish. Because these variables are resolved at runtime, bulk publish orders items into dependency **batches**: when an `$items.*` variable references another item in the same workspace, the referenced item is published in an earlier batch so its resolved value is available to its dependents. Each batch is published in its own bulk call, and deployed items are refreshed between batches so later batches resolve against real item IDs.
 
 ### Automatic Fallback to Standard Publish
 
@@ -183,7 +175,7 @@ Bulk publish will automatically fall back to standard publish mode when any of t
 
 - **Unsupported item types in scope**: `DataBuildToolJob` and `Warehouse` are not supported. If either is included in `item_type_in_scope`, the entire deployment uses standard publish.
 - **No `item_type_in_scope` specified**: Bulk publish requires an explicit `item_type_in_scope`. When omitted, all supported item types are included — which inevitably contains bulk unsupported types — so standard publish is used instead.
-- **Unfiltered current-workspace `$items.*` replace values**: A current-workspace `$items.*` `replace_value` with no `item_type`, `item_name`, or `file_path` filter forces fallback, since its dependency scope cannot be narrowed. Add a filter to each such entry to stay on the bulk path. All other dynamic replacement variables — `$workspace.*`, cross-workspace `$items.*`, and dynamic `find_value`s — are fully supported in bulk mode (see [Dynamic Replacement Variables](#dynamic-replacement-variables)).
+- **Unfiltered current-workspace `$items.*` replace values**: A current-workspace `$items.*` `replace_value` with no `item_type`, `item_name`, or `file_path` parameter filter forces fallback, since its dependency scope cannot be narrowed. Add a filter to each such entry to stay on the bulk path. All other dynamic replacement variables — `$workspace.*`, cross-workspace `$items.*`, and dynamic `find_value`s — are fully supported in bulk mode (see [Dynamic Replacement Variable Support](#dynamic-replacement-variable-support)).
 
 Check your deployment logs for the message `"Falling back to standard deployment..."` to confirm whether bulk publish was actually used.
 

--- a/docs/how_to/optional_feature.md
+++ b/docs/how_to/optional_feature.md
@@ -153,15 +153,25 @@ To enable bulk publish, set both `enable_experimental_features` and `enable_bulk
 
 With bulk publishing, there is no predefined order of item types. The API leverages a dependency graph under the hood to determine the correct publishing sequence. As long as logical IDs are used to reference Fabric items, the API handles the rest — simplifying dependency management overhead. This may also reduce the complexity of your parameter file, though parameterization remains a key feature for edge cases and environment-specific customizations.
 
-Since this feature is experimental, it is recommended for non-production environments only. We encourage you to use this period to **provide feedback and help shape the bulk publish experience.** The initial release does not support all fabric-cicd item types and lacks support for more advanced parameterization features, specifically dynamic replacement variables (`$workspace`, `$items`).
+Since this feature is experimental, it is recommended for non-production environments only. We encourage you to use this period to **provide feedback and help shape the bulk publish experience.** The initial release does not support all fabric-cicd item types.
 
 !!! tip "Items using item IDs instead of logical IDs"
 
     Item definitions in the same workspace that reference other items by item ID (rather than logical ID) can still be published via bulk publish. However, parameterization is required to ensure references are correctly re-pointed in the target workspace. The recommended approach is to use a `find_replace` parameter where the `find_value` is the referenced item's ID and the `replace_value` is its logical ID. For example, a Dataflow Gen2 item that references a Lakehouse by item ID — use `find_replace` to swap the Lakehouse's item ID with its logical ID so the bulk publish API can resolve the dependency.
 
-    Note that logical ID replacement may not be a valid solution for all item types. In such cases, you can either use standard publish where dynamic replacement variables are supported, or use a multi-phased bulk publish deployment by applying [selective deployment](#selective-deployment-features) to separate the affected items across phases.
+    Note that logical ID replacement may not be a valid solution for all item types. In such cases, you can either use standard publish, or use a multi-phased bulk publish deployment by applying [selective deployment](#selective-deployment-features) to separate the affected items across phases.
 
     For more details on logical IDs, see [Resolve Logical ID Conflicts in Microsoft Fabric](https://learn.microsoft.com/en-us/fabric/cicd/git-integration/logical-id-conflict-resolution).
+
+### Dynamic Replacement Variables
+
+Dynamic replacement variables (`$workspace` and `$items`) are supported in bulk publish. Because these variables are resolved at runtime, bulk publish orders items into dependency **tiers**: when an `$items.*` variable references another item in the same workspace, the referenced item is published in an earlier tier so its resolved value is available to its dependents. Each tier is published in its own bulk call, and deployed items are refreshed between tiers so later tiers resolve against real item IDs.
+
+Asynchronously provisioned attributes are handled automatically. When a downstream item references a SQL endpoint (`$sqlendpoint`, `$sqlendpointid`) or an Eventhouse query URI (`$queryserviceuri`), bulk publish waits for the source item's endpoint to finish provisioning before publishing the next tier, so the variable never resolves to an empty value.
+
+!!! warning "Unfiltered current-workspace `$items.*` replace values"
+
+    A current-workspace `$items.*` **`replace_value`** with no `item_type`, `item_name`, or `file_path` filter causes bulk publish to fall back to standard publish. Without a filter the dependency scope cannot be narrowed, so every item would be treated as a dependent of the referenced item. Add at least one filter to each such parameter entry to keep the deployment on the bulk path. Cross-workspace item variables (`$workspace.<name>.$items.*`), `$workspace.*` variables, and dynamic `find_value`s do not trigger this fallback.
 
 ### Authentication Requirements
 
@@ -173,7 +183,7 @@ Bulk publish will automatically fall back to standard publish mode when any of t
 
 - **Unsupported item types in scope**: `DataBuildToolJob` and `Warehouse` are not supported. If either is included in `item_type_in_scope`, the entire deployment uses standard publish.
 - **No `item_type_in_scope` specified**: Bulk publish requires an explicit `item_type_in_scope`. When omitted, all supported item types are included — which inevitably contains bulk unsupported types — so standard publish is used instead.
-- **Dynamic parameter variables**: Parameter files containing `$workspace` or `$items` replacement variables require runtime resolution, which is incompatible with bulk publish.
+- **Unfiltered current-workspace `$items.*` replace values**: A current-workspace `$items.*` `replace_value` with no `item_type`, `item_name`, or `file_path` filter forces fallback, since its dependency scope cannot be narrowed. Add a filter to each such entry to stay on the bulk path. All other dynamic replacement variables — `$workspace.*`, cross-workspace `$items.*`, and dynamic `find_value`s — are fully supported in bulk mode (see [Dynamic Replacement Variables](#dynamic-replacement-variables)).
 
 Check your deployment logs for the message `"Falling back to standard deployment..."` to confirm whether bulk publish was actually used.
 

--- a/docs/how_to/parameterization.md
+++ b/docs/how_to/parameterization.md
@@ -233,9 +233,9 @@ The `find_replace` and `key_value_replace` parameters support fabric-cicd define
     - **Cannot be combined with `is_regex: "true"`** — use either a dynamic replacement variable OR a regex pattern, not both
 - **`find_key`** (`key_value_replace`): does **not** support variables — must be a valid JSONPath expression
 
-!!! note "Bulk Publish Limitation"
+!!! note "Bulk Publish Note"
 
-    Dynamic replacement variables (`$workspace`, `$items`) are not supported when using [bulk publish](optional_feature.md#bulk-publish) mode. When dynamic replacement variables are detected in the parameter file, the deployment automatically falls back to standard publishing. To use bulk publish, replace dynamic replacement variables with static values or use logical IDs directly.
+    Dynamic replacement variables (`$workspace`, `$items`) are supported in [bulk publish](optional_feature.md#bulk-publish) mode. Current-workspace `$items.*` references are published in dependency-ordered batches so referenced items are available before their dependents. However, a current-workspace `$items.*` `replace_value` without an `item_type`, `item_name`, or `file_path` filter causes a fallback to standard publishing because its dependency scope cannot be determined. `$workspace.*` and cross-workspace item variables do not create in-batch dependencies.
 
 Additional notes:
 

--- a/sample/workspace/ByConnection.Report/definition.pbir
+++ b/sample/workspace/ByConnection.Report/definition.pbir
@@ -3,7 +3,7 @@
   "version": "4.0",
   "datasetReference": {
     "byConnection": {
-      "connectionString": "Data Source=powerbi://api.powerbi.com/v1.0/myorg/dev-workspace-id;initial catalog=dev-semantic-model;access mode=readonly;integrated security=ClaimsToken;semanticmodelid=00000000-0000-0000-0000-000000000000"
+      "connectionString": "Data Source=powerbi://api.powerbi.com/v1.0/myorg/dev-workspace-name;initial catalog=dev-semantic-model;access mode=readonly;integrated security=ClaimsToken;semanticmodelid=00000000-0000-0000-0000-000000000000"
     }
   }
 }

--- a/sample/workspace/parameter.yml
+++ b/sample/workspace/parameter.yml
@@ -45,10 +45,10 @@ find_replace:
       # Optional fields:
       file_path: "/Example Notebook.Notebook/notebook-content.py"
     # Report byConnection - workspace id in connection string
-    - find_value: "dev-workspace-id"
+    - find_value: "dev-workspace-name"
       replace_value:
-        PPE: "$workspace.$id"
-        PROD: "$workspace.$id"
+        PPE: "$workspace.$name"
+        PROD: "$workspace.$name"
       # Optional fields:
       file_path: "/ByConnection.Report/definition.pbir"
     # Report byConnection - semantic model name in connection string

--- a/sample/workspace/parameter.yml
+++ b/sample/workspace/parameter.yml
@@ -44,7 +44,7 @@ find_replace:
         PROD: "$items.Eventhouse.SampleEventhouse.queryserviceuri" 
       # Optional fields:
       file_path: "/Example Notebook.Notebook/notebook-content.py"
-    # Report byConnection - workspace id in connection string
+    # Report byConnection - workspace name in connection string
     - find_value: "dev-workspace-name"
       replace_value:
         PPE: "$workspace.$name"

--- a/sample/workspace/parameter.yml
+++ b/sample/workspace/parameter.yml
@@ -14,8 +14,8 @@ find_replace:
     - find_value: \#\s*META\s+"default_lakehouse":\s*"([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
       replace_value:
       # Variable: $items.type.name.attribute (Note: item type and name values are CASE SENSITIVE; id attribute returns the deployed item's id/guid)
-        PPE: "$items.Lakehouse.WithoutSchema.id"   
-        PROD: "$items.Lakehouse.WithoutSchema.id" 
+        PPE: "$items.Lakehouse.WithoutSchema.$id"   
+        PROD: "$items.Lakehouse.WithoutSchema.$id" 
       # Optional fields:
       is_regex: "true"
       file_path: "/Example Notebook.Notebook/notebook-content.py"
@@ -23,25 +23,32 @@ find_replace:
     - find_value: \#\s*META\s+"default_lakehouse_workspace_id":\s*"([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
       replace_value:
       # Variable: $workspace.id -> target workspace id
-        PPE: "$workspace.id"
-        PROD: "$workspace.id"
+        PPE: "$workspace.$id"
+        PROD: "$workspace.$id"
       # Optional fields:
+      is_regex: "true"
+      file_path: "/Example Notebook.Notebook/notebook-content.py"
+    # Known lakehouse ID regex
+    - find_value: '"known_lakehouses":\s*\[\s*# META\s*\{\s*# META\s*"id":\s*"([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"'
+      replace_value:
+        PPE: "$items.Lakehouse.WithoutSchema.$id"
+        PROD: "$items.Lakehouse.WithoutSchema.$id"
       is_regex: "true"
       file_path: "/Example Notebook.Notebook/notebook-content.py"
     # SQL connection string
     - find_value: "sqlserverconnectionstringinoriginlakehouse.com"
       replace_value:
       # Variable: $items.type.name.attribute (Note: item type and name values are CASE SENSITIVE; sqlendpoint attribute returns the deployed item's sql endpoint)
-        PPE: "$items.Lakehouse.WithoutSchema.sqlendpoint"   
-        PROD: "$items.Lakehouse.WithoutSchema.sqlendpoint" 
+        PPE: "$items.Lakehouse.WithoutSchema.$sqlendpoint"   
+        PROD: "$items.Lakehouse.WithoutSchema.$sqlendpoint" 
       # Optional fields:
       file_path: "/Example Notebook.Notebook/notebook-content.py"
     # Eventhouse query URI
     - find_value: "https://trd-origineventhouse.z4.kusto.fabric.microsoft.com"
       replace_value:
       # Variable: $items.type.name.attribute (Note: item type and name values are CASE SENSITIVE; queryserviceuri attribute returns the deployed item's query service URI)
-        PPE: "$items.Eventhouse.SampleEventhouse.queryserviceuri"   
-        PROD: "$items.Eventhouse.SampleEventhouse.queryserviceuri" 
+        PPE: "$items.Eventhouse.SampleEventhouse.$queryserviceuri"   
+        PROD: "$items.Eventhouse.SampleEventhouse.$queryserviceuri" 
       # Optional fields:
       file_path: "/Example Notebook.Notebook/notebook-content.py"
     # Report byConnection - workspace name in connection string

--- a/src/fabric_cicd/_items/_base_publisher.py
+++ b/src/fabric_cicd/_items/_base_publisher.py
@@ -306,17 +306,25 @@ class ItemPublisher(Publisher):
     @staticmethod
     def publish_all_bulk(fabric_workspace_obj: "FabricWorkspace") -> list["ItemPublisher"]:
         """
-        Execute a single bulk publish across all item types in scope.
+        Execute bulk publish across all item types in scope, with batched (tiered) execution
+        when dynamic replacement variable dependencies require it.
 
         Lifecycle:
             1. pre_publish_all() — per type
             2. get_items_to_publish() — per type, collect into one pool
-            3. _publish_items() — single cross-type API call
-            4. post_publish_all() — per type
+            3. Build dependency graph from $items.* dynamic replacement variables
+            4. Compute publish batches (topological sort)
+            5. For each batch: _publish_items() → refresh deployed items between batches
+            6. post_publish_all() — per type
 
         Returns:
             List of publishers that have async checks pending.
         """
+        from fabric_cicd._items._bulk_publish_dependencies import (
+            build_dynamic_variable_dependency_graph,
+            compute_publish_batches,
+        )
+
         publishers: list[ItemPublisher] = []
         items_with_context: list[tuple[str, Item, ItemPublisher]] = []
         skipped_items: list[str] = []
@@ -348,19 +356,45 @@ class ItemPublisher(Publisher):
             items_with_context.extend(publishable_items)
             publishers.append(publisher)
 
-        # Phase 2: Single bulk API call (publisher context used inside for per-item transforms)
+        # Phase 2: Batched bulk API calls (publisher context used inside for per-item transforms)
         if items_with_context:
             if skipped_items:
                 logger.info(f"Skipping {len(skipped_items)} item(s) due to publish filters")
 
-            item_count = len(items_with_context)
-            if item_count > constants.BULK_ITEM_COUNT_LIMIT:
-                msg = (
-                    f"Bulk publish item count ({item_count}) exceeds the API limit "
-                    f"of {constants.BULK_ITEM_COUNT_LIMIT} items."
+            # Build a dependency graph from dynamic replacement variables when the parameter file has them.
+            # An empty graph (the common case) yields a single batch, identical to a single bulk call.
+            dependency_edges: list[tuple[str, str]] = []
+            if fabric_workspace_obj.contains_param_vars:
+                publish_item_keys = {f"{item.type}.{item_name}" for item_name, item, _publisher in items_with_context}
+                dependency_edges = build_dynamic_variable_dependency_graph(fabric_workspace_obj, publish_item_keys)
+
+            batches = compute_publish_batches(items_with_context, dependency_edges)
+
+            for batch_index, batch_items in enumerate(batches):
+                batch_count = len(batch_items)
+                if batch_count > constants.BULK_ITEM_COUNT_LIMIT:
+                    msg = (
+                        f"Bulk publish batch {batch_index} item count ({batch_count}) exceeds the API limit "
+                        f"of {constants.BULK_ITEM_COUNT_LIMIT} items."
+                    )
+                    raise InputError(msg, logger)
+
+                if len(batches) > 1:
+                    batch_names = sorted(f"{item.type}: {name}" for name, item, _ in batch_items)
+                    logger.info(f"Publishing batch {batch_index + 1}/{len(batches)}: {batch_names}")
+
+                fabric_workspace_obj._publish_items(
+                    batch_items, skipped_items=skipped_items if batch_index == 0 else None
                 )
-                raise InputError(msg, logger)
-            fabric_workspace_obj._publish_items(items_with_context, skipped_items=skipped_items)
+
+                # Between batches: refresh deployed items so the next batch can resolve $items.* variables
+                # to real GUIDs. Drop resolved $items.* cache entries (deployed state changed) while keeping
+                # $workspace.* entries, which reference other workspaces that do not change here.
+                if batch_index < len(batches) - 1:
+                    fabric_workspace_obj._dynamic_var_cache = {
+                        k: v for k, v in fabric_workspace_obj._dynamic_var_cache.items() if k.startswith("$workspace.")
+                    }
+                    fabric_workspace_obj._refresh_deployed_items()
 
         # Phase 3: Post-hooks per type
         for publisher in publishers:

--- a/src/fabric_cicd/_items/_base_publisher.py
+++ b/src/fabric_cicd/_items/_base_publisher.py
@@ -372,6 +372,8 @@ class ItemPublisher(Publisher):
 
             batches = compute_publish_batches(items_with_context, dependency_edges)
 
+            # Validate every batch against the API item-count limit before publishing any of them,
+            # so an oversized batch fails fast instead of leaving a partial (batch-by-batch) deployment.
             for batch_index, batch_items in enumerate(batches):
                 batch_count = len(batch_items)
                 if batch_count > constants.BULK_ITEM_COUNT_LIMIT:
@@ -381,6 +383,7 @@ class ItemPublisher(Publisher):
                     )
                     raise InputError(msg, logger)
 
+            for batch_index, batch_items in enumerate(batches):
                 if len(batches) > 1:
                     logger.info(f"Publishing batch {batch_index + 1}/{len(batches)}")
                     logger.debug(
@@ -396,14 +399,15 @@ class ItemPublisher(Publisher):
                 # Refresh deployed items and invalidate cached $items.* values between batches
                 if batch_index < len(batches) - 1:
                     # Wait for async attributes needed by later batches before refreshing
-                    for b_item_name, b_item, _b_publisher in batch_items:
-                        referenced_attrs = async_source_map.get(f"{b_item.type}.{b_item_name}")
-                        if not referenced_attrs:
-                            continue
-                        for attribute_name in sorted(referenced_attrs):
-                            fabric_workspace_obj._wait_for_item_attribute_provisioning(
-                                b_item.type, b_item.guid, b_item_name, attribute_name
-                            )
+                    provisioning_tasks = (
+                        (item, item_name, attribute_name)
+                        for item_name, item, _publisher in batch_items
+                        for attribute_name in sorted(async_source_map.get(f"{item.type}.{item_name}", ()))
+                    )
+                    for item, item_name, attribute_name in provisioning_tasks:
+                        fabric_workspace_obj._wait_for_item_attribute_provisioning(
+                            item.type, item.guid, item_name, attribute_name
+                        )
 
                     fabric_workspace_obj._dynamic_var_cache = {
                         k: v for k, v in fabric_workspace_obj._dynamic_var_cache.items() if k.startswith("$workspace.")

--- a/src/fabric_cicd/_items/_base_publisher.py
+++ b/src/fabric_cicd/_items/_base_publisher.py
@@ -372,13 +372,12 @@ class ItemPublisher(Publisher):
 
             batches = compute_publish_batches(items_with_context, dependency_edges)
 
-            # Validate every batch against the API item-count limit before publishing any of them,
-            # so an oversized batch fails fast instead of leaving a partial (batch-by-batch) deployment.
+            # Validate all batch sizes before publishing to prevent partial deployment
             for batch_index, batch_items in enumerate(batches):
                 batch_count = len(batch_items)
                 if batch_count > constants.BULK_ITEM_COUNT_LIMIT:
                     msg = (
-                        f"Bulk publish batch {batch_index} item count ({batch_count}) exceeds the API limit "
+                        f"Bulk publish batch {batch_index + 1} item count ({batch_count}) exceeds the API limit "
                         f"of {constants.BULK_ITEM_COUNT_LIMIT} items."
                     )
                     raise InputError(msg, logger)

--- a/src/fabric_cicd/_items/_base_publisher.py
+++ b/src/fabric_cicd/_items/_base_publisher.py
@@ -323,6 +323,7 @@ class ItemPublisher(Publisher):
         from fabric_cicd._items._bulk_publish_dependencies import (
             build_dynamic_variable_dependency_graph,
             compute_publish_batches,
+            get_async_provisioned_dependencies,
         )
 
         publishers: list[ItemPublisher] = []
@@ -364,9 +365,11 @@ class ItemPublisher(Publisher):
             # Build a dependency graph from dynamic replacement variables when the parameter file has them.
             # An empty graph (the common case) yields a single batch, identical to a single bulk call.
             dependency_edges: list[tuple[str, str]] = []
+            async_source_map: dict[str, set[str]] = {}
             if fabric_workspace_obj.contains_param_vars:
                 publish_item_keys = {f"{item.type}.{item_name}" for item_name, item, _publisher in items_with_context}
                 dependency_edges = build_dynamic_variable_dependency_graph(fabric_workspace_obj, publish_item_keys)
+                async_source_map = get_async_provisioned_dependencies(fabric_workspace_obj, publish_item_keys)
 
             batches = compute_publish_batches(items_with_context, dependency_edges)
 
@@ -391,6 +394,18 @@ class ItemPublisher(Publisher):
                 # to real GUIDs. Drop resolved $items.* cache entries (deployed state changed) while keeping
                 # $workspace.* entries, which reference other workspaces that do not change here.
                 if batch_index < len(batches) - 1:
+                    # Wait for asynchronously provisioned attributes (SQL endpoint / Eventhouse query URI)
+                    # of just-deployed source items referenced by a later tier, so the refresh below captures
+                    # real values instead of empty strings.
+                    for b_item_name, b_item, _b_publisher in batch_items:
+                        referenced_attrs = async_source_map.get(f"{b_item.type}.{b_item_name}")
+                        if not referenced_attrs:
+                            continue
+                        for attribute_name in sorted(referenced_attrs):
+                            fabric_workspace_obj._wait_for_item_attribute_provisioning(
+                                b_item.type, b_item.guid, b_item_name, attribute_name
+                            )
+
                     fabric_workspace_obj._dynamic_var_cache = {
                         k: v for k, v in fabric_workspace_obj._dynamic_var_cache.items() if k.startswith("$workspace.")
                     }

--- a/src/fabric_cicd/_items/_base_publisher.py
+++ b/src/fabric_cicd/_items/_base_publisher.py
@@ -362,8 +362,7 @@ class ItemPublisher(Publisher):
             if skipped_items:
                 logger.info(f"Skipping {len(skipped_items)} item(s) due to publish filters")
 
-            # Build a dependency graph from dynamic replacement variables when the parameter file has them.
-            # An empty graph (the common case) yields a single batch, identical to a single bulk call.
+            # Build dynamic variable dependencies; none yields a single batch
             dependency_edges: list[tuple[str, str]] = []
             async_source_map: dict[str, set[str]] = {}
             if fabric_workspace_obj.contains_param_vars:
@@ -383,20 +382,20 @@ class ItemPublisher(Publisher):
                     raise InputError(msg, logger)
 
                 if len(batches) > 1:
-                    batch_names = sorted(f"{item.type}: {name}" for name, item, _ in batch_items)
-                    logger.info(f"Publishing batch {batch_index + 1}/{len(batches)}: {batch_names}")
+                    logger.info(f"Publishing batch {batch_index + 1}/{len(batches)}")
+                    logger.debug(
+                        "Publishing batch %s items: %s",
+                        batch_index + 1,
+                        sorted(f"{item.type}: {name}" for name, item, _ in batch_items),
+                    )
 
                 fabric_workspace_obj._publish_items(
                     batch_items, skipped_items=skipped_items if batch_index == 0 else None
                 )
 
-                # Between batches: refresh deployed items so the next batch can resolve $items.* variables
-                # to real GUIDs. Drop resolved $items.* cache entries (deployed state changed) while keeping
-                # $workspace.* entries, which reference other workspaces that do not change here.
+                # Refresh deployed items and invalidate cached $items.* values between batches
                 if batch_index < len(batches) - 1:
-                    # Wait for asynchronously provisioned attributes (SQL endpoint / Eventhouse query URI)
-                    # of just-deployed source items referenced by a later tier, so the refresh below captures
-                    # real values instead of empty strings.
+                    # Wait for async attributes needed by later batches before refreshing
                     for b_item_name, b_item, _b_publisher in batch_items:
                         referenced_attrs = async_source_map.get(f"{b_item.type}.{b_item_name}")
                         if not referenced_attrs:

--- a/src/fabric_cicd/_items/_bulk_publish_dependencies.py
+++ b/src/fabric_cicd/_items/_bulk_publish_dependencies.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Optional
 
 from fabric_cicd._common._exceptions import InputError, ParsingError
 from fabric_cicd._parameter._utils import (
+    ParsedDynamicVariable,
     parse_dynamic_variable,
     process_environment_key,
     process_input_path,
@@ -27,6 +28,34 @@ if TYPE_CHECKING:
     from fabric_cicd.fabric_workspace import FabricWorkspace
 
 logger = logging.getLogger(__name__)
+
+# Item attributes that are provisioned asynchronously after item creation and therefore
+# require a provisioning wait between bulk-publish tiers before a downstream item can resolve
+# them (mirrors constants.PROPERTY_PATH_ATTR_MAPPING; everything except the immediately
+# available "id").
+ASYNC_PROVISIONED_ATTRIBUTES = frozenset({"sqlendpoint", "sqlendpointid", "queryserviceuri"})
+
+
+def _parse_current_workspace_item(env_value: str) -> Optional["ParsedDynamicVariable"]:
+    """
+    Returns the parsed variable when env_value is a *current-workspace* $items.* variable.
+
+    Returns None for non-variable strings, $workspace.* variables, and cross-workspace item
+    variables ($workspace.<name>.$items.*), whose targets live in another workspace and never
+    create an in-batch dependency here.
+    """
+    if not isinstance(env_value, str) or not env_value.startswith("$"):
+        return None
+
+    try:
+        parsed = parse_dynamic_variable(env_value)
+    except ParsingError:
+        return None
+
+    if parsed.kind == "item" and parsed.workspace_name is None:
+        return parsed
+
+    return None
 
 
 def _resolve_current_workspace_item_ref(env_value: str) -> Optional[tuple[str, str]]:
@@ -43,20 +72,10 @@ def _resolve_current_workspace_item_ref(env_value: str) -> Optional[tuple[str, s
     runs, `_validate_dynamic_replacement_variables` has already validated every variable,
     so `parse_dynamic_variable` is not expected to raise here; the guard is purely defensive.
     """
-    if not isinstance(env_value, str) or not env_value.startswith("$"):
+    parsed = _parse_current_workspace_item(env_value)
+    if parsed is None:
         return None
-
-    try:
-        parsed = parse_dynamic_variable(env_value)
-    except ParsingError:
-        return None
-
-    # Only same-workspace item references (kind == "item", no workspace_name) create
-    # an intra-batch dependency that tiered publishing must order.
-    if parsed.kind == "item" and parsed.workspace_name is None:
-        return parsed.item_type, parsed.item_name
-
-    return None
+    return parsed.item_type, parsed.item_name
 
 
 def _iter_dynamic_replace_values(workspace_obj: "FabricWorkspace") -> Iterator[tuple[dict, str]]:
@@ -91,6 +110,35 @@ def has_unfiltered_items_variable(workspace_obj: "FabricWorkspace") -> bool:
             return True
 
     return False
+
+
+def get_async_provisioned_dependencies(
+    workspace_obj: "FabricWorkspace", publish_item_keys: set[str]
+) -> dict[str, set[str]]:
+    """
+    Maps each to-be-published source item to the asynchronously provisioned attributes referenced on it.
+
+    Scans find_replace / key_value_replace entries for current-workspace $items.* variables whose
+    attribute is asynchronously provisioned (SQL endpoint / Eventhouse query URI). Only source items
+    that are part of the current publish set are included, since already-deployed items are already
+    provisioned and impose no tiering.
+
+    Returns:
+        A dict of "ItemType.ItemName" -> set of async attribute names (e.g. {"sqlendpoint"}). Empty
+        when no such references exist, in which case no between-tier provisioning wait is needed.
+    """
+    result: dict[str, set[str]] = {}
+
+    for _param_dict, env_value in _iter_dynamic_replace_values(workspace_obj):
+        parsed = _parse_current_workspace_item(env_value)
+        if parsed is None or parsed.attribute not in ASYNC_PROVISIONED_ATTRIBUTES:
+            continue
+
+        key = f"{parsed.item_type}.{parsed.item_name}"
+        if key in publish_item_keys:
+            result.setdefault(key, set()).add(parsed.attribute)
+
+    return result
 
 
 def build_dynamic_variable_dependency_graph(

--- a/src/fabric_cicd/_items/_bulk_publish_dependencies.py
+++ b/src/fabric_cicd/_items/_bulk_publish_dependencies.py
@@ -15,29 +15,20 @@ from fabric_cicd._parameter._utils import (
     process_environment_key,
     process_input_path,
 )
+from fabric_cicd.constants import ASYNC_PROVISIONED_ATTRIBUTES
 
 if TYPE_CHECKING:
     from fabric_cicd.fabric_workspace import FabricWorkspace
 
 logger = logging.getLogger(__name__)
 
-# Asynchronously provisioned attributes that require waits between dependent publish tiers
-# (mirrors constants.PROPERTY_PATH_ATTR_MAPPING, excluding the immediately available "id").
-ASYNC_PROVISIONED_ATTRIBUTES = frozenset({"sqlendpoint", "sqlendpointid", "queryserviceuri"})
 
-
-def _parse_current_workspace_item(env_value: str) -> Optional["ParsedDynamicVariable"]:
-    """
-    Returns the parsed variable when env_value is a *current-workspace* $items.* variable.
-
-    Returns None for non-variable strings, $workspace.* variables, and cross-workspace item
-    variables ($workspace.<name>.$items.*), whose targets live in another workspace and never
-    create an in-batch dependency here.
-    """
-    if not isinstance(env_value, str) or not env_value.startswith("$"):
+def _parse_current_workspace_item(dyn_var: str) -> Optional["ParsedDynamicVariable"]:
+    """Parse a current-workspace $items.* variable, or return None."""
+    if not dyn_var.startswith("$"):
         return None
 
-    parsed = parse_dynamic_variable(env_value)
+    parsed = parse_dynamic_variable(dyn_var)
 
     if parsed.kind == "item" and parsed.workspace_name is None:
         return parsed
@@ -45,37 +36,10 @@ def _parse_current_workspace_item(env_value: str) -> Optional["ParsedDynamicVari
     return None
 
 
-def _resolve_current_workspace_item_ref(env_value: str) -> Optional[tuple[str, str]]:
-    """
-    Returns (item_type, item_name) when env_value is a *current-workspace* $items.* variable.
-
-    Returns None for:
-      - non-variable strings (no leading '$')
-      - $workspace.* variables (workspace id/name/name_encoded)
-      - cross-workspace item variables ($workspace.<name>.$items.*), whose target lives
-        in another workspace and therefore never creates an in-batch dependency here.
-
-    Parsing is delegated to the canonical dynamic-variable parser. Every variable is
-    validated when the parameter file is loaded (at workspace initialization), so by the
-    time bulk publish runs `parse_dynamic_variable` resolves without raising here.
-    """
-    parsed = _parse_current_workspace_item(env_value)
-    if parsed is None:
-        return None
-    return parsed.item_type, parsed.item_name
-
-
 def _iter_dynamic_replace_values(
     workspace_obj: "FabricWorkspace",
 ) -> Iterator[tuple[dict, str, Optional["ParsedDynamicVariable"]]]:
-    """
-    Yields (param_dict, env_value, parsed) for every find_replace / key_value_replace entry
-    whose replace_value resolves to a string for the active environment.
-
-    Each value is parsed exactly once here (single pass), so consumers can reuse `parsed`
-    instead of re-parsing. `parsed` is the current-workspace item variable, or None when the
-    value is not a current-workspace $items.* reference (plain string or $workspace.* variable).
-    """
+    """Yield each active string replacement and its current-workspace item variable, if any."""
     for param_name in ("find_replace", "key_value_replace"):
         for param_dict in workspace_obj.environment_parameter.get(param_name, []):
             replace_value = param_dict.get("replace_value")
@@ -88,14 +52,7 @@ def _iter_dynamic_replace_values(
 
 
 def has_unfiltered_items_variable(workspace_obj: "FabricWorkspace") -> bool:
-    """
-    Returns True if any find_replace or key_value_replace entry uses a current-workspace
-    $items.* variable in replace_value without any item_type, item_name, or file_path filter.
-
-    When this is the case, dependency scope cannot be narrowed and bulk publish would treat
-    all items as dependents of the referenced item, so callers should fall back to standard
-    (serial) deployment instead.
-    """
+    """Return whether an $items.* variable is unfiltered and requires serial deployment."""
     for param_dict, _env_value, parsed in _iter_dynamic_replace_values(workspace_obj):
         if parsed is None:
             continue
@@ -109,16 +66,9 @@ def get_async_provisioned_dependencies(
     workspace_obj: "FabricWorkspace", publish_item_keys: set[str]
 ) -> dict[str, set[str]]:
     """
-    Maps each to-be-published source item to the asynchronously provisioned attributes referenced on it.
+    Map published source items to referenced, asynchronously provisioned attributes.
 
-    Scans find_replace / key_value_replace entries for current-workspace $items.* variables whose
-    attribute is asynchronously provisioned (SQL endpoint / Eventhouse query URI). Only source items
-    that are part of the current publish set are included, since already-deployed items are already
-    provisioned and impose no tiering.
-
-    Returns:
-        A dict of "ItemType.ItemName" -> set of async attribute names (e.g. {"sqlendpoint"}). Empty
-        when no such references exist, in which case no between-tier provisioning wait is needed.
+    Already-deployed items need no tiering and are excluded.
     """
     result: dict[str, set[str]] = {}
 
@@ -139,7 +89,7 @@ def build_dynamic_variable_dependency_graph(
     workspace_obj: "FabricWorkspace", publish_item_keys: set[str]
 ) -> list[tuple[str, str]]:
     """
-    Builds a dependency graph from current-workspace $items.* variables in the parameter file.
+    Build dependency edges from current-workspace $items.* variables.
 
     For each replace_value that references an item which is NOT already deployed but IS in the
     current publish set, an edge (referencing_item_key -> referenced_item_key) is added, where
@@ -153,11 +103,9 @@ def build_dynamic_variable_dependency_graph(
     seen_edges: set[tuple[str, str]] = set()
 
     repository_items = workspace_obj.repository_items
-    # Resolve the repository root once; reused for every file_path filter below.
+    # Reuse resolved paths and filter matches across parameter entries
     resolved_repo_dir = workspace_obj.repository_directory.resolve() if workspace_obj.repository_directory else None
-    # Lazily memoize each item's resolved path (only touched when a file_path filter is present).
     path_cache: dict[str, Path] = {}
-    # Cache referencing-item lookups by their filter signature; identical filters reuse the result.
     referencing_cache: dict[tuple, list[str]] = {}
 
     for param_dict, _env_value, parsed in _iter_dynamic_replace_values(workspace_obj):
@@ -167,14 +115,15 @@ def build_dynamic_variable_dependency_graph(
         ref_type, ref_name = parsed.item_type, parsed.item_name
         ref_key = f"{ref_type}.{ref_name}"
 
-        # Already deployed -> resolvable immediately, no ordering constraint
+        # Deployed references impose no ordering constraint
         if ref_type in workspace_obj.deployed_items and ref_name in workspace_obj.deployed_items[ref_type]:
             continue
 
-        # Only items new in this batch impose ordering
+        # Only references created in this batch impose ordering
         if ref_key not in publish_item_keys:
             continue
 
+        # Match parameter filters to referencing items once per filter set
         cache_key = (
             _hashable_filter(param_dict.get("item_type")),
             _hashable_filter(param_dict.get("item_name")),
@@ -185,6 +134,7 @@ def build_dynamic_variable_dependency_graph(
             referencing_keys = _get_referencing_item_keys(param_dict, repository_items, resolved_repo_dir, path_cache)
             referencing_cache[cache_key] = referencing_keys
 
+        # Add unique in-batch edges, excluding self-references
         for referencing_key in referencing_keys:
             if referencing_key != ref_key and referencing_key in publish_item_keys:
                 edge = (referencing_key, ref_key)
@@ -209,24 +159,17 @@ def _get_referencing_item_keys(
     path_cache: Optional[dict[str, Path]] = None,
 ) -> list[str]:
     """
-    Determines which items a parameter entry applies to based on item_type/item_name/file_path filters.
+    Return item keys matching a parameter entry's type, name, and path filters.
 
-    `resolved_repo_dir` must already be resolved by the caller. Item paths are resolved lazily and only
-    when a file_path filter is present, memoized in `path_cache` to avoid repeated filesystem syscalls.
-
-    Returns:
-        A list of item keys ("ItemType.ItemName") that this parameter applies to.
+    `resolved_repo_dir` must be resolved. Item paths are resolved lazily and cached.
     """
-    # Normalize the parameter entry's optional filters
     filter_type = param_dict.get("item_type")
     filter_name = param_dict.get("item_name")
     filter_paths = process_input_path(resolved_repo_dir, param_dict.get("file_path")) if resolved_repo_dir else None
-    # process_input_path resolves relative/absolute paths but returns wildcard matches unresolved;
-    # resolve once here so comparisons against resolved item paths are consistent (matches legacy behavior).
+    # Wildcard matches may be unresolved, unlike explicit paths
     if filter_paths is not None:
         filter_paths = [p.resolve() for p in filter_paths]
 
-    # Collect repository items that satisfy every specified filter
     keys = []
     for item_type, items in repository_items.items():
         if filter_type is not None and item_type != filter_type:
@@ -249,12 +192,7 @@ def _get_referencing_item_keys(
 
 
 def _is_path_in_item(file_path: Path, item_path: Path) -> bool:
-    """
-    Returns True when file_path is contained by the repository item's directory.
-
-    Both arguments are expected to be already-resolved absolute paths (filter paths come pre-resolved
-    from process_input_path; item paths are resolved by the caller), so no resolve() is done here.
-    """
+    """Return whether a resolved file path is within a resolved item directory."""
     try:
         file_path.relative_to(item_path)
         return True
@@ -267,31 +205,30 @@ def compute_publish_batches(
     dependency_edges: list[tuple[str, str]],
 ) -> list[list[tuple[str, object, object]]]:
     """
-    Computes publish batches from a dependency graph using topological sort (Kahn's algorithm).
+    Compute dependency tiers with Kahn's topological-sort algorithm.
 
-    Items with no dependencies (or whose dependencies are already deployed) go into Batch 0;
-    items depending on Batch 0 go into Batch 1, and so on. No edges -> a single batch.
+    Dependency-free items enter the first batch. No edges produce one batch.
 
     Raises:
-        InputError: If a circular dependency is detected.
+        InputError: If dependencies contain a cycle.
     """
     if not dependency_edges:
         return [items_with_context]
 
-    # Defensively dedupe edges (order-preserving) so in-degree counts are not inflated by duplicates.
+    # Preserve edge order while deduplicating
     dependency_edges = list(dict.fromkeys(dependency_edges))
 
-    # Index publish contexts by their dependency-graph keys
+    # Index publish contexts by graph key
     item_key_to_context: dict[str, tuple[str, object, object]] = {}
     for item_name, item, publisher in items_with_context:
         key = f"{item.type}.{item_name}"
         item_key_to_context[key] = (item_name, item, publisher)
 
-    # Build in-degrees and reverse edges for Kahn's algorithm
     publish_item_keys = set(item_key_to_context.keys())
     in_degree: dict[str, int] = {k: 0 for k in publish_item_keys}
     dependents: dict[str, list[str]] = {k: [] for k in publish_item_keys}
 
+    # Build in-degrees and reverse edges for Kahn's algorithm
     for referencing, referenced in dependency_edges:
         if referencing in publish_item_keys and referenced in publish_item_keys:
             in_degree[referencing] = in_degree.get(referencing, 0) + 1
@@ -300,7 +237,7 @@ def compute_publish_batches(
     batches: list[list[tuple[str, object, object]]] = []
     current_batch_keys = [k for k, deg in in_degree.items() if deg == 0]
 
-    # Process each dependency-free tier as one publish batch
+    # Publish each dependency-free tier as one batch
     processed = set()
     while current_batch_keys:
         batch = []
@@ -318,7 +255,7 @@ def compute_publish_batches(
             batches.append(batch)
         current_batch_keys = next_batch_keys
 
-    # Unprocessed items belong to at least one dependency cycle
+    # Unprocessed items belong to a dependency cycle
     if len(processed) < len(publish_item_keys):
         cycle_keys = sorted(publish_item_keys - processed)
         msg = f"Circular dynamic variable dependency detected among: {', '.join(cycle_keys)}"

--- a/src/fabric_cicd/_items/_bulk_publish_dependencies.py
+++ b/src/fabric_cicd/_items/_bulk_publish_dependencies.py
@@ -8,7 +8,7 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
-from fabric_cicd._common._exceptions import InputError, ParsingError
+from fabric_cicd._common._exceptions import InputError
 from fabric_cicd._parameter._utils import (
     ParsedDynamicVariable,
     parse_dynamic_variable,
@@ -39,10 +39,7 @@ def _parse_current_workspace_item(env_value: str) -> Optional["ParsedDynamicVari
     if not isinstance(env_value, str) or not env_value.startswith("$"):
         return None
 
-    try:
-        parsed = parse_dynamic_variable(env_value)
-    except ParsingError:
-        return None
+    parsed = parse_dynamic_variable(env_value)
 
     if parsed.kind == "item" and parsed.workspace_name is None:
         return parsed
@@ -60,9 +57,9 @@ def _resolve_current_workspace_item_ref(env_value: str) -> Optional[tuple[str, s
       - cross-workspace item variables ($workspace.<name>.$items.*), whose target lives
         in another workspace and therefore never creates an in-batch dependency here.
 
-    Parsing is delegated to the canonical parser from #1102. By the time bulk publish
-    runs, `_validate_dynamic_replacement_variables` has already validated every variable,
-    so `parse_dynamic_variable` is not expected to raise here; the guard is purely defensive.
+    Parsing is delegated to the canonical dynamic-variable parser. Every variable is
+    validated when the parameter file is loaded (at workspace initialization), so by the
+    time bulk publish runs `parse_dynamic_variable` resolves without raising here.
     """
     parsed = _parse_current_workspace_item(env_value)
     if parsed is None:

--- a/src/fabric_cicd/_items/_bulk_publish_dependencies.py
+++ b/src/fabric_cicd/_items/_bulk_publish_dependencies.py
@@ -65,10 +65,16 @@ def _resolve_current_workspace_item_ref(env_value: str) -> Optional[tuple[str, s
     return parsed.item_type, parsed.item_name
 
 
-def _iter_dynamic_replace_values(workspace_obj: "FabricWorkspace") -> Iterator[tuple[dict, str]]:
+def _iter_dynamic_replace_values(
+    workspace_obj: "FabricWorkspace",
+) -> Iterator[tuple[dict, str, Optional["ParsedDynamicVariable"]]]:
     """
-    Yields (param_dict, env_value) for every find_replace / key_value_replace entry whose
-    replace_value resolves to a string for the active environment.
+    Yields (param_dict, env_value, parsed) for every find_replace / key_value_replace entry
+    whose replace_value resolves to a string for the active environment.
+
+    Each value is parsed exactly once here (single pass), so consumers can reuse `parsed`
+    instead of re-parsing. `parsed` is the current-workspace item variable, or None when the
+    value is not a current-workspace $items.* reference (plain string or $workspace.* variable).
     """
     for param_name in ("find_replace", "key_value_replace"):
         for param_dict in workspace_obj.environment_parameter.get(param_name, []):
@@ -78,7 +84,7 @@ def _iter_dynamic_replace_values(workspace_obj: "FabricWorkspace") -> Iterator[t
             processed = process_environment_key(workspace_obj.environment, dict(replace_value))
             env_value = processed.get(workspace_obj.environment)
             if isinstance(env_value, str):
-                yield param_dict, env_value
+                yield param_dict, env_value, _parse_current_workspace_item(env_value)
 
 
 def has_unfiltered_items_variable(workspace_obj: "FabricWorkspace") -> bool:
@@ -90,8 +96,8 @@ def has_unfiltered_items_variable(workspace_obj: "FabricWorkspace") -> bool:
     all items as dependents of the referenced item, so callers should fall back to standard
     (serial) deployment instead.
     """
-    for param_dict, env_value in _iter_dynamic_replace_values(workspace_obj):
-        if _resolve_current_workspace_item_ref(env_value) is None:
+    for param_dict, _env_value, parsed in _iter_dynamic_replace_values(workspace_obj):
+        if parsed is None:
             continue
         if not any(param_dict.get(f) for f in ("item_type", "item_name", "file_path")):
             return True
@@ -117,8 +123,7 @@ def get_async_provisioned_dependencies(
     result: dict[str, set[str]] = {}
 
     # Find current-workspace references to asynchronously provisioned attributes
-    for _param_dict, env_value in _iter_dynamic_replace_values(workspace_obj):
-        parsed = _parse_current_workspace_item(env_value)
+    for _param_dict, _env_value, parsed in _iter_dynamic_replace_values(workspace_obj):
         if parsed is None or parsed.attribute not in ASYNC_PROVISIONED_ATTRIBUTES:
             continue
 
@@ -145,13 +150,21 @@ def build_dynamic_variable_dependency_graph(
         upfront and a single bulk call is sufficient.
     """
     edges: list[tuple[str, str]] = []
+    seen_edges: set[tuple[str, str]] = set()
 
-    for param_dict, env_value in _iter_dynamic_replace_values(workspace_obj):
-        referenced = _resolve_current_workspace_item_ref(env_value)
-        if referenced is None:
+    repository_items = workspace_obj.repository_items
+    # Resolve the repository root once; reused for every file_path filter below.
+    resolved_repo_dir = workspace_obj.repository_directory.resolve() if workspace_obj.repository_directory else None
+    # Lazily memoize each item's resolved path (only touched when a file_path filter is present).
+    path_cache: dict[str, Path] = {}
+    # Cache referencing-item lookups by their filter signature; identical filters reuse the result.
+    referencing_cache: dict[tuple, list[str]] = {}
+
+    for param_dict, _env_value, parsed in _iter_dynamic_replace_values(workspace_obj):
+        if parsed is None:
             continue
 
-        ref_type, ref_name = referenced
+        ref_type, ref_name = parsed.item_type, parsed.item_name
         ref_key = f"{ref_type}.{ref_name}"
 
         # Already deployed -> resolvable immediately, no ordering constraint
@@ -162,21 +175,44 @@ def build_dynamic_variable_dependency_graph(
         if ref_key not in publish_item_keys:
             continue
 
-        referencing_keys = _get_referencing_item_keys(
-            param_dict, workspace_obj.repository_items, workspace_obj.repository_directory
+        cache_key = (
+            param_dict.get("item_type"),
+            _hashable_filter(param_dict.get("item_name")),
+            _hashable_filter(param_dict.get("file_path")),
         )
+        referencing_keys = referencing_cache.get(cache_key)
+        if referencing_keys is None:
+            referencing_keys = _get_referencing_item_keys(param_dict, repository_items, resolved_repo_dir, path_cache)
+            referencing_cache[cache_key] = referencing_keys
+
         for referencing_key in referencing_keys:
             if referencing_key != ref_key and referencing_key in publish_item_keys:
-                edges.append((referencing_key, ref_key))
+                edge = (referencing_key, ref_key)
+                if edge not in seen_edges:
+                    seen_edges.add(edge)
+                    edges.append(edge)
 
     return edges
 
 
+def _hashable_filter(value: object) -> object:
+    """Normalizes an optional filter value (None, str, or list) to a hashable cache-key component."""
+    if isinstance(value, list):
+        return tuple(value)
+    return value
+
+
 def _get_referencing_item_keys(
-    param_dict: dict, repository_items: dict, repository_directory: Optional[Path] = None
+    param_dict: dict,
+    repository_items: dict,
+    resolved_repo_dir: Optional[Path] = None,
+    path_cache: Optional[dict[str, Path]] = None,
 ) -> list[str]:
     """
     Determines which items a parameter entry applies to based on item_type/item_name/file_path filters.
+
+    `resolved_repo_dir` must already be resolved by the caller. Item paths are resolved lazily and only
+    when a file_path filter is present, memoized in `path_cache` to avoid repeated filesystem syscalls.
 
     Returns:
         A list of item keys ("ItemType.ItemName") that this parameter applies to.
@@ -184,11 +220,7 @@ def _get_referencing_item_keys(
     # Normalize the parameter entry's optional filters
     filter_type = param_dict.get("item_type")
     filter_name = param_dict.get("item_name")
-    if repository_directory is not None:
-        repository_directory = repository_directory.resolve()
-    filter_paths = (
-        process_input_path(repository_directory, param_dict.get("file_path")) if repository_directory else None
-    )
+    filter_paths = process_input_path(resolved_repo_dir, param_dict.get("file_path")) if resolved_repo_dir else None
 
     # Collect repository items that satisfy every specified filter
     keys = []
@@ -198,19 +230,29 @@ def _get_referencing_item_keys(
         for item_name, item in items.items():
             if filter_name is not None and item_name != filter_name:
                 continue
-            if filter_paths is not None and not any(
-                _is_path_in_item(file_path, item.path) for file_path in filter_paths
-            ):
-                continue
+            if filter_paths is not None:
+                item_key = f"{item_type}.{item_name}"
+                item_path = path_cache.get(item_key) if path_cache is not None else None
+                if item_path is None:
+                    item_path = item.path.resolve()
+                    if path_cache is not None:
+                        path_cache[item_key] = item_path
+                if not any(_is_path_in_item(file_path, item_path) for file_path in filter_paths):
+                    continue
             keys.append(f"{item_type}.{item_name}")
 
     return keys
 
 
 def _is_path_in_item(file_path: Path, item_path: Path) -> bool:
-    """Returns True when file_path is contained by the repository item's directory."""
+    """
+    Returns True when file_path is contained by the repository item's directory.
+
+    Both arguments are expected to be already-resolved absolute paths (filter paths come pre-resolved
+    from process_input_path; item paths are resolved by the caller), so no resolve() is done here.
+    """
     try:
-        file_path.resolve().relative_to(item_path.resolve())
+        file_path.relative_to(item_path)
         return True
     except ValueError:
         return False
@@ -231,6 +273,9 @@ def compute_publish_batches(
     """
     if not dependency_edges:
         return [items_with_context]
+
+    # Defensively dedupe edges (order-preserving) so in-degree counts are not inflated by duplicates.
+    dependency_edges = list(dict.fromkeys(dependency_edges))
 
     # Index publish contexts by their dependency-graph keys
     item_key_to_context: dict[str, tuple[str, object, object]] = {}

--- a/src/fabric_cicd/_items/_bulk_publish_dependencies.py
+++ b/src/fabric_cicd/_items/_bulk_publish_dependencies.py
@@ -1,0 +1,235 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Dependency graph helpers for batched bulk item publishing.
+
+Refactored to build on microsoft/fabric-cicd#1102: instead of a private, ad-hoc
+`$items.*` string parser, this module reuses the single canonical parser
+(`parse_dynamic_variable` -> `ParsedDynamicVariable`) introduced by #1102. That
+gives one source of truth for variable parsing, correct handling of dotted item
+names, the legacy `$items.type.name.attribute` form, and cross-workspace forms,
+plus item-type/attribute validation.
+"""
+
+import logging
+from collections.abc import Iterator
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional
+
+from fabric_cicd._common._exceptions import InputError, ParsingError
+from fabric_cicd._parameter._utils import (
+    parse_dynamic_variable,
+    process_environment_key,
+    process_input_path,
+)
+
+if TYPE_CHECKING:
+    from fabric_cicd.fabric_workspace import FabricWorkspace
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_current_workspace_item_ref(env_value: str) -> Optional[tuple[str, str]]:
+    """
+    Returns (item_type, item_name) when env_value is a *current-workspace* $items.* variable.
+
+    Returns None for:
+      - non-variable strings (no leading '$')
+      - $workspace.* variables (workspace id/name/name_encoded)
+      - cross-workspace item variables ($workspace.<name>.$items.*), whose target lives
+        in another workspace and therefore never creates an in-batch dependency here.
+
+    Parsing is delegated to the canonical parser from #1102. By the time bulk publish
+    runs, `_validate_dynamic_replacement_variables` has already validated every variable,
+    so `parse_dynamic_variable` is not expected to raise here; the guard is purely defensive.
+    """
+    if not isinstance(env_value, str) or not env_value.startswith("$"):
+        return None
+
+    try:
+        parsed = parse_dynamic_variable(env_value)
+    except ParsingError:
+        return None
+
+    # Only same-workspace item references (kind == "item", no workspace_name) create
+    # an intra-batch dependency that tiered publishing must order.
+    if parsed.kind == "item" and parsed.workspace_name is None:
+        return parsed.item_type, parsed.item_name
+
+    return None
+
+
+def _iter_dynamic_replace_values(workspace_obj: "FabricWorkspace") -> Iterator[tuple[dict, str]]:
+    """
+    Yields (param_dict, env_value) for every find_replace / key_value_replace entry whose
+    replace_value resolves to a string for the active environment.
+    """
+    for param_name in ("find_replace", "key_value_replace"):
+        for param_dict in workspace_obj.environment_parameter.get(param_name, []):
+            replace_value = param_dict.get("replace_value")
+            if not isinstance(replace_value, dict):
+                continue
+            processed = process_environment_key(workspace_obj.environment, dict(replace_value))
+            env_value = processed.get(workspace_obj.environment)
+            if isinstance(env_value, str):
+                yield param_dict, env_value
+
+
+def has_unfiltered_items_variable(workspace_obj: "FabricWorkspace") -> bool:
+    """
+    Returns True if any find_replace or key_value_replace entry uses a current-workspace
+    $items.* variable in replace_value without any item_type, item_name, or file_path filter.
+
+    When this is the case, dependency scope cannot be narrowed and bulk publish would treat
+    all items as dependents of the referenced item, so callers should fall back to standard
+    (serial) deployment instead.
+    """
+    for param_dict, env_value in _iter_dynamic_replace_values(workspace_obj):
+        if _resolve_current_workspace_item_ref(env_value) is None:
+            continue
+        if not any(param_dict.get(f) for f in ("item_type", "item_name", "file_path")):
+            return True
+
+    return False
+
+
+def build_dynamic_variable_dependency_graph(
+    workspace_obj: "FabricWorkspace", publish_item_keys: set[str]
+) -> list[tuple[str, str]]:
+    """
+    Builds a dependency graph from current-workspace $items.* variables in the parameter file.
+
+    For each replace_value that references an item which is NOT already deployed but IS in the
+    current publish set, an edge (referencing_item_key -> referenced_item_key) is added, where
+    key format is "ItemType.ItemName".
+
+    Returns:
+        A list of dependency edges. An empty list means all dynamic variables are resolvable
+        upfront and a single bulk call is sufficient.
+    """
+    edges: list[tuple[str, str]] = []
+
+    for param_dict, env_value in _iter_dynamic_replace_values(workspace_obj):
+        referenced = _resolve_current_workspace_item_ref(env_value)
+        if referenced is None:
+            continue
+
+        ref_type, ref_name = referenced
+        ref_key = f"{ref_type}.{ref_name}"
+
+        # Already deployed -> resolvable immediately, no ordering constraint.
+        if ref_type in workspace_obj.deployed_items and ref_name in workspace_obj.deployed_items[ref_type]:
+            continue
+
+        # Only items new in this batch impose ordering.
+        if ref_key not in publish_item_keys:
+            continue
+
+        referencing_keys = _get_referencing_item_keys(
+            param_dict, workspace_obj.repository_items, workspace_obj.repository_directory
+        )
+        for referencing_key in referencing_keys:
+            if referencing_key != ref_key and referencing_key in publish_item_keys:
+                edges.append((referencing_key, ref_key))
+
+    return edges
+
+
+def _get_referencing_item_keys(
+    param_dict: dict, repository_items: dict, repository_directory: Optional[Path] = None
+) -> list[str]:
+    """
+    Determines which items a parameter entry applies to based on item_type/item_name/file_path filters.
+
+    Returns:
+        A list of item keys ("ItemType.ItemName") that this parameter applies to.
+    """
+    filter_type = param_dict.get("item_type")
+    filter_name = param_dict.get("item_name")
+    if repository_directory is not None:
+        repository_directory = repository_directory.resolve()
+    filter_paths = (
+        process_input_path(repository_directory, param_dict.get("file_path")) if repository_directory else None
+    )
+
+    keys = []
+    for item_type, items in repository_items.items():
+        if filter_type is not None and item_type != filter_type:
+            continue
+        for item_name, item in items.items():
+            if filter_name is not None and item_name != filter_name:
+                continue
+            if filter_paths is not None and not any(
+                _is_path_in_item(file_path, item.path) for file_path in filter_paths
+            ):
+                continue
+            keys.append(f"{item_type}.{item_name}")
+
+    return keys
+
+
+def _is_path_in_item(file_path: Path, item_path: Path) -> bool:
+    """Returns True when file_path is contained by the repository item's directory."""
+    try:
+        file_path.resolve().relative_to(item_path.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def compute_publish_batches(
+    items_with_context: list[tuple[str, object, object]],
+    dependency_edges: list[tuple[str, str]],
+) -> list[list[tuple[str, object, object]]]:
+    """
+    Computes publish batches from a dependency graph using topological sort (Kahn's algorithm).
+
+    Items with no dependencies (or whose dependencies are already deployed) go into Batch 0;
+    items depending on Batch 0 go into Batch 1, and so on. No edges -> a single batch.
+
+    Raises:
+        InputError: If a circular dependency is detected.
+    """
+    if not dependency_edges:
+        return [items_with_context]
+
+    item_key_to_context: dict[str, tuple[str, object, object]] = {}
+    for item_name, item, publisher in items_with_context:
+        key = f"{item.type}.{item_name}"
+        item_key_to_context[key] = (item_name, item, publisher)
+
+    publish_item_keys = set(item_key_to_context.keys())
+    in_degree: dict[str, int] = {k: 0 for k in publish_item_keys}
+    dependents: dict[str, list[str]] = {k: [] for k in publish_item_keys}
+
+    for referencing, referenced in dependency_edges:
+        if referencing in publish_item_keys and referenced in publish_item_keys:
+            in_degree[referencing] = in_degree.get(referencing, 0) + 1
+            dependents.setdefault(referenced, []).append(referencing)
+
+    batches: list[list[tuple[str, object, object]]] = []
+    current_batch_keys = [k for k, deg in in_degree.items() if deg == 0]
+
+    processed = set()
+    while current_batch_keys:
+        batch = []
+        next_batch_keys = []
+        for key in current_batch_keys:
+            if key in item_key_to_context:
+                batch.append(item_key_to_context[key])
+            processed.add(key)
+            for dependent in dependents.get(key, []):
+                in_degree[dependent] -= 1
+                if in_degree[dependent] == 0:
+                    next_batch_keys.append(dependent)
+
+        if batch:
+            batches.append(batch)
+        current_batch_keys = next_batch_keys
+
+    if len(processed) < len(publish_item_keys):
+        cycle_keys = sorted(publish_item_keys - processed)
+        msg = f"Circular dynamic variable dependency detected among: {', '.join(cycle_keys)}"
+        raise InputError(msg, logger)
+
+    return batches

--- a/src/fabric_cicd/_items/_bulk_publish_dependencies.py
+++ b/src/fabric_cicd/_items/_bulk_publish_dependencies.py
@@ -23,17 +23,15 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _parse_current_workspace_item(env_value: str) -> Optional["ParsedDynamicVariable"]:
-    """Parse a current-workspace $items.* variable, or return None."""
-    if not env_value.startswith("$"):
-        return None
+def has_unfiltered_items_variable(workspace_obj: "FabricWorkspace") -> bool:
+    """Return whether an $items.* variable is unfiltered and requires serial deployment."""
+    for param_dict, _env_value, parsed in _iter_dynamic_replace_values(workspace_obj):
+        if parsed is None:
+            continue
+        if not any(param_dict.get(f) for f in ("item_type", "item_name", "file_path")):
+            return True
 
-    parsed = parse_dynamic_variable(env_value)
-
-    if parsed.kind == "item" and parsed.workspace_name is None:
-        return parsed
-
-    return None
+    return False
 
 
 def _iter_dynamic_replace_values(
@@ -51,15 +49,17 @@ def _iter_dynamic_replace_values(
                 yield param_dict, env_value, _parse_current_workspace_item(env_value)
 
 
-def has_unfiltered_items_variable(workspace_obj: "FabricWorkspace") -> bool:
-    """Return whether an $items.* variable is unfiltered and requires serial deployment."""
-    for param_dict, _env_value, parsed in _iter_dynamic_replace_values(workspace_obj):
-        if parsed is None:
-            continue
-        if not any(param_dict.get(f) for f in ("item_type", "item_name", "file_path")):
-            return True
+def _parse_current_workspace_item(env_value: str) -> Optional["ParsedDynamicVariable"]:
+    """Parse a current-workspace $items.* variable, or return None."""
+    if not env_value.startswith("$"):
+        return None
 
-    return False
+    parsed = parse_dynamic_variable(env_value)
+
+    if parsed.kind == "item" and parsed.workspace_name is None:
+        return parsed
+
+    return None
 
 
 def get_async_provisioned_dependencies(

--- a/src/fabric_cicd/_items/_bulk_publish_dependencies.py
+++ b/src/fabric_cicd/_items/_bulk_publish_dependencies.py
@@ -21,10 +21,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Item attributes that are provisioned asynchronously after item creation and therefore
-# require a provisioning wait between bulk-publish tiers before a downstream item can resolve
-# them (mirrors constants.PROPERTY_PATH_ATTR_MAPPING; everything except the immediately
-# available "id").
+# Asynchronously provisioned attributes that require waits between dependent publish tiers
+# (mirrors constants.PROPERTY_PATH_ATTR_MAPPING, excluding the immediately available "id").
 ASYNC_PROVISIONED_ATTRIBUTES = frozenset({"sqlendpoint", "sqlendpointid", "queryserviceuri"})
 
 
@@ -118,11 +116,13 @@ def get_async_provisioned_dependencies(
     """
     result: dict[str, set[str]] = {}
 
+    # Find current-workspace references to asynchronously provisioned attributes
     for _param_dict, env_value in _iter_dynamic_replace_values(workspace_obj):
         parsed = _parse_current_workspace_item(env_value)
         if parsed is None or parsed.attribute not in ASYNC_PROVISIONED_ATTRIBUTES:
             continue
 
+        # Record only source items created in this publish operation
         key = f"{parsed.item_type}.{parsed.item_name}"
         if key in publish_item_keys:
             result.setdefault(key, set()).add(parsed.attribute)
@@ -154,11 +154,11 @@ def build_dynamic_variable_dependency_graph(
         ref_type, ref_name = referenced
         ref_key = f"{ref_type}.{ref_name}"
 
-        # Already deployed -> resolvable immediately, no ordering constraint.
+        # Already deployed -> resolvable immediately, no ordering constraint
         if ref_type in workspace_obj.deployed_items and ref_name in workspace_obj.deployed_items[ref_type]:
             continue
 
-        # Only items new in this batch impose ordering.
+        # Only items new in this batch impose ordering
         if ref_key not in publish_item_keys:
             continue
 
@@ -181,6 +181,7 @@ def _get_referencing_item_keys(
     Returns:
         A list of item keys ("ItemType.ItemName") that this parameter applies to.
     """
+    # Normalize the parameter entry's optional filters
     filter_type = param_dict.get("item_type")
     filter_name = param_dict.get("item_name")
     if repository_directory is not None:
@@ -189,6 +190,7 @@ def _get_referencing_item_keys(
         process_input_path(repository_directory, param_dict.get("file_path")) if repository_directory else None
     )
 
+    # Collect repository items that satisfy every specified filter
     keys = []
     for item_type, items in repository_items.items():
         if filter_type is not None and item_type != filter_type:
@@ -230,11 +232,13 @@ def compute_publish_batches(
     if not dependency_edges:
         return [items_with_context]
 
+    # Index publish contexts by their dependency-graph keys
     item_key_to_context: dict[str, tuple[str, object, object]] = {}
     for item_name, item, publisher in items_with_context:
         key = f"{item.type}.{item_name}"
         item_key_to_context[key] = (item_name, item, publisher)
 
+    # Build in-degrees and reverse edges for Kahn's algorithm
     publish_item_keys = set(item_key_to_context.keys())
     in_degree: dict[str, int] = {k: 0 for k in publish_item_keys}
     dependents: dict[str, list[str]] = {k: [] for k in publish_item_keys}
@@ -247,6 +251,7 @@ def compute_publish_batches(
     batches: list[list[tuple[str, object, object]]] = []
     current_batch_keys = [k for k, deg in in_degree.items() if deg == 0]
 
+    # Process each dependency-free tier as one publish batch
     processed = set()
     while current_batch_keys:
         batch = []
@@ -264,6 +269,7 @@ def compute_publish_batches(
             batches.append(batch)
         current_batch_keys = next_batch_keys
 
+    # Unprocessed items belong to at least one dependency cycle
     if len(processed) < len(publish_item_keys):
         cycle_keys = sorted(publish_item_keys - processed)
         msg = f"Circular dynamic variable dependency detected among: {', '.join(cycle_keys)}"

--- a/src/fabric_cicd/_items/_bulk_publish_dependencies.py
+++ b/src/fabric_cicd/_items/_bulk_publish_dependencies.py
@@ -1,15 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-"""Dependency graph helpers for batched bulk item publishing.
-
-Refactored to build on microsoft/fabric-cicd#1102: instead of a private, ad-hoc
-`$items.*` string parser, this module reuses the single canonical parser
-(`parse_dynamic_variable` -> `ParsedDynamicVariable`) introduced by #1102. That
-gives one source of truth for variable parsing, correct handling of dotted item
-names, the legacy `$items.type.name.attribute` form, and cross-workspace forms,
-plus item-type/attribute validation.
-"""
+"""Dependency graph helpers for batched bulk item publishing."""
 
 import logging
 from collections.abc import Iterator

--- a/src/fabric_cicd/_items/_bulk_publish_dependencies.py
+++ b/src/fabric_cicd/_items/_bulk_publish_dependencies.py
@@ -23,12 +23,12 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _parse_current_workspace_item(dyn_var: str) -> Optional["ParsedDynamicVariable"]:
+def _parse_current_workspace_item(env_value: str) -> Optional["ParsedDynamicVariable"]:
     """Parse a current-workspace $items.* variable, or return None."""
-    if not dyn_var.startswith("$"):
+    if not env_value.startswith("$"):
         return None
 
-    parsed = parse_dynamic_variable(dyn_var)
+    parsed = parse_dynamic_variable(env_value)
 
     if parsed.kind == "item" and parsed.workspace_name is None:
         return parsed

--- a/src/fabric_cicd/_items/_bulk_publish_dependencies.py
+++ b/src/fabric_cicd/_items/_bulk_publish_dependencies.py
@@ -176,7 +176,7 @@ def build_dynamic_variable_dependency_graph(
             continue
 
         cache_key = (
-            param_dict.get("item_type"),
+            _hashable_filter(param_dict.get("item_type")),
             _hashable_filter(param_dict.get("item_name")),
             _hashable_filter(param_dict.get("file_path")),
         )
@@ -221,6 +221,10 @@ def _get_referencing_item_keys(
     filter_type = param_dict.get("item_type")
     filter_name = param_dict.get("item_name")
     filter_paths = process_input_path(resolved_repo_dir, param_dict.get("file_path")) if resolved_repo_dir else None
+    # process_input_path resolves relative/absolute paths but returns wildcard matches unresolved;
+    # resolve once here so comparisons against resolved item paths are consistent (matches legacy behavior).
+    if filter_paths is not None:
+        filter_paths = [p.resolve() for p in filter_paths]
 
     # Collect repository items that satisfy every specified filter
     keys = []

--- a/src/fabric_cicd/_parameter/_utils.py
+++ b/src/fabric_cicd/_parameter/_utils.py
@@ -177,6 +177,15 @@ def extract_replace_value(workspace_obj: FabricWorkspace, replace_value: str, ge
             return None
         return replace_value
 
+    # Check the dynamic replacement variable cache first (only populated during bulk publish)
+    if (
+        not get_dataflow_name
+        and workspace_obj.bulk_publish_enabled
+        and replace_value in workspace_obj._dynamic_var_cache
+    ):
+        logger.debug(f"Cache hit for dynamic replacement variable: {replace_value}")
+        return workspace_obj._dynamic_var_cache[replace_value]
+
     # Parse and validate the dynamic variable to determine its kind and components
     parsed_variable = parse_dynamic_variable(replace_value)
 
@@ -186,11 +195,17 @@ def extract_replace_value(workspace_obj: FabricWorkspace, replace_value: str, ge
             msg = "Invalid replace_value variable: '$workspace'. Expected format to get dataflow name: '$items.type.name.$attribute'"
             raise InputError(msg, logger)
 
-        return _extract_workspace_id(workspace_obj, replace_value, parsed_variable)
+        resolved = _extract_workspace_id(workspace_obj, replace_value, parsed_variable)
+        if workspace_obj.bulk_publish_enabled:
+            workspace_obj._dynamic_var_cache[replace_value] = resolved
+        return resolved
 
     # Current-workspace item variables resolve against deployed workspace items
     if parsed_variable.kind == "item":
-        return _extract_item_attribute(workspace_obj, get_dataflow_name, parsed_variable)
+        resolved = _extract_item_attribute(workspace_obj, get_dataflow_name, parsed_variable)
+        if workspace_obj.bulk_publish_enabled and not get_dataflow_name and resolved is not None:
+            workspace_obj._dynamic_var_cache[replace_value] = resolved
+        return resolved
 
     msg = constants.DYNAMIC_VARIABLE_MSGS["invalid_format"].format(replace_value)
     raise ParsingError(msg, logger)

--- a/src/fabric_cicd/constants.py
+++ b/src/fabric_cicd/constants.py
@@ -277,6 +277,9 @@ PROPERTY_PATH_ATTR_MAPPING = {
     },
 }
 
+# Attributes that require waits between publish tiers. Excludes immediately available "id".
+ASYNC_PROVISIONED_ATTRIBUTES = frozenset({"sqlendpoint", "sqlendpointid", "queryserviceuri"})
+
 # Parameter file configs
 PARAMETER_FILE_NAME = "parameter.yml"
 # Parameters to validate

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -322,7 +322,7 @@ class FabricWorkspace:
                 )
                 return
 
-            # Terminal-failure detection where the API exposes a provisioning status (Lakehouse / Mirrored Database).
+            # Terminal-failure detection where the API exposes a provisioning status (Lakehouse / Mirrored Database)
             provisioning_status = dpath.get(
                 response, "body/properties/sqlEndpointProperties/provisioningStatus", default=None
             )

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -298,9 +298,9 @@ class FabricWorkspace:
         between tiers so a downstream tier does not resolve a dynamic variable to an empty value.
 
         Args:
-            item_type: The item type (e.g. ``Lakehouse``).
-            item_guid: The deployed item GUID. A falsy value is a no-op.
-            item_name: The item display name (for logging).
+            item_type: The item type.
+            item_guid: The deployed item ID.
+            item_name: The item display name.
             attribute_name: The asynchronously provisioned attribute to wait for.
         """
         if not item_guid:

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -144,6 +144,9 @@ class FabricWorkspace:
         self.contains_param_vars = False
         self.bulk_publish_enabled = False
 
+        # Cache for pre-resolved dynamic replacement variable values (used during bulk publish only)
+        self._dynamic_var_cache: dict[str, str] = {}
+
         # Initialize dataflow dependencies dictionary (used in dataflow item processing)
         self.dataflow_dependencies = {}
 

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -17,7 +17,7 @@ from azure.core.credentials import TokenCredential
 from fabric_cicd import constants
 from fabric_cicd._common._check_utils import check_regex, check_valid_json_content, check_valid_yaml_content
 from fabric_cicd._common._exceptions import FailedPublishedItemStatusError, InputError, ParameterFileError, ParsingError
-from fabric_cicd._common._fabric_endpoint import FabricEndpoint
+from fabric_cicd._common._fabric_endpoint import FabricEndpoint, handle_retry
 from fabric_cicd._common._item import Item
 from fabric_cicd._common._logging import log_header
 from fabric_cicd.constants import FeatureFlag, ItemType
@@ -284,6 +284,59 @@ class FabricWorkspace:
         with self._item_attribute_cache_lock:
             self._item_attribute_cache[cache_key] = attribute_value
         return attribute_value
+
+    def _wait_for_item_attribute_provisioning(
+        self, item_type: str, item_guid: str, item_name: str, attribute_name: str
+    ) -> None:
+        """
+        Poll an item until an asynchronously provisioned attribute becomes available.
+
+        SQL endpoints (``sqlendpoint`` / ``sqlendpointid``) and the Eventhouse query URI
+        (``queryserviceuri``) are provisioned asynchronously after the item is created, so a
+        freshly deployed item may not expose them immediately. Serial publishing waits for this
+        via ``check_sqlendpoint_provision_status``; bulk (tiered) publishing calls this method
+        between tiers so a downstream tier does not resolve a dynamic variable to an empty value.
+
+        Args:
+            item_type: The item type (e.g. ``Lakehouse``).
+            item_guid: The deployed item GUID. A falsy value is a no-op.
+            item_name: The item display name (for logging).
+            attribute_name: The asynchronously provisioned attribute to wait for.
+        """
+        if not item_guid:
+            return
+
+        property_path = constants.PROPERTY_PATH_ATTR_MAPPING.get(item_type, {}).get(attribute_name)
+        if property_path is None:
+            return
+
+        item_url = f"{self.base_api_url}/{item_type.lower()}s/{item_guid}"
+        iteration = 1
+
+        while True:
+            response = self.endpoint.invoke(method="GET", url=item_url)
+
+            if dpath.get(response, property_path, default=""):
+                logger.debug(
+                    f"{constants.INDENT}Attribute '{attribute_name}' provisioned for {item_type} '{item_name}'"
+                )
+                return
+
+            # Terminal-failure detection where the API exposes a provisioning status (Lakehouse / Mirrored Database).
+            provisioning_status = dpath.get(
+                response, "body/properties/sqlEndpointProperties/provisioningStatus", default=None
+            )
+            if provisioning_status == "Failed":
+                msg = f"Cannot resolve '{attribute_name}' for {item_type} '{item_name}' (provisioning failed)"
+                raise FailedPublishedItemStatusError(msg, logger)
+
+            handle_retry(
+                attempt=iteration,
+                base_delay=5,
+                response_retry_after=30,
+                prepend_message=f"{constants.INDENT}Waiting for '{attribute_name}' provisioning on {item_type} '{item_name}'",
+            )
+            iteration += 1
 
     def _get_workspace_pools(self) -> list[dict]:
         """Return the list of workspace custom Spark pools, fetching from the API on first call.

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -220,15 +220,23 @@ def publish_all_items(
 
         reasons = []
         unsupported = set(fabric_workspace_obj.item_type_in_scope) - set(constants.BULK_ACCEPTED_ITEM_TYPES)
-        # Fall back to standard deployment if unsupported item types or dynamic parameter variables are detected, otherwise enable bulk publish
-        if unsupported or fabric_workspace_obj.contains_param_vars:
-            if unsupported:
-                reasons.append(f"unsupported item types: {', '.join(sorted(unsupported))}")
+        if unsupported:
+            reasons.append(f"unsupported item types: {', '.join(sorted(unsupported))}")
 
-            if fabric_workspace_obj.contains_param_vars:
+        # Dynamic replacement variables are supported in bulk mode via tiered publishing, EXCEPT
+        # when an $items.* replace_value has no item_type/item_name/file_path filter — dependency
+        # scope cannot be narrowed, so fall back to standard deployment in that case only.
+        if not unsupported and fabric_workspace_obj.contains_param_vars:
+            from fabric_cicd._items._bulk_publish_dependencies import has_unfiltered_items_variable
+
+            if has_unfiltered_items_variable(fabric_workspace_obj):
                 reasons.append(
-                    "parameter file contains dynamic replacement variables ($workspace/$items) requiring runtime resolution"
+                    "parameter file contains $items.* replace_value entries without an item_type, "
+                    "item_name, or file_path filter; add at least one filter to each to enable bulk publish"
                 )
+
+        # Fall back to standard deployment if any blocking reason was found, otherwise enable bulk publish
+        if reasons:
             logger.warning(f"Falling back to standard deployment. Reason: {'; '.join(reasons)}.")
 
         else:

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -29,6 +29,7 @@ from fabric_cicd._common._validate_input import (
     validate_items_to_include,
     validate_shortcut_exclude_regex,
 )
+from fabric_cicd._items._bulk_publish_dependencies import has_unfiltered_items_variable
 from fabric_cicd.constants import FeatureFlag, ItemType
 from fabric_cicd.fabric_workspace import FabricWorkspace
 
@@ -224,16 +225,16 @@ def publish_all_items(
             reasons.append(f"unsupported item types: {', '.join(sorted(unsupported))}")
 
         # Dynamic replacement variables are supported in bulk mode via tiered publishing, EXCEPT
-        # when an $items.* replace_value has no item_type/item_name/file_path filter — dependency
-        # scope cannot be narrowed, so fall back to standard deployment in that case only.
-        if not unsupported and fabric_workspace_obj.contains_param_vars:
-            from fabric_cicd._items._bulk_publish_dependencies import has_unfiltered_items_variable
-
-            if has_unfiltered_items_variable(fabric_workspace_obj):
-                reasons.append(
-                    "parameter file contains $items.* replace_value entries without an item_type, "
-                    "item_name, or file_path filter; add at least one filter to each to enable bulk publish"
-                )
+        # when an $items.* replace_value has no file filter — dependency scope cannot be narrowed, so fall back to standard deployment in that case only
+        if (
+            not unsupported
+            and fabric_workspace_obj.contains_param_vars
+            and has_unfiltered_items_variable(fabric_workspace_obj)
+        ):
+            reasons.append(
+                "parameter file contains $items.* replace_value entries without an item_type, "
+                "item_name, or file_path filter; add at least one filter to each to enable bulk publish"
+            )
 
         # Fall back to standard deployment if any blocking reason was found, otherwise enable bulk publish
         if reasons:

--- a/tests/test_bulk_publish.py
+++ b/tests/test_bulk_publish.py
@@ -1006,6 +1006,19 @@ class TestBulkPublishDependencyGraph:
 
         assert build_dynamic_variable_dependency_graph(ws, {"DataPipeline.PL"}) == []
 
+    def test_list_valued_item_type_filter_does_not_crash(self):
+        """A list-valued item_type filter is hashable for the referencing cache and does not raise."""
+        env = {
+            "find_replace": [
+                {"item_type": ["DataPipeline", "Notebook"], "replace_value": {"PPE": "$items.Lakehouse.LH.$id"}},
+            ]
+        }
+        repo = {"DataPipeline": {"PL": _repo_item()}, "Lakehouse": {"LH": _repo_item()}}
+        ws = _graph_workspace(env, deployed_items={}, repository_items=repo)
+
+        # A list item_type never matches a str item_type (preserved quirk) -> no referencing items -> no edges
+        assert build_dynamic_variable_dependency_graph(ws, {"DataPipeline.PL", "Lakehouse.LH"}) == []
+
     def test_has_unfiltered_items_variable_true(self):
         """An $items.* replace_value with no filter is reported as unfiltered."""
         env = {"find_replace": [{"replace_value": {"PPE": "$items.Lakehouse.LH.$id"}}]}
@@ -1123,6 +1136,27 @@ class TestBulkPublishTieredExecution:
         assert ws._refresh_deployed_items.call_count == 1
         # Stale $items.* cache entry dropped between tiers; $workspace.* entry retained
         assert ws._dynamic_var_cache == {"$workspace.$id": "wsid"}
+
+    def test_oversized_later_batch_fails_before_any_publish(self):
+        """An oversized batch anywhere raises before any batch is published (no partial deployment)."""
+        ws, publisher, base, dep = self._workspace_with_two_items()
+        oversized = [("x", SimpleNamespace(type="Notebook"), publisher)] * (constants.BULK_ITEM_COUNT_LIMIT + 1)
+        batches = [[("base", base, publisher)], oversized]
+
+        with (
+            patch.object(ItemPublisher, "get_item_types_to_publish", return_value=[(1, ItemType.NOTEBOOK)]),
+            patch.object(ItemPublisher, "create", return_value=publisher),
+            patch.object(ItemPublisher, "_mark_skipped_items", return_value=[]),
+            patch(
+                "fabric_cicd._items._bulk_publish_dependencies.compute_publish_batches",
+                return_value=batches,
+            ),
+            pytest.raises(InputError, match="exceeds the API limit"),
+        ):
+            ItemPublisher.publish_all_bulk(ws)
+
+        # Nothing was published because validation fails fast for all batches upfront
+        assert ws._publish_items.call_count == 0
 
     def test_single_batch_makes_no_refresh(self):
         ws, publisher, base, dep = self._workspace_with_two_items()

--- a/tests/test_bulk_publish.py
+++ b/tests/test_bulk_publish.py
@@ -16,12 +16,13 @@ from fixtures.credentials import DummyTokenCredential
 
 import fabric_cicd.publish as publish
 from fabric_cicd import constants
-from fabric_cicd._common._exceptions import InputError
+from fabric_cicd._common._exceptions import FailedPublishedItemStatusError, InputError
 from fabric_cicd._items._base_publisher import ItemPublisher
 from fabric_cicd._items._bulk_publish_dependencies import (
     _resolve_current_workspace_item_ref,
     build_dynamic_variable_dependency_graph,
     compute_publish_batches,
+    get_async_provisioned_dependencies,
     has_unfiltered_items_variable,
 )
 from fabric_cicd.constants import FeatureFlag, ItemType
@@ -1142,3 +1143,158 @@ class TestBulkPublishTieredExecution:
         assert ws._refresh_deployed_items.call_count == 0
         # Cache untouched for a single batch
         assert ws._dynamic_var_cache == {"$workspace.$id": "wsid", "$items.Notebook.base.$id": "stale"}
+
+    def test_waits_for_async_attribute_before_refresh(self):
+        """A source item referenced downstream via an async attribute is waited on between tiers."""
+        base = SimpleNamespace(type="Lakehouse", guid="lh-guid")
+        dep = SimpleNamespace(type="Notebook", guid="nb-guid")
+
+        publisher = MagicMock()
+        publisher.get_items_to_publish.return_value = {"base": base, "dep": dep}
+        publisher.has_async_publish_check = False
+
+        ws = MagicMock()
+        ws.contains_param_vars = True
+        ws._apply_publish_filters.return_value = False
+        ws._dynamic_var_cache = {}
+
+        two_batches = [[("base", base, publisher)], [("dep", dep, publisher)]]
+
+        with (
+            patch.object(ItemPublisher, "get_item_types_to_publish", return_value=[(1, ItemType.LAKEHOUSE)]),
+            patch.object(ItemPublisher, "create", return_value=publisher),
+            patch.object(ItemPublisher, "_mark_skipped_items", return_value=[]),
+            patch(
+                "fabric_cicd._items._bulk_publish_dependencies.build_dynamic_variable_dependency_graph",
+                return_value=[],
+            ),
+            patch(
+                "fabric_cicd._items._bulk_publish_dependencies.get_async_provisioned_dependencies",
+                return_value={"Lakehouse.base": {"sqlendpoint"}},
+            ),
+            patch(
+                "fabric_cicd._items._bulk_publish_dependencies.compute_publish_batches",
+                return_value=two_batches,
+            ),
+        ):
+            ItemPublisher.publish_all_bulk(ws)
+
+        # The source item's async attribute is awaited before the refresh feeds the next tier
+        ws._wait_for_item_attribute_provisioning.assert_called_once_with("Lakehouse", "lh-guid", "base", "sqlendpoint")
+        assert ws._refresh_deployed_items.call_count == 1
+
+
+# =============================================================================
+# Async-Provisioned Attribute Dependencies (SQL endpoint / query URI)
+# =============================================================================
+
+
+class TestAsyncProvisionedDependencies:
+    """get_async_provisioned_dependencies maps to-be-published sources to their async attributes."""
+
+    def test_sqlendpoint_reference_mapped(self):
+        env = {"find_replace": [{"replace_value": {"PPE": "$items.Lakehouse.LH.$sqlendpoint"}}]}
+        ws = _graph_workspace(env, deployed_items={}, repository_items={})
+        assert get_async_provisioned_dependencies(ws, {"Lakehouse.LH"}) == {"Lakehouse.LH": {"sqlendpoint"}}
+
+    def test_id_attribute_is_not_async(self):
+        """$id resolves immediately from the items list and needs no provisioning wait."""
+        env = {"find_replace": [{"replace_value": {"PPE": "$items.Lakehouse.LH.$id"}}]}
+        ws = _graph_workspace(env, deployed_items={}, repository_items={})
+        assert get_async_provisioned_dependencies(ws, {"Lakehouse.LH"}) == {}
+
+    def test_reference_outside_publish_set_ignored(self):
+        env = {"find_replace": [{"replace_value": {"PPE": "$items.Lakehouse.LH.$sqlendpoint"}}]}
+        ws = _graph_workspace(env, deployed_items={}, repository_items={})
+        assert get_async_provisioned_dependencies(ws, {"Notebook.NB"}) == {}
+
+    def test_multiple_attributes_aggregated_per_source(self):
+        env = {
+            "find_replace": [
+                {"replace_value": {"PPE": "$items.Lakehouse.LH.$sqlendpoint"}},
+                {"replace_value": {"PPE": "$items.Lakehouse.LH.$sqlendpointid"}},
+                {"replace_value": {"PPE": "$items.Eventhouse.EH.$queryserviceuri"}},
+            ]
+        }
+        ws = _graph_workspace(env, deployed_items={}, repository_items={})
+        assert get_async_provisioned_dependencies(ws, {"Lakehouse.LH", "Eventhouse.EH"}) == {
+            "Lakehouse.LH": {"sqlendpoint", "sqlendpointid"},
+            "Eventhouse.EH": {"queryserviceuri"},
+        }
+
+    def test_cross_workspace_reference_ignored(self):
+        """Cross-workspace items live in another workspace and impose no in-batch provisioning wait."""
+        env = {"find_replace": [{"replace_value": {"PPE": "$workspace.other.$items.Lakehouse.LH.$sqlendpoint"}}]}
+        ws = _graph_workspace(env, deployed_items={}, repository_items={})
+        assert get_async_provisioned_dependencies(ws, {"Lakehouse.LH"}) == {}
+
+
+# =============================================================================
+# Async Attribute Provisioning Wait (_wait_for_item_attribute_provisioning)
+# =============================================================================
+
+
+def _lakehouse_response(connection_string=None, provisioning_status=None):
+    """Build a Lakehouse GET response with optional SQL endpoint connection string / status."""
+    sql_props = {}
+    if connection_string is not None:
+        sql_props["connectionString"] = connection_string
+    if provisioning_status is not None:
+        sql_props["provisioningStatus"] = provisioning_status
+    properties = {"sqlEndpointProperties": sql_props} if sql_props else {}
+    return {"body": {"properties": properties}}
+
+
+class TestWaitForItemAttributeProvisioning:
+    """FabricWorkspace._wait_for_item_attribute_provisioning polls until an async attribute is ready."""
+
+    def _fake_ws(self, endpoint):
+        return SimpleNamespace(base_api_url="https://api/v1/workspaces/ws", endpoint=endpoint)
+
+    def test_returns_immediately_when_attribute_present(self):
+        endpoint = MagicMock()
+        endpoint.invoke.return_value = _lakehouse_response(connection_string="sql.endpoint.fabric")
+        ws = self._fake_ws(endpoint)
+
+        FabricWorkspace._wait_for_item_attribute_provisioning(ws, "Lakehouse", "guid-1", "LH", "sqlendpoint")
+
+        assert endpoint.invoke.call_count == 1
+
+    def test_polls_until_attribute_provisioned(self):
+        endpoint = MagicMock()
+        endpoint.invoke.side_effect = [
+            _lakehouse_response(provisioning_status="InProgress"),
+            _lakehouse_response(connection_string="sql.endpoint.fabric"),
+        ]
+        ws = self._fake_ws(endpoint)
+
+        with patch("fabric_cicd.fabric_workspace.handle_retry") as mock_retry:
+            FabricWorkspace._wait_for_item_attribute_provisioning(ws, "Lakehouse", "guid-1", "LH", "sqlendpoint")
+
+        assert endpoint.invoke.call_count == 2
+        assert mock_retry.call_count == 1
+
+    def test_raises_on_failed_provisioning(self):
+        endpoint = MagicMock()
+        endpoint.invoke.return_value = _lakehouse_response(provisioning_status="Failed")
+        ws = self._fake_ws(endpoint)
+
+        with pytest.raises(FailedPublishedItemStatusError):
+            FabricWorkspace._wait_for_item_attribute_provisioning(ws, "Lakehouse", "guid-1", "LH", "sqlendpoint")
+
+    def test_noop_for_empty_guid(self):
+        endpoint = MagicMock()
+        ws = self._fake_ws(endpoint)
+
+        FabricWorkspace._wait_for_item_attribute_provisioning(ws, "Lakehouse", "", "LH", "sqlendpoint")
+
+        endpoint.invoke.assert_not_called()
+
+    def test_noop_for_unmapped_attribute(self):
+        endpoint = MagicMock()
+        ws = self._fake_ws(endpoint)
+
+        # Notebook has no async-provisioned attribute mapping
+        FabricWorkspace._wait_for_item_attribute_provisioning(ws, "Notebook", "guid-1", "NB", "sqlendpoint")
+
+        endpoint.invoke.assert_not_called()

--- a/tests/test_bulk_publish.py
+++ b/tests/test_bulk_publish.py
@@ -19,7 +19,6 @@ from fabric_cicd import constants
 from fabric_cicd._common._exceptions import FailedPublishedItemStatusError, InputError
 from fabric_cicd._items._base_publisher import ItemPublisher
 from fabric_cicd._items._bulk_publish_dependencies import (
-    _resolve_current_workspace_item_ref,
     build_dynamic_variable_dependency_graph,
     compute_publish_batches,
     get_async_provisioned_dependencies,
@@ -918,35 +917,6 @@ class TestBulkPublishResponseCollection:
                 result = publish.publish_all_items(workspace, item_name_exclude_regex="^FilteredNB$")
 
                 assert result is None
-
-
-# =============================================================================
-# Dynamic Variable Reference Parsing (parser alignment)
-# =============================================================================
-
-
-class TestDynamicVariableReferenceParsing:
-    """_resolve_current_workspace_item_ref reuses the canonical parser and only flags
-    current-workspace item references."""
-
-    @pytest.mark.parametrize(
-        ("value", "expected"),
-        [
-            ("$items.Notebook.my_nb.$id", ("Notebook", "my_nb")),
-            # Dotted item name — a case a naive split-on-dot parser gets wrong
-            ("$items.Notebook.my.nb.$id", ("Notebook", "my.nb")),
-            # Legacy attribute form (no leading $ on attribute)
-            ("$items.Notebook.my_nb.id", ("Notebook", "my_nb")),
-            # $workspace.* is not an in-batch item dependency
-            ("$workspace.$id", None),
-            # Cross-workspace item reference targets another workspace, not this batch
-            ("$workspace.other_ws.$items.Notebook.some_item.$id", None),
-            # Plain strings are not variables
-            ("literal-connection-string", None),
-        ],
-    )
-    def test_resolve_current_workspace_item_ref(self, value, expected):
-        assert _resolve_current_workspace_item_ref(value) == expected
 
 
 # =============================================================================

--- a/tests/test_bulk_publish.py
+++ b/tests/test_bulk_publish.py
@@ -921,7 +921,7 @@ class TestBulkPublishResponseCollection:
 
 
 # =============================================================================
-# Dynamic Variable Reference Parsing (parser alignment with #1102)
+# Dynamic Variable Reference Parsing (parser alignment)
 # =============================================================================
 
 
@@ -933,7 +933,7 @@ class TestDynamicVariableReferenceParsing:
         ("value", "expected"),
         [
             ("$items.Notebook.my_nb.$id", ("Notebook", "my_nb")),
-            # Dotted item name — the regression the #19 private parser got wrong
+            # Dotted item name — a case a naive split-on-dot parser gets wrong
             ("$items.Notebook.my.nb.$id", ("Notebook", "my.nb")),
             # Legacy attribute form (no leading $ on attribute)
             ("$items.Notebook.my_nb.id", ("Notebook", "my_nb")),

--- a/tests/test_bulk_publish.py
+++ b/tests/test_bulk_publish.py
@@ -1006,6 +1006,19 @@ class TestBulkPublishDependencyGraph:
 
         assert build_dynamic_variable_dependency_graph(ws, {"DataPipeline.PL"}) == []
 
+    def test_list_valued_item_type_filter_does_not_crash(self):
+        """A list-valued item_type filter is hashable for the referencing cache and does not raise."""
+        env = {
+            "find_replace": [
+                {"item_type": ["DataPipeline", "Notebook"], "replace_value": {"PPE": "$items.Lakehouse.LH.$id"}},
+            ]
+        }
+        repo = {"DataPipeline": {"PL": _repo_item()}, "Lakehouse": {"LH": _repo_item()}}
+        ws = _graph_workspace(env, deployed_items={}, repository_items=repo)
+
+        # A list item_type never matches a str item_type (preserved quirk) -> no referencing items -> no edges
+        assert build_dynamic_variable_dependency_graph(ws, {"DataPipeline.PL", "Lakehouse.LH"}) == []
+
     def test_has_unfiltered_items_variable_true(self):
         """An $items.* replace_value with no filter is reported as unfiltered."""
         env = {"find_replace": [{"replace_value": {"PPE": "$items.Lakehouse.LH.$id"}}]}
@@ -1123,6 +1136,27 @@ class TestBulkPublishTieredExecution:
         assert ws._refresh_deployed_items.call_count == 1
         # Stale $items.* cache entry dropped between tiers; $workspace.* entry retained
         assert ws._dynamic_var_cache == {"$workspace.$id": "wsid"}
+
+    def test_oversized_later_batch_fails_before_any_publish(self):
+        """An oversized batch anywhere raises before any batch is published (no partial deployment)."""
+        ws, publisher, base, _dep = self._workspace_with_two_items()
+        oversized = [("x", SimpleNamespace(type="Notebook"), publisher)] * (constants.BULK_ITEM_COUNT_LIMIT + 1)
+        batches = [[("base", base, publisher)], oversized]
+
+        with (
+            patch.object(ItemPublisher, "get_item_types_to_publish", return_value=[(1, ItemType.NOTEBOOK)]),
+            patch.object(ItemPublisher, "create", return_value=publisher),
+            patch.object(ItemPublisher, "_mark_skipped_items", return_value=[]),
+            patch(
+                "fabric_cicd._items._bulk_publish_dependencies.compute_publish_batches",
+                return_value=batches,
+            ),
+            pytest.raises(InputError, match="exceeds the API limit"),
+        ):
+            ItemPublisher.publish_all_bulk(ws)
+
+        # Nothing was published because validation fails fast for all batches upfront
+        assert ws._publish_items.call_count == 0
 
     def test_single_batch_makes_no_refresh(self):
         ws, publisher, base, dep = self._workspace_with_two_items()

--- a/tests/test_bulk_publish.py
+++ b/tests/test_bulk_publish.py
@@ -1139,7 +1139,7 @@ class TestBulkPublishTieredExecution:
 
     def test_oversized_later_batch_fails_before_any_publish(self):
         """An oversized batch anywhere raises before any batch is published (no partial deployment)."""
-        ws, publisher, base, dep = self._workspace_with_two_items()
+        ws, publisher, base, _dep = self._workspace_with_two_items()
         oversized = [("x", SimpleNamespace(type="Notebook"), publisher)] * (constants.BULK_ITEM_COUNT_LIMIT + 1)
         batches = [[("base", base, publisher)], oversized]
 

--- a/tests/test_bulk_publish.py
+++ b/tests/test_bulk_publish.py
@@ -8,6 +8,7 @@ import json
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -17,7 +18,13 @@ import fabric_cicd.publish as publish
 from fabric_cicd import constants
 from fabric_cicd._common._exceptions import InputError
 from fabric_cicd._items._base_publisher import ItemPublisher
-from fabric_cicd.constants import FeatureFlag
+from fabric_cicd._items._bulk_publish_dependencies import (
+    _resolve_current_workspace_item_ref,
+    build_dynamic_variable_dependency_graph,
+    compute_publish_batches,
+    has_unfiltered_items_variable,
+)
+from fabric_cicd.constants import FeatureFlag, ItemType
 from fabric_cicd.fabric_workspace import FabricWorkspace
 
 # =============================================================================
@@ -242,13 +249,13 @@ class TestBulkPublishFallback:
     @pytest.mark.parametrize(
         "param_yaml",
         [
-            'find_replace:\n  - find_value: "some-id"\n    replace_value:\n      PPE: "$workspace.other_ws.$items.Notebook.some_item.$id"\n',
-            'find_replace:\n  - find_value: "$workspace.source_ws.$items.Notebook.some_lakehouse.$id"\n    replace_value:\n      PPE: "replacement-id"\n',
+            'find_replace:\n  - find_value: "some-id"\n    replace_value:\n      PPE: "$items.Notebook.TestNotebook.$id"\n',
+            'key_value_replace:\n  - find_key: "$.some.path"\n    replace_value:\n      PPE: "$items.Notebook.TestNotebook.$id"\n',
         ],
-        ids=["dynamic_replace_value", "dynamic_find_value"],
+        ids=["find_replace", "key_value_replace"],
     )
-    def test_fallback_on_dynamic_variables(self, mock_endpoint, temp_workspace_dir, param_yaml):
-        """Bulk publish falls back when parameter file contains dynamic $workspace/$items variables."""
+    def test_fallback_on_unfiltered_items_variable(self, mock_endpoint, temp_workspace_dir, param_yaml):
+        """Bulk falls back only when an $items.* replace_value has no item_type/item_name/file_path filter."""
         create_test_item_dir(temp_workspace_dir, None, "TestNotebook", "Notebook", "nb-id-001")
         create_parameter_file(temp_workspace_dir, param_yaml)
 
@@ -258,6 +265,33 @@ class TestBulkPublishFallback:
         ):
             publish.publish_all_items(workspace)
             assert workspace.bulk_publish_enabled is False
+            assert workspace.contains_param_vars is True
+
+    @pytest.mark.parametrize(
+        "param_yaml",
+        [
+            # Filtered current-workspace $items.* -> supported via tiered publishing
+            'find_replace:\n  - find_value: "some-id"\n    item_type: "Notebook"\n    replace_value:\n      PPE: "$items.Notebook.TestNotebook.$id"\n',
+            # $workspace.* -> resolved upfront, no dependency
+            'find_replace:\n  - find_value: "some-id"\n    replace_value:\n      PPE: "$workspace.$id"\n',
+            # Cross-workspace item variable -> targets another workspace, resolved upfront
+            'find_replace:\n  - find_value: "some-id"\n    replace_value:\n      PPE: "$workspace.other_ws.$items.Notebook.some_item.$id"\n',
+            # Dynamic find_value -> resolved upfront, does not gate bulk
+            'find_replace:\n  - find_value: "$workspace.source_ws.$items.Notebook.some_lakehouse.$id"\n    replace_value:\n      PPE: "replacement-id"\n',
+        ],
+        ids=["filtered_items", "workspace_var", "cross_workspace_item", "dynamic_find_value"],
+    )
+    def test_no_fallback_on_supported_dynamic_variables(self, mock_endpoint, temp_workspace_dir, param_yaml):
+        """Bulk stays enabled for $workspace.*, cross-workspace, dynamic find_value, and filtered $items.* vars."""
+        create_test_item_dir(temp_workspace_dir, None, "TestNotebook", "Notebook", "nb-id-001")
+        create_parameter_file(temp_workspace_dir, param_yaml)
+
+        with (
+            patched_workspace(mock_endpoint, temp_workspace_dir, environment="PPE") as workspace,
+            patch.object(ItemPublisher, "publish_all_bulk", return_value=[]),
+        ):
+            publish.publish_all_items(workspace)
+            assert workspace.bulk_publish_enabled is True
             assert workspace.contains_param_vars is True
 
     def test_no_fallback_without_dynamic_variables(self, mock_endpoint, temp_workspace_dir):
@@ -883,3 +917,228 @@ class TestBulkPublishResponseCollection:
                 result = publish.publish_all_items(workspace, item_name_exclude_regex="^FilteredNB$")
 
                 assert result is None
+
+
+# =============================================================================
+# Dynamic Variable Reference Parsing (parser alignment with #1102)
+# =============================================================================
+
+
+class TestDynamicVariableReferenceParsing:
+    """_resolve_current_workspace_item_ref reuses the canonical parser and only flags
+    current-workspace item references."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("$items.Notebook.my_nb.$id", ("Notebook", "my_nb")),
+            # Dotted item name — the regression the #19 private parser got wrong
+            ("$items.Notebook.my.nb.$id", ("Notebook", "my.nb")),
+            # Legacy attribute form (no leading $ on attribute)
+            ("$items.Notebook.my_nb.id", ("Notebook", "my_nb")),
+            # $workspace.* is not an in-batch item dependency
+            ("$workspace.$id", None),
+            # Cross-workspace item reference targets another workspace, not this batch
+            ("$workspace.other_ws.$items.Notebook.some_item.$id", None),
+            # Plain strings are not variables
+            ("literal-connection-string", None),
+        ],
+    )
+    def test_resolve_current_workspace_item_ref(self, value, expected):
+        assert _resolve_current_workspace_item_ref(value) == expected
+
+
+# =============================================================================
+# Dependency Graph Construction
+# =============================================================================
+
+
+def _graph_workspace(environment_parameter, deployed_items, repository_items):
+    """Minimal workspace stub for dependency-graph helpers."""
+    return SimpleNamespace(
+        environment="PPE",
+        environment_parameter=environment_parameter,
+        deployed_items=deployed_items,
+        repository_items=repository_items,
+        repository_directory=None,
+    )
+
+
+def _repo_item():
+    return SimpleNamespace(path=None)
+
+
+class TestBulkPublishDependencyGraph:
+    """Tests for build_dynamic_variable_dependency_graph and has_unfiltered_items_variable."""
+
+    def test_edge_created_for_new_referenced_item(self):
+        """A filtered $items.* ref to an item new in the batch produces a dependency edge."""
+        env = {
+            "find_replace": [
+                {"item_type": "DataPipeline", "replace_value": {"PPE": "$items.Lakehouse.LH.$id"}},
+            ]
+        }
+        repo = {"DataPipeline": {"PL": _repo_item()}, "Lakehouse": {"LH": _repo_item()}}
+        ws = _graph_workspace(env, deployed_items={}, repository_items=repo)
+
+        edges = build_dynamic_variable_dependency_graph(ws, {"DataPipeline.PL", "Lakehouse.LH"})
+
+        assert edges == [("DataPipeline.PL", "Lakehouse.LH")]
+
+    def test_no_edge_when_referenced_item_already_deployed(self):
+        """No edge when the referenced item is already deployed (resolvable in a single batch)."""
+        env = {
+            "find_replace": [
+                {"item_type": "DataPipeline", "replace_value": {"PPE": "$items.Lakehouse.LH.$id"}},
+            ]
+        }
+        repo = {"DataPipeline": {"PL": _repo_item()}, "Lakehouse": {"LH": _repo_item()}}
+        ws = _graph_workspace(env, deployed_items={"Lakehouse": {"LH": {"id": "guid"}}}, repository_items=repo)
+
+        assert build_dynamic_variable_dependency_graph(ws, {"DataPipeline.PL", "Lakehouse.LH"}) == []
+
+    def test_no_edge_for_workspace_variable(self):
+        """$workspace.* references never create dependency edges."""
+        env = {"find_replace": [{"item_type": "DataPipeline", "replace_value": {"PPE": "$workspace.$id"}}]}
+        repo = {"DataPipeline": {"PL": _repo_item()}}
+        ws = _graph_workspace(env, deployed_items={}, repository_items=repo)
+
+        assert build_dynamic_variable_dependency_graph(ws, {"DataPipeline.PL"}) == []
+
+    def test_has_unfiltered_items_variable_true(self):
+        """An $items.* replace_value with no filter is reported as unfiltered."""
+        env = {"find_replace": [{"replace_value": {"PPE": "$items.Lakehouse.LH.$id"}}]}
+        ws = _graph_workspace(env, deployed_items={}, repository_items={})
+
+        assert has_unfiltered_items_variable(ws) is True
+
+    def test_has_unfiltered_items_variable_false_when_filtered(self):
+        """An $items.* replace_value carrying any filter is not reported as unfiltered."""
+        env = {"find_replace": [{"item_type": "DataPipeline", "replace_value": {"PPE": "$items.Lakehouse.LH.$id"}}]}
+        ws = _graph_workspace(env, deployed_items={}, repository_items={})
+
+        assert has_unfiltered_items_variable(ws) is False
+
+    def test_has_unfiltered_items_variable_false_for_workspace_var(self):
+        """Unfiltered $workspace.* variables do not gate bulk publish."""
+        env = {"find_replace": [{"replace_value": {"PPE": "$workspace.$id"}}]}
+        ws = _graph_workspace(env, deployed_items={}, repository_items={})
+
+        assert has_unfiltered_items_variable(ws) is False
+
+
+# =============================================================================
+# Publish Batch Computation (topological sort)
+# =============================================================================
+
+
+def _batch_ctx(key):
+    """Build an (item_name, item, publisher) context tuple from a 'Type.Name' key."""
+    item_type, item_name = key.split(".", 1)
+    return (item_name, SimpleNamespace(type=item_type), object())
+
+
+def _batch_keys(batches):
+    """Reduce computed batches to a list of key sets for assertion."""
+    return [{f"{item.type}.{name}" for name, item, _ in batch} for batch in batches]
+
+
+class TestComputePublishBatches:
+    """Tests for compute_publish_batches."""
+
+    def test_no_edges_single_batch(self):
+        items = [_batch_ctx("Notebook.A"), _batch_ctx("Notebook.B")]
+        batches = compute_publish_batches(items, [])
+        assert batches == [items]
+
+    def test_linear_chain_produces_ordered_tiers(self):
+        items = [_batch_ctx("Notebook.A"), _batch_ctx("Lakehouse.B"), _batch_ctx("DataPipeline.C")]
+        # C depends on B, B depends on A
+        edges = [("DataPipeline.C", "Lakehouse.B"), ("Lakehouse.B", "Notebook.A")]
+        assert _batch_keys(compute_publish_batches(items, edges)) == [
+            {"Notebook.A"},
+            {"Lakehouse.B"},
+            {"DataPipeline.C"},
+        ]
+
+    def test_shared_dependency_groups_dependents_in_later_tier(self):
+        items = [_batch_ctx("Lakehouse.Base"), _batch_ctx("Notebook.X"), _batch_ctx("Notebook.Y")]
+        edges = [("Notebook.X", "Lakehouse.Base"), ("Notebook.Y", "Lakehouse.Base")]
+        result = _batch_keys(compute_publish_batches(items, edges))
+        assert result[0] == {"Lakehouse.Base"}
+        assert result[1] == {"Notebook.X", "Notebook.Y"}
+
+    def test_circular_dependency_raises(self):
+        items = [_batch_ctx("Notebook.A"), _batch_ctx("Lakehouse.B")]
+        edges = [("Notebook.A", "Lakehouse.B"), ("Lakehouse.B", "Notebook.A")]
+        with pytest.raises(InputError, match="Circular dynamic variable dependency"):
+            compute_publish_batches(items, edges)
+
+
+# =============================================================================
+# Tiered Execution Loop (publish_all_bulk)
+# =============================================================================
+
+
+@pytest.mark.usefixtures("bulk_publish_flags")
+class TestBulkPublishTieredExecution:
+    """Tests that publish_all_bulk issues one bulk call per batch and refreshes between tiers."""
+
+    def _workspace_with_two_items(self):
+        """MagicMock workspace whose Phase-1 collection yields two Notebook items."""
+        base = SimpleNamespace(type="Notebook")
+        dep = SimpleNamespace(type="Notebook")
+
+        publisher = MagicMock()
+        publisher.get_items_to_publish.return_value = {"base": base, "dep": dep}
+        publisher.pre_publish_all.return_value = None
+        publisher.post_publish_all.return_value = None
+        publisher.has_async_publish_check = False
+
+        ws = MagicMock()
+        ws.contains_param_vars = False  # skip graph build; batches are injected below
+        ws._apply_publish_filters.return_value = False
+        ws._dynamic_var_cache = {"$workspace.$id": "wsid", "$items.Notebook.base.$id": "stale"}
+        return ws, publisher, base, dep
+
+    def test_one_bulk_call_per_batch_with_refresh_between(self):
+        ws, publisher, base, dep = self._workspace_with_two_items()
+        two_batches = [[("base", base, publisher)], [("dep", dep, publisher)]]
+
+        with (
+            patch.object(ItemPublisher, "get_item_types_to_publish", return_value=[(1, ItemType.NOTEBOOK)]),
+            patch.object(ItemPublisher, "create", return_value=publisher),
+            patch.object(ItemPublisher, "_mark_skipped_items", return_value=[]),
+            patch(
+                "fabric_cicd._items._bulk_publish_dependencies.compute_publish_batches",
+                return_value=two_batches,
+            ),
+        ):
+            ItemPublisher.publish_all_bulk(ws)
+
+        # One bulk API call per batch
+        assert ws._publish_items.call_count == 2
+        # Deployed items refreshed once, between the two batches
+        assert ws._refresh_deployed_items.call_count == 1
+        # Stale $items.* cache entry dropped between tiers; $workspace.* entry retained
+        assert ws._dynamic_var_cache == {"$workspace.$id": "wsid"}
+
+    def test_single_batch_makes_no_refresh(self):
+        ws, publisher, base, dep = self._workspace_with_two_items()
+        single_batch = [[("base", base, publisher), ("dep", dep, publisher)]]
+
+        with (
+            patch.object(ItemPublisher, "get_item_types_to_publish", return_value=[(1, ItemType.NOTEBOOK)]),
+            patch.object(ItemPublisher, "create", return_value=publisher),
+            patch.object(ItemPublisher, "_mark_skipped_items", return_value=[]),
+            patch(
+                "fabric_cicd._items._bulk_publish_dependencies.compute_publish_batches",
+                return_value=single_batch,
+            ),
+        ):
+            ItemPublisher.publish_all_bulk(ws)
+
+        assert ws._publish_items.call_count == 1
+        assert ws._refresh_deployed_items.call_count == 0
+        # Cache untouched for a single batch
+        assert ws._dynamic_var_cache == {"$workspace.$id": "wsid", "$items.Notebook.base.$id": "stale"}


### PR DESCRIPTION
## Summary

Enables native dynamic replacement variable (`$workspace.*` / `$items.*`) support in the **bulk publish** path. Previously, bulk publish fell back to serial deployment whenever the parameter file contained any dynamic variables. Now bulk publish resolves them natively by ordering deployment into dependency tiers.

## Approach

- **New `_bulk_publish_dependencies` module** — builds a dependency graph from same-workspace `$items.*` references, topologically sorts items into tiers via Kahn's algorithm (raising on cycles), and detects unfiltered item references.
- **Tiered execution in `publish_all_bulk`** — instead of a single bulk API call, executes one bulk call per tier, calling `_refresh_deployed_items()` and trimming the resolution cache between tiers so each tier resolves against freshly deployed state.
- **Bulk-scoped resolution cache** (`_dynamic_var_cache`) wired into `extract_replace_value` to avoid redundant resolution within a bulk run; `$workspace.*` keys are retained across tiers while `$items.*` keys are dropped after each tier.
- **Narrowed serial fallback gate** — only an *unfiltered* current-workspace `$items.*` replace_value forces serial fallback (its dependency scope can't be narrowed without a filter). Cross-workspace item vars, `$workspace.*` vars, and dynamic `find_value`s now stay on the bulk path.
- Reuses the canonical `parse_dynamic_variable` parser.

## Asynchronous SQL endpoint / query URI handling

SQL endpoints (`sqlendpoint` / `sqlendpointid`) and the Eventhouse query URI (`queryserviceuri`) are provisioned **asynchronously** after item creation. In serial publishing this is awaited by `check_sqlendpoint_provision_status`, but the bulk path never calls `publish_one`, so a downstream tier could otherwise resolve these to empty strings.

- New `FabricWorkspace._wait_for_item_attribute_provisioning` — a generalized poll (Lakehouse / Mirrored Database / Warehouse / SQL Database / Eventhouse) that waits until the async attribute is available, with terminal-failure detection where the API exposes a provisioning status.
- `get_async_provisioned_dependencies` maps to-be-published source items to the async attributes referenced on them.
- `publish_all_bulk` waits for those attributes on just-deployed source items **before** the between-tier refresh, so the next tier resolves real values.

## Docs

Updated the optional features page to document dynamic replacement variable support in bulk publish, the tiered publishing model, async SQL endpoint handling, and the single remaining fallback condition (unfiltered current-workspace `$items.*` replace values).

## Testing

- `tests/test_bulk_publish.py` — reference parsing, dependency graph, batch computation, tiered execution, async-provisioned dependency mapping, provisioning-wait polling/failure, and the tiered wait hook
- `tests/test_parameter.py` + `tests/test_parameter_utils.py` — confirm cache hooks don't regress non-bulk paths
- Full suite green; `ruff check` / `ruff format` clean

---

> **Note:** Linked issue and changelog entry to follow.
